### PR TITLE
Decouple MANA code from coordinator code

### DIFF
--- a/compile-coord-cori.sh
+++ b/compile-coord-cori.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-cd src/
-CC -DHAVE_CONFIG_H -I. -I../include  -I../include -I../jalib -Wall -DDEBUG -fPIC \
-   -std=c++11 -g3 -O0 -DDEBUG -MT dmtcp_coordinator.o -MD -MP -MF .deps/dmtcp_coordinator.Tpo \
-   -c -o dmtcp_coordinator.o dmtcp_coordinator.cpp
-# Next line no longer needed.  'make -j' does it.
-# g++ -g3 -O0 -o ../bin/dmtcp_coordinator dmtcp_coordinator.o lookup_service.o restartscript.o \
-#       	 libdmtcpinternal.a libjalib.a libnohijack.a -lpthread -lrt

--- a/contrib/mpi-proxy-split/Makefile
+++ b/contrib/mpi-proxy-split/Makefile
@@ -27,6 +27,8 @@ LIBOBJS = mpi_plugin.o drain_send_recv_packets.o \
           record-replay.o two-phase-algo.o \
           split_process.o ${LOWER_HALF_SRCDIR}/procmapsutils.o
 
+MANA_COORD_OBJS = mana_coordinator.o
+
 PROXY_BIN = lh_proxy
 LIBPROXY = libproxy.a
 
@@ -42,7 +44,7 @@ override CXXFLAGS += -g3 -O0 -fPIC -I${DMTCP_INCLUDE} -I${JALIB_INCLUDE} \
                      -I${WRAPPERS_SRCDIR} -I. \
                      -I${DMTCP_ROOT}/src -I${LOWER_HALF_SRCDIR} -std=c++11
 
-default: ${LIBNAME}.so ${LOWER_HALF_SRCDIR}/${PROXY_BIN} ${WRAPPERS_SRCDIR}/libmpidummy.so ${WRAPPERS_SRCDIR}/libmpich_intel.so.3
+default: ${LIBNAME}.so ${MANA_COORD_OBJS} ${LOWER_HALF_SRCDIR}/${PROXY_BIN} ${WRAPPERS_SRCDIR}/libmpidummy.so ${WRAPPERS_SRCDIR}/libmpich_intel.so.3
 
 ${LIBNAME}.so: ${LIBOBJS} ${WRAPPERS_SRCDIR}/${LIBWRAPPER}
 	${MPICXX} -shared -fPIC -g3 -O0 -o $@ $< -Wl,--whole-archive ${WRAPPERS_SRCDIR}/${LIBWRAPPER} -Wl,--no-whole-archive
@@ -104,7 +106,7 @@ tidy:
 
 clean: tidy
 	@cd ${LOWER_HALF_SRCDIR} && make clean
-	rm -f ${LIBOBJS}
+	rm -f ${LIBOBJS} ${MANA_COORD_OBJS}
 	rm -f ${LIBNAME}.so
 	@cd ${WRAPPERS_SRCDIR} && make clean
 

--- a/contrib/mpi-proxy-split/drain_send_recv_packets.h
+++ b/contrib/mpi-proxy-split/drain_send_recv_packets.h
@@ -3,32 +3,9 @@
 
 #include <mpi.h>
 
+#include "mana_coord_proto.h"
+
 #define DRAINED_REQUEST_VALUE 0xFFFFFFFF
-
-// Key-value database containing the counts of sends, receives, and unserviced
-// sends for each rank
-// Mapping is (rank -> send_recv_totals_t)
-#define MPI_SEND_RECV_DB  "SR_DB"
-
-// Key-value database containing the metadata of unserviced sends for each rank
-// Mapping is (rank -> mpi_call_params_t)
-#define MPI_US_DB         "US_DB"
-
-// Database containing the counts of wrappers (send, isend, recv, irecv)
-// executed for each rank (useful while debugging)
-// Mapping is (rank -> wr_counts_t)
-#define MPI_WRAPPER_DB    "WR_DB"
-
-// Struct to store the number of times send, isend, recv, and irecv wrappers
-// were executed
-typedef struct __wr_counts
-{
-  int sendCount;     // Number of times MPI_Send wrapper was called
-  int isendCount;    // Number of times MPI_Isend wrapper was called
-  int recvCount;     // Number of times MPI_Recv wrapper was called
-  int irecvCount;    // Number of times MPI_Irecv wrapper was called
-  int sendrecvCount; // Number of times MPI_Sendrecv wrapper was called
-} wr_counts_t;
 
 // Stores the counts of executed wrappers (send, isend, recv, irecv); useful
 // while debugging
@@ -80,15 +57,6 @@ typedef struct __mpi_async_call
   MPI_Request req; // Original request value
   int flag;
 } mpi_async_call_t;
-
-// Struct to store the MPI send/recv counts of a rank
-typedef struct __send_recv_totals
-{
-  int rank;         // MPI rank
-  uint64_t sends;   // Number of completed sends
-  uint64_t recvs;   // Number of completed receives
-  int countSends;   // Number of unserviced sends
-} send_recv_totals_t;
 
 // Increments the global number of receives by 1
 extern void updateLocalRecvs();

--- a/contrib/mpi-proxy-split/mana_coord_proto.h
+++ b/contrib/mpi-proxy-split/mana_coord_proto.h
@@ -1,0 +1,66 @@
+#ifndef _MANA_COORD_PROTO_
+#define _MANA_COORD_PROTO_
+
+// Key-value database containing the counts of sends, receives, and unserviced
+// sends for each rank
+// Mapping is (rank -> send_recv_totals_t)
+#define MPI_SEND_RECV_DB  "SR_DB"
+
+// Key-value database containing the metadata of unserviced sends for each rank
+// Mapping is (rank -> mpi_call_params_t)
+#define MPI_US_DB         "US_DB"
+
+// Database containing the counts of wrappers (send, isend, recv, irecv)
+// executed for each rank (useful while debugging)
+// Mapping is (rank -> wr_counts_t)
+#define MPI_WRAPPER_DB    "WR_DB"
+
+typedef enum __phase_t
+{
+  UNKNOWN = -1,
+  IS_READY,
+  PHASE_1,
+  IN_CS,
+  OUT_CS,
+  READY_FOR_CKPT,
+  PHASE_2,
+} phase_t;
+
+typedef enum __query_t
+{
+  NONE = -1,
+  INTENT,
+  GET_STATUS,
+  FREE_PASS,
+  CKPT,
+} query_t;
+
+// Struct to encapsulate the checkpointing state of a rank
+typedef struct __rank_state_t
+{
+  int rank;       // MPI rank
+  MPI_Comm comm;  // MPI communicator object
+  phase_t st;     // Checkpointing state of the MPI rank
+} rank_state_t;
+
+// Struct to store the number of times send, isend, recv, and irecv wrappers
+// were executed
+typedef struct __wr_counts
+{
+  int sendCount;     // Number of times MPI_Send wrapper was called
+  int isendCount;    // Number of times MPI_Isend wrapper was called
+  int recvCount;     // Number of times MPI_Recv wrapper was called
+  int irecvCount;    // Number of times MPI_Irecv wrapper was called
+  int sendrecvCount; // Number of times MPI_Sendrecv wrapper was called
+} wr_counts_t;
+
+// Struct to store the MPI send/recv counts of a rank
+typedef struct __send_recv_totals
+{
+  int rank;         // MPI rank
+  uint64_t sends;   // Number of completed sends
+  uint64_t recvs;   // Number of completed receives
+  int countSends;   // Number of unserviced sends
+} send_recv_totals_t;
+
+#endif // ifndef _MANA_COORD_PROTO_

--- a/contrib/mpi-proxy-split/mana_coordinator.cpp
+++ b/contrib/mpi-proxy-split/mana_coordinator.cpp
@@ -1,0 +1,294 @@
+#include <mpi.h>
+
+#include <functional>
+#include <numeric>
+#include <algorithm>
+#include <map>
+#include <sstream>
+
+#include "dmtcp_coordinator.h"
+#include "lookup_service.h"
+#include "mana_coordinator.h"
+#include "mana_coord_proto.h"
+#include "jtimer.h"
+
+using namespace dmtcp;
+
+typedef dmtcp::map<dmtcp::CoordClient*, rank_state_t> ClientToStateMap;
+typedef dmtcp::map<dmtcp::CoordClient*, phase_t> ClientToPhaseMap;
+typedef ClientToStateMap::value_type RankKVPair;
+typedef ClientToPhaseMap::value_type PhaseKVPair;
+typedef ClientToStateMap::const_iterator RankMapConstIterator;
+typedef ClientToPhaseMap::const_iterator PhaseMapConstIterator;
+
+static ClientToStateMap clientStates;
+static ClientToPhaseMap clientPhases;
+
+static std::ostream& operator<<(std::ostream &os, const phase_t &st);
+static bool noRanksInCriticalSection(const ClientToStateMap& clientStates);
+static bool allRanksReadyForCkpt(const ClientToStateMap& clientStates, long int size);
+static bool allRanksReady(const ClientToStateMap& clientStates, long int size);
+static void unblockRanks(const ClientToStateMap& clientStates, long int size);
+
+JTIMER(twoPc);
+
+void
+printNonReadyRanks()
+{
+  ostringstream o;
+  o << "Non-ready Rank States:" << std::endl;
+  for (PhaseKVPair c : clientPhases) {
+    phase_t st = c.second;
+    CoordClient *client = c.first;
+    if (st != IS_READY && st != READY_FOR_CKPT) {
+      o << client->identity() << ": " << st << std::endl;
+    }
+  }
+  printf("%s\n", o.str().c_str());
+  fflush(stdout);
+}
+
+void
+printMpiDrainStatus(const LookupService& lookupService)
+{
+  const KeyValueMap* map = lookupService.getMap(MPI_SEND_RECV_DB);
+  if (!map) {
+    JTRACE("No send recv database");
+    return;
+  }
+
+  typedef std::pair<KeyValue, KeyValue *> KVPair;
+  std::function<uint64_t(uint64_t, KVPair)> sendSum =
+                 [](uint64_t sum, KVPair el)
+                 { send_recv_totals_t *obj =
+                           (send_recv_totals_t*)el.second->data();
+                    return sum + obj->sends; };
+  std::function<uint64_t(uint64_t, KVPair)> recvSum =
+                 [](uint64_t sum, KVPair el)
+                 { send_recv_totals_t *obj =
+                           (send_recv_totals_t*)el.second->data();
+                    return sum + obj->recvs; };
+  std::function<string(string, KVPair)> indivStats =
+                    [](string str, KVPair el)
+                    { send_recv_totals_t *obj =
+                              (send_recv_totals_t*)el.second->data();
+                      ostringstream o;
+                      o << str
+                        <<  "Rank-" << std::to_string(obj->rank) << ": "
+                        << std::to_string(obj->sends) << ", "
+                        << std::to_string(obj->recvs) << "; ";
+                      return o.str(); };
+  uint64_t totalSends = std::accumulate(map->begin(), map->end(),
+                                        (uint64_t)0, sendSum);
+  uint64_t totalRecvs = std::accumulate(map->begin(), map->end(),
+                                        (uint64_t)0, recvSum);
+  string individuals = std::accumulate(map->begin(), map->end(),
+                                       string(""), indivStats);
+  ostringstream o;
+  o << MPI_SEND_RECV_DB << ": Total Sends: " << totalSends << "; ";
+  o << "Total Recvs: " << totalRecvs << std::endl;
+  o << "  Individual Stats: " << individuals;
+  printf("%s\n", o.str().c_str());
+  fflush(stdout);
+
+  const KeyValueMap* map2 = lookupService.getMap(MPI_WRAPPER_DB);
+  if (!map2) {
+    JTRACE("No wrapper database");
+    return;
+  }
+
+  std::function<string(string, KVPair)> rankStats =
+                    [](string str, KVPair el)
+                    { wr_counts_t *obj = (wr_counts_t*)el.second->data();
+                      int rank = *(int*)el.first.data();
+                      ostringstream o;
+                      o << str
+                        <<  "Rank-" << std::to_string(rank) << ": "
+                        << std::to_string(obj->sendCount) << ", "
+                        << std::to_string(obj->isendCount) << ", "
+                        << std::to_string(obj->recvCount) << ", "
+                        << std::to_string(obj->irecvCount) << ", "
+                        << std::to_string(obj->sendrecvCount) << "; ";
+                      return o.str(); };
+
+  individuals = std::accumulate(map->begin(), map->end(),
+                                string(""), rankStats);
+  ostringstream o2;
+  o2 << MPI_WRAPPER_DB << std::endl;
+  o2 << "  Individual Stats: " << individuals;
+  printf("%s\n", o2.str().c_str());
+  fflush(stdout);
+}
+
+string
+getClientPhase(CoordClient *client)
+{
+  ostringstream o;
+  o << ", " << clientPhases[client];
+  return o.str();
+}
+
+void
+processPreSuspendClientMsgHelper(DmtcpCoordinator *coord,
+                                 CoordClient *client,
+                                 int &workersAtCurrentBarrier,
+                                 const DmtcpMessage& msg,
+                                 const void *extraData)
+{
+  static bool firstTime = true;
+  if (firstTime) {
+    JTIMER_START(twoPc);
+    firstTime = false;
+  }
+  ComputationStatus status = coord->getStatus();
+
+  // Verify correctness of the response
+  if (msg.extraBytes != sizeof(rank_state_t) || !extraData) {
+    JWARNING(false)(msg.from)(msg.state)(msg.extraBytes)
+            .Text("Received msg with no (or invalid) state information!");
+    return;
+  }
+
+  // First, insert client's response in our map
+  rank_state_t state = *(rank_state_t*)extraData;
+  clientStates[client] = state;
+  clientPhases[client] = state.st;
+
+  JTRACE("Received pre-suspend response from client")(msg.from)(state.st);
+
+  // Next, return early, if we haven't received acks from all clients
+  if (!status.minimumStateUnanimous ||
+      workersAtCurrentBarrier < status.numPeers) {
+    return;
+  }
+  JTRACE("Received pre-suspend response from all ranks");
+
+  // Initiate checkpointing, if all clients are ready and have
+  // responded with their approvals.
+  if (allRanksReadyForCkpt(clientStates, status.numPeers)) {
+    JTRACE("All ranks ready for checkpoint; broadcasting suspend msg...");
+    JTIMER_STOP(twoPc);
+    coord->startCheckpoint();
+    goto done;
+  }
+
+  // We are ready! If all clients responded with IN_READY, inform the
+  // ranks of the imminent checkpoint msg and wait for their final approvals...
+  if (allRanksReady(clientStates, status.numPeers)) {
+    JTRACE("All ranks ready for checkpoint; broadcasting ckpt msg...");
+    query_t q(CKPT);
+    coord->broadcastMessage(DMT_DO_PRE_SUSPEND, sizeof q, &q);
+    goto done;
+  }
+
+  // Nothing to do if no rank is in critical section
+  if (noRanksInCriticalSection(clientStates)) {
+    JTRACE("No ranks in critical section; nothing to do...");
+    query_t q(GET_STATUS);
+    coord->broadcastMessage(DMT_DO_PRE_SUSPEND, sizeof q, &q);
+    goto done;
+  }
+
+  // Finally, if there are ranks stuck in PHASE_1 or in PHASE_2 (is PHASE_2
+  // required??), unblock them. This can happen only if there are ranks
+  // executing in critical section.
+  unblockRanks(clientStates, status.numPeers);
+done:
+  workersAtCurrentBarrier = 0;
+  clientStates.clear();
+}
+
+void
+sendCkptIntentMsg(dmtcp::DmtcpCoordinator *coord)
+{
+  query_t q(INTENT);
+  coord->broadcastMessage(DMT_DO_PRE_SUSPEND, sizeof q, &q);
+}
+
+static std::ostream&
+operator<<(std::ostream &os, const phase_t &st)
+{
+  switch (st) {
+    case UNKNOWN        : os << "UNKNOWN"; break;
+    case IS_READY       : os << "IS_READY"; break;
+    case PHASE_1        : os << "PHASE_1"; break;
+    case IN_CS          : os << "IN_CS"; break;
+    case OUT_CS         : os << "OUT_CS"; break;
+    case READY_FOR_CKPT : os << "READY_FOR_CKPT"; break;
+    case PHASE_2        : os << "PHASE_2"; break;
+    default             : os << "Unknown state"; break;
+  }
+  return os;
+}
+
+static bool
+noRanksInCriticalSection(const ClientToStateMap& clientStates)
+{
+  RankMapConstIterator req =
+    std::find_if(clientStates.begin(), clientStates.end(),
+                 [](const RankKVPair& elt)
+                 { return elt.second.st == IN_CS; });
+  return req == std::end(clientStates);
+}
+
+static bool
+allRanksReadyForCkpt(const ClientToStateMap& clientStates, long int size)
+{
+  int numReadyRanks =
+        std::count_if(clientStates.begin(), clientStates.end(),
+                      [](const RankKVPair& elt)
+                      { return elt.second.st == READY_FOR_CKPT; });
+  JTRACE("Ranks ready for ckpting")(numReadyRanks)(size);
+  return numReadyRanks == size;
+}
+
+static bool
+allRanksReady(const ClientToStateMap& clientStates, long int size)
+{
+  int numReadyRanks =
+        std::count_if(clientStates.begin(), clientStates.end(),
+                      [=](const RankKVPair& elt)
+                      { return elt.second.st == IS_READY; });
+  int numPhase1Ranks =
+        std::count_if(clientStates.begin(), clientStates.end(),
+                      [=](const RankKVPair& elt)
+                      { return elt.second.st == PHASE_1; });
+  int numPhase2Ranks =
+        std::count_if(clientStates.begin(), clientStates.end(),
+                      [=](const RankKVPair& elt)
+                      { return elt.second.st == PHASE_2; });
+  return ((numReadyRanks + numPhase1Ranks) == size) ||
+         ((numReadyRanks + numPhase1Ranks + numPhase2Ranks) == size) ||
+         (numPhase2Ranks == size);
+}
+
+static void
+unblockRanks(const ClientToStateMap& clientStates, long int size)
+{
+  int count = 0;
+  for (RankKVPair c : clientStates) {
+    DmtcpMessage msg(DMT_DO_PRE_SUSPEND);
+    if (c.second.st == PHASE_1 || c.second.st == PHASE_2) {
+      // For ranks in PHASE_1 or in PHASE_2, send them a free pass to unblock
+      // them.
+      JTRACE("Sending free pass to client")(c.first->identity())(c.second.st);
+      query_t q(FREE_PASS);
+      msg.extraBytes = sizeof q;
+      c.first->sock() << msg;
+      c.first->sock().writeAll((const char*)&q, msg.extraBytes);
+      count++;
+    } else if (c.second.st == IN_CS || c.second.st == IS_READY) {
+      // For other ranks in critical section or in ready state, just send
+      // them an info msg.
+      query_t q(GET_STATUS);
+      msg.extraBytes = sizeof q;
+      c.first->sock() << msg;
+      c.first->sock().writeAll((const char*)&q, msg.extraBytes);
+      count++;
+    } else {
+      JWARNING(false)(c.first->identity())(c.second.st)
+              .Text("Rank in unhandled state");
+    }
+  }
+  JTRACE("Unblocked ranks")(count);
+}

--- a/contrib/mpi-proxy-split/mana_coordinator.h
+++ b/contrib/mpi-proxy-split/mana_coordinator.h
@@ -1,0 +1,18 @@
+#ifndef _MANA_COORDINATOR_
+#define _MANA_COORDINATOR_
+
+#include "dmtcp_coordinator.h"
+#include "dmtcpmessagetypes.h"
+#include "lookup_service.h"
+
+void printNonReadyRanks();
+dmtcp::string getClientPhase(dmtcp::CoordClient* client);
+void printMpiDrainStatus(const dmtcp::LookupService& lookupService);
+void processPreSuspendClientMsgHelper(dmtcp::DmtcpCoordinator *coord,
+                                      dmtcp::CoordClient *client,
+                                      int &workersAtCurrentBarrier,
+                                      const dmtcp::DmtcpMessage& msg,
+                                      const void *extraData);
+void sendCkptIntentMsg(dmtcp::DmtcpCoordinator *coord);
+
+#endif // ifndef _MANA_COORDINATOR_

--- a/contrib/mpi-proxy-split/two-phase-algo.h
+++ b/contrib/mpi-proxy-split/two-phase-algo.h
@@ -10,40 +10,13 @@
 #include "jassert.h"
 #include "dmtcpmessagetypes.h"
 #include "workerstate.h"
+#include "mana_coord_proto.h"
 
 // Convenience macro
 #define twoPhaseCommit(comm, fnc) \
         dmtcp_mpi::TwoPhaseAlgo::instance().commit(comm, __FUNCTION__, fnc)
 
 using namespace dmtcp;
-
-typedef enum __phase_t
-{
-  UNKNOWN = -1,
-  IS_READY,
-  PHASE_1,
-  IN_CS,
-  OUT_CS,
-  READY_FOR_CKPT,
-  PHASE_2,
-} phase_t;
-
-typedef enum __query_t
-{
-  NONE = -1,
-  INTENT,
-  GET_STATUS,
-  FREE_PASS,
-  CKPT,
-} query_t;
-
-// Struct to encapsulate the checkpointing state of a rank
-typedef struct __rank_state_t
-{
-  int rank;       // MPI rank
-  MPI_Comm comm;  // MPI communicator object
-  phase_t st;     // Checkpointing state of the MPI rank
-} rank_state_t;
 
 namespace dmtcp_mpi
 {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,7 @@ AUTOMAKE_OPTIONS = foreign
 jalibdir=$(top_srcdir)/jalib
 dmtcpincludedir=$(top_srcdir)/include
 dmtcplibdir = $(pkglibdir)
+manaplugindir = $(top_srcdir)/contrib/mpi-proxy-split
 
 SUBDIRS = mtcp plugin
 
@@ -117,7 +118,8 @@ __d_libdir__libdmtcp_so_LDADD = libdmtcpinternal.a libjalib.a \
 				libsyscallsreal.a mtcp/libmtcp.a \
 				-ldl -lpthread -lrt
 
-__d_bindir__dmtcp_coordinator_LDADD = libdmtcpinternal.a libjalib.a \
+__d_bindir__dmtcp_coordinator_LDADD = $(manaplugindir)/mana_coordinator.o \
+			  libdmtcpinternal.a libjalib.a \
 			  libnohijack.a -lpthread -lrt
 __d_bindir__dmtcp_launch_LDADD  = libdmtcpinternal.a libjalib.a \
 			  libnohijack.a -lpthread -lrt -ldl

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -154,7 +154,8 @@ am___d_bindir__dmtcp_coordinator_OBJECTS =  \
 	restartscript.$(OBJEXT)
 __d_bindir__dmtcp_coordinator_OBJECTS =  \
 	$(am___d_bindir__dmtcp_coordinator_OBJECTS)
-__d_bindir__dmtcp_coordinator_DEPENDENCIES = libdmtcpinternal.a \
+__d_bindir__dmtcp_coordinator_DEPENDENCIES =  \
+	$(manaplugindir)/mana_coordinator.o libdmtcpinternal.a \
 	libjalib.a libnohijack.a
 am___d_bindir__dmtcp_launch_OBJECTS = dmtcp_launch.$(OBJEXT)
 __d_bindir__dmtcp_launch_OBJECTS =  \
@@ -504,6 +505,7 @@ AUTOMAKE_OPTIONS = foreign
 jalibdir = $(top_srcdir)/jalib
 dmtcpincludedir = $(top_srcdir)/include
 dmtcplibdir = $(pkglibdir)
+manaplugindir = $(top_srcdir)/contrib/mpi-proxy-split
 SUBDIRS = mtcp plugin
 PICFLAGS = -fPIC
 AM_CFLAGS = $(PICFLAGS)
@@ -586,7 +588,8 @@ __d_libdir__libdmtcp_so_LDADD = libdmtcpinternal.a libjalib.a \
 				libsyscallsreal.a mtcp/libmtcp.a \
 				-ldl -lpthread -lrt
 
-__d_bindir__dmtcp_coordinator_LDADD = libdmtcpinternal.a libjalib.a \
+__d_bindir__dmtcp_coordinator_LDADD = $(manaplugindir)/mana_coordinator.o \
+			  libdmtcpinternal.a libjalib.a \
 			  libnohijack.a -lpthread -lrt
 
 __d_bindir__dmtcp_launch_LDADD = libdmtcpinternal.a libjalib.a \

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -68,7 +68,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include <mpi.h>
+#include "../contrib/mpi-proxy-split/mana_coordinator.h"
 
 #include <functional>
 #include <numeric>
@@ -394,145 +394,6 @@ DmtcpCoordinator::handleUserCommand(char cmd, DmtcpMessage *reply /*= NULL*/)
   }
 }
 
-typedef enum __phase_t
-{
-  UNKNOWN = -1,
-  IS_READY,
-  PHASE_1,
-  IN_CS,
-  OUT_CS,
-  READY_FOR_CKPT,
-  PHASE_2,
-} phase_t;
-
-typedef enum __query_t
-{
-  NONE = -1,
-  INTENT,
-  GET_STATUS,
-  FREE_PASS,
-  CKPT,
-} query_t;
-
-typedef struct __rank_state_t
-{
-  int rank;
-  MPI_Comm comm;
-  phase_t st;
-} rank_state_t;
-
-typedef struct __send_recv_totals
-{
-  int rank;
-  uint64_t sends;
-  uint64_t recvs;
-  int countSends;
-} send_recv_totals_t;
-
-static map<CoordClient*, phase_t> clientPhases;
-typedef map<CoordClient*, phase_t>::value_type PhaseKVPair;
-
-static std::ostream&
-operator<<(std::ostream &os, const phase_t &st)
-{
-  switch (st) {
-    case UNKNOWN        : os << "UNKNOWN"; break;
-    case IS_READY       : os << "IS_READY"; break;
-    case PHASE_1        : os << "PHASE_1"; break;
-    case IN_CS          : os << "IN_CS"; break;
-    case OUT_CS         : os << "OUT_CS"; break;
-    case READY_FOR_CKPT : os << "READY_FOR_CKPT"; break;
-    case PHASE_2        : os << "PHASE_2"; break;
-    default             : os << "Unknown state"; break;
-  }
-  return os;
-}
-
-static map<CoordClient*, rank_state_t> clientStates;
-typedef map<CoordClient*, rank_state_t>::value_type RankKVPair;
-typedef map<CoordClient*, rank_state_t>::const_iterator RankConstIterator;
-
-#define MPI_SEND_RECV_DB  "SR_DB"
-#define MPI_US_DB         "US_DB"
-#define MPI_WRAPPER_DB    "WR_DB"
-
-typedef struct __wr_counts
-{
-  int sendCount;
-  int isendCount;
-  int recvCount;
-  int irecvCount;
-  int sendrecvCount;
-} wr_counts_t;
-
-static void
-printMpiDrainStatus()
-{
-  const KeyValueMap* map = lookupService.getMap(MPI_SEND_RECV_DB);
-  if (!map) {
-    JTRACE("No send recv database");
-    return;
-  }
-
-  typedef std::pair<KeyValue, KeyValue *> KVPair;
-  std::function<uint64_t(uint64_t, KVPair)> sendSum = [](uint64_t sum, KVPair el)
-                 { send_recv_totals_t *obj =
-                           (send_recv_totals_t*)el.second->data();
-                    return sum + obj->sends; };
-  std::function<uint64_t(uint64_t, KVPair)> recvSum = [](uint64_t sum, KVPair el)
-                 { send_recv_totals_t *obj =
-                           (send_recv_totals_t*)el.second->data();
-                    return sum + obj->recvs; };
-  std::function<string(string, KVPair)> indivStats = [](string str, KVPair el)
-                    { send_recv_totals_t *obj =
-                              (send_recv_totals_t*)el.second->data();
-                      ostringstream o;
-                      o << str
-                        <<  "Rank-" << std::to_string(obj->rank) << ": "
-                        << std::to_string(obj->sends) << ", "
-                        << std::to_string(obj->recvs) << "; ";
-                      return o.str(); };
-  uint64_t totalSends = std::accumulate(map->begin(), map->end(),
-                                        (uint64_t)0, sendSum);
-  uint64_t totalRecvs = std::accumulate(map->begin(), map->end(),
-                                        (uint64_t)0, recvSum);
-  string individuals = std::accumulate(map->begin(), map->end(),
-                                       string(""), indivStats);
-  ostringstream o;
-  o << MPI_SEND_RECV_DB << ": Total Sends: " << totalSends << "; ";
-  o << "Total Recvs: " << totalRecvs << std::endl;
-  o << "  Individual Stats: " << individuals;
-  printf("%s\n", o.str().c_str());
-  fflush(stdout);
-
-  const KeyValueMap* map2 = lookupService.getMap(MPI_WRAPPER_DB);
-  if (!map2) {
-    JTRACE("No wrapper database");
-    return;
-  }
-
-  std::function<string(string, KVPair)> rankStats = [](string str, KVPair el)
-                    { wr_counts_t *obj = (wr_counts_t*)el.second->data();
-                      int rank = *(int*)el.first.data();
-                      ostringstream o;
-                      o << str
-                        <<  "Rank-" << std::to_string(rank) << ": "
-                        << std::to_string(obj->sendCount) << ", "
-                        << std::to_string(obj->isendCount) << ", "
-                        << std::to_string(obj->recvCount) << ", "
-                        << std::to_string(obj->irecvCount) << ", "
-                        << std::to_string(obj->sendrecvCount) << "; ";
-                      return o.str(); };
-
-  individuals = std::accumulate(map->begin(), map->end(),
-                                string(""), rankStats);
-  ostringstream o2;
-  o2 << MPI_WRAPPER_DB << std::endl;
-  o2 << "  Individual Stats: " << individuals;
-  printf("%s\n", o2.str().c_str());
-  fflush(stdout);
-}
-
 void
 DmtcpCoordinator::printStatus(size_t numPeers, bool isRunning)
 {
@@ -560,21 +421,11 @@ DmtcpCoordinator::printStatus(size_t numPeers, bool isRunning)
     << "NUM_PEERS=" << numPeers << std::endl
     << "RUNNING=" << (isRunning ? "yes" : "no") << std::endl;
 
-  if (mpiMode) {
-    o << "Non-ready Rank States:" << std::endl;
-    for (PhaseKVPair c : clientPhases) {
-      phase_t st = c.second;
-      CoordClient *client = c.first;
-      if (st != IS_READY && st != READY_FOR_CKPT) {
-        o << client->identity() << ": " << st << std::endl;
-      }
-    }
-  }
-
   printf("%s", o.str().c_str());
   printf("\n%s\n", lookupService.getSummaryStats().c_str());
   if (mpiMode) {
-    printMpiDrainStatus();
+    printNonReadyRanks();
+    printMpiDrainStatus(lookupService);
   }
   fflush(stdout);
 }
@@ -597,7 +448,7 @@ DmtcpCoordinator::printList()
       << ", " << clients[i]->identity()
       << ", " << clients[i]->state();
     if (mpiMode) {
-      o << ", " << clientPhases[clients[i]];
+      o << getClientPhase(clients[i]);
     }
     o << '\n';
   }
@@ -725,144 +576,12 @@ DmtcpCoordinator::recordCkptFilename(CoordClient *client, const char *extraData)
   }
 }
 
-static bool
-noRanksInCriticalSection(map<CoordClient*, rank_state_t>& clientStates)
-{
-  RankConstIterator req = std::find_if(clientStates.begin(), clientStates.end(),
-                         [](const std::pair<CoordClient*, rank_state_t> &elt)
-                         { return elt.second.st == IN_CS; });
-  return req == std::end(clientStates);
-}
-
-static bool
-allRanksReadyForCkpt(map<CoordClient*, rank_state_t>& clientStates,
-                     long int size)
-{
-  int numReadyRanks =
-        std::count_if(clientStates.begin(), clientStates.end(),
-                      [](const std::pair<CoordClient*, rank_state_t> &elt)
-                      { return elt.second.st == READY_FOR_CKPT; });
-  JTRACE("Ranks ready for ckpting")(numReadyRanks)(size);
-  return numReadyRanks == size;
-}
-
-static bool
-allRanksReady(map<CoordClient*, rank_state_t>& clientStates, long int size)
-{
-  int numReadyRanks =
-        std::count_if(clientStates.begin(), clientStates.end(),
-                      [](const std::pair<CoordClient*, rank_state_t> &elt)
-                      { return elt.second.st == IS_READY; });
-  int numPhase1Ranks =
-        std::count_if(clientStates.begin(), clientStates.end(),
-                      [](const std::pair<CoordClient*, rank_state_t> &elt)
-                      { return elt.second.st == PHASE_1; });
-  int numPhase2Ranks =
-        std::count_if(clientStates.begin(), clientStates.end(),
-                      [](const std::pair<CoordClient*, rank_state_t> &elt)
-                      { return elt.second.st == PHASE_2; });
-  return ((numReadyRanks + numPhase1Ranks) == size) ||
-         ((numReadyRanks + numPhase1Ranks + numPhase2Ranks) == size) ||
-         (numPhase2Ranks == size);
-}
-
-static void
-unblockRanks(map<CoordClient*, rank_state_t>& clientStates, long int size)
-{
-  int count = 0;
-  for (RankKVPair c : clientStates) {
-    DmtcpMessage msg(DMT_DO_PRE_SUSPEND);
-    if (c.second.st == PHASE_1 || c.second.st == PHASE_2) {
-      // For ranks in PHASE_1 or in PHASE_2, send them a free pass to unblock
-      // other ranks stuck in critical section.
-      JTRACE("Sending free pass to client")(c.first->identity())(c.second.st);
-      query_t q(FREE_PASS);
-      msg.extraBytes = sizeof q;
-      c.first->sock() << msg;
-      c.first->sock().writeAll((const char*)&q, msg.extraBytes);
-      count++;
-    } else if (c.second.st == IN_CS || c.second.st == IS_READY) {
-      // For other ranks in critical section or in ready state, just send
-      // them an info msg.
-      query_t q(GET_STATUS);
-      msg.extraBytes = sizeof q;
-      c.first->sock() << msg;
-      c.first->sock().writeAll((const char*)&q, msg.extraBytes);
-      count++;
-    } else {
-      JWARNING(false)(c.first->identity())(c.second.st)
-              .Text("Rank in unhandled state");
-    }
-  }
-  JTRACE("Unblocked ranks")(count);
-}
-
 void
 DmtcpCoordinator::processPreSuspendClientMsg(CoordClient *client,
                                              const DmtcpMessage& msg,
                                              const void *extraData)
 {
-  static bool firstTime = true;
-  if (firstTime) {
-    JTIMER_START(twoPc);
-    firstTime = false;
-  }
-  ComputationStatus status = getStatus();
-
-  // Verify correctness of the response
-  if (msg.extraBytes != sizeof(rank_state_t) || !extraData) {
-    JWARNING(false)(msg.from)(msg.state)(msg.extraBytes)
-            .Text("Received msg with no (or invalid) state information!");
-    return;
-  }
-
-  // First, insert client's response in our map
-  rank_state_t state = *(rank_state_t*)extraData;
-  clientStates[client] = state;
-  clientPhases[client] = state.st;
-
-  JTRACE("Received pre-suspend response from client")(msg.from)(state.st);
-
-  // Next, return early, if we haven't received acks from all clients
-  if (!status.minimumStateUnanimous ||
-      workersAtCurrentBarrier < status.numPeers) {
-    return;
-  }
-  JTRACE("Received pre-suspend response from all ranks");
-
-  // Initiate checkpointing, if all clients are ready and have
-  // responded with their approvals.
-  if (allRanksReadyForCkpt(clientStates, status.numPeers)) {
-    JTRACE("All ranks ready for checkpoint; broadcasting suspend msg...");
-    JTIMER_STOP(twoPc);
-    startCheckpoint();
-    goto done;
-  }
-
-  // We are ready! If all clients responded with IN_READY, inform the
-  // ranks of the imminent checkpoint msg and wait for their final approvals...
-  if (allRanksReady(clientStates, status.numPeers)) {
-    JTRACE("All ranks ready for checkpoint; broadcasting ckpt msg...");
-    query_t q(CKPT);
-    broadcastMessage(DMT_DO_PRE_SUSPEND, sizeof q, &q);
-    goto done;
-  }
-
-  // Nothing to do if no rank is in critical section
-  if (noRanksInCriticalSection(clientStates)) {
-    JTRACE("No ranks in critical section; nothing to do...");
-    query_t q(GET_STATUS);
-    broadcastMessage(DMT_DO_PRE_SUSPEND, sizeof q, &q);
-    goto done;
-  }
-
-  // Finally, if there are ranks stuck in PHASE_1 or in PHASE_2 (is PHASE_2
-  // required??), unblock them. This can happen only if there are ranks
-  // executing in critical section.
-  unblockRanks(clientStates, status.numPeers);
-done:
-  workersAtCurrentBarrier = 0;
-  clientStates.clear();
+  processPreSuspendClientMsgHelper(this, client, workersAtCurrentBarrier, msg, extraData);
 }
 
 void
@@ -1451,8 +1170,7 @@ DmtcpCoordinator::startCheckpoint()
   // happen from processPreSuspendClientMsg(), we go ahead and do the
   // checkpoint.
   if (mpiMode && !sentIntentMsg) {
-    query_t q(INTENT);
-    broadcastMessage(DMT_DO_PRE_SUSPEND, sizeof q, &q);
+    sendCkptIntentMsg(this);
     sentIntentMsg = true;
     return false;
   }
@@ -1518,7 +1236,7 @@ DmtcpCoordinator::broadcastMessage(DmtcpMessageType type,
   workersAtCurrentBarrier = 0;
 }
 
-DmtcpCoordinator::ComputationStatus
+ComputationStatus
 DmtcpCoordinator::getStatus() const
 {
   ComputationStatus status;

--- a/src/dmtcp_coordinator.h
+++ b/src/dmtcp_coordinator.h
@@ -28,6 +28,13 @@
 
 namespace dmtcp
 {
+typedef struct {
+  WorkerState::eWorkerState minimumState;
+  WorkerState::eWorkerState maximumState;
+  bool minimumStateUnanimous;
+  int numPeers;
+} ComputationStatus;
+
 class CoordClient
 {
   public:
@@ -87,13 +94,6 @@ class CoordClient
 class DmtcpCoordinator
 {
   public:
-    typedef struct {
-      WorkerState::eWorkerState minimumState;
-      WorkerState::eWorkerState maximumState;
-      bool minimumStateUnanimous;
-      int numPeers;
-    } ComputationStatus;
-
     void onData(CoordClient *client);
     void onConnect();
     void onDisconnect(CoordClient *client);

--- a/src/lookup_service.cpp
+++ b/src/lookup_service.cpp
@@ -57,11 +57,11 @@ LookupService::getSummaryStats()
 }
 
 const KeyValueMap*
-LookupService::getMap(string mapName)
+LookupService::getMap(string mapName) const
 {
   ConstMapIterator map = _maps.find(mapName);
   if (map != _maps.end()) {
-    return &_maps[mapName];
+    return &_maps.at(mapName);
   }
   return NULL;
 }

--- a/src/lookup_service.h
+++ b/src/lookup_service.h
@@ -84,7 +84,7 @@ class LookupService
     ~LookupService() { reset(); }
 
     string getSummaryStats();
-    const KeyValueMap* getMap(string name);
+    const KeyValueMap* getMap(string name) const;
     void reset();
     void registerData(const DmtcpMessage &msg, const void *data);
     void respondToQuery(jalib::JSocket &remote,


### PR DESCRIPTION
These are the first steps to decouple the coordinator and the MANA code.

I have moved all of the MANA-specific code from `dmtcp_coordinator.cpp` to a separate set of files that are compiled along with the MANA plugin code. This code can be linked independently with the `dmtcp_coordinator` binary. I have added appropriate dependencies in the coordinator `Makefile`. It seems like a cleaner design.

The build process for the coordinator is still not fully automated yet, but it seems better than having a separate compilation script (`compile-coord-cori.sh`) just for the coordinator. After applying these patches, the steps for compiling the coordinator would be as follows:

```bash
$ cd $DMTCP_ROOT
$ ./configure --enable-debug
$ cd contrib/mpi-proxy-split/ && make -j # First, build the plugin
$ cd $DMTCP_ROOT && make -j # Next, finish building the rest of DMTCP
```

Note that the plugin can be compiled independent of DMTCP and must be built first. This creates the relevant file in the plugin directory (`mana_coordinator.o`) required to build the dmtcp_coordinator binary

Since I cannot directly compile and test on Cori, I am not directly pushing this change to the refactoring branch and instead created this PR. Could someone please test this and see if it works?