### PR TITLE
Refactor: mtcp_restart does set_lh_mem_range, instead of lower-half doing it

### DIFF
--- a/contrib/mpi-proxy-split/drain_send_recv_packets.cpp
+++ b/contrib/mpi-proxy-split/drain_send_recv_packets.cpp
@@ -116,7 +116,10 @@ updateCkptDirByRank()
   o << "/lhregions.dat";
   const char *fname = o.str().c_str();
   int fd = open(fname, O_CREAT | O_WRONLY);
+#if 0
+  // g_range (lh_memory_range) was written for debugging here.
   Util::writeAll(fd, g_range, sizeof(*g_range));
+#endif
   Util::writeAll(fd, &g_numMmaps, sizeof(g_numMmaps));
   for (int i = 0; i < g_numMmaps; i++) {
     Util::writeAll(fd, &g_list[i], sizeof(g_list[i]));

--- a/contrib/mpi-proxy-split/lower-half/lower_half_api.h
+++ b/contrib/mpi-proxy-split/lower-half/lower_half_api.h
@@ -91,6 +91,16 @@ typedef void* (*updateEnviron_t)(char **environ);
 typedef MmapInfo_t* (*getMmappedList_t)(int *num);
 typedef void (*resetMmappedList_t)();
 
+// Global variables with lower-half information
+
+// startProxy() (called from splitProcess()) will initialize 'info'
+extern struct LowerHalfInfo_t info;
+// Pointer to the custom dlsym implementation (see mydlsym() in libproxy.c) in
+// the lower half. This is initialized using the information passed to us by
+// the transient lh_proxy process in DMTCP_EVENT_INIT.
+// initializeLowerHalf() will initialize this to: (proxyDlsym_t)info.lh_dlsym
+extern proxyDlsym_t pdlsym;
+
 // API
 
 // Returns the address of an MPI API in the lower half's MPI library based on

--- a/contrib/mpi-proxy-split/lower-half/lower_half_api.h
+++ b/contrib/mpi-proxy-split/lower-half/lower_half_api.h
@@ -29,6 +29,20 @@
 
 // Shared data structures
 
+typedef struct __MemRange
+{
+  void *start;  // Start of the address range for lower half memory allocations
+  void *end;    // End of the address range for lower half memory allocations
+} MemRange_t;
+
+typedef struct __MmapInfo
+{
+  void *addr;   // Start address of mmapped region
+  size_t len;   // Length (in bytes) of mmapped region
+  int unmapped; // 1 if the region was unmapped; 0 otherwise
+  int guard;    // 1 if the region has additional guard pages around it; 0 otherwise
+} MmapInfo_t;
+
 // The transient lh_proxy process introspects its memory layout and passes this
 // information back to the main application process using this struct.
 struct LowerHalfInfo_t
@@ -51,22 +65,8 @@ struct LowerHalfInfo_t
   void *updateEnvironFptr; // Pointer to updateEnviron() function in the lower half
   void *getMmappedListFptr; // Pointer to getMmapedList() function in the lower half
   void *resetMmappedListFptr; // Pointer to resetMmapedList() function in the lower half
-  void *memRange; // Pointer to MemRange_t object in the lower half
+  MemRange_t memRange; // MemRange_t object in the lower half
 };
-
-typedef struct __MemRange
-{
-  void *start;  // Start of the address range for lower half memory allocations
-  void *end;    // End of the address range for lower half memory allocations
-} MemRange_t;
-
-typedef struct __MmapInfo
-{
-  void *addr;   // Start address of mmapped region
-  size_t len;   // Length (in bytes) of mmapped region
-  int unmapped; // 1 if the region was unmapped; 0 otherwise
-  int guard;    // 1 if the region has additional guard pages around it; 0 otherwise
-} MmapInfo_t;
 
 enum MPI_Fncs {
   MPI_Fnc_NULL,

--- a/contrib/mpi-proxy-split/mpi_plugin.cpp
+++ b/contrib/mpi-proxy-split/mpi_plugin.cpp
@@ -23,7 +23,6 @@ LowerHalfInfo_t info;
 
 int g_numMmaps = 0;
 MmapInfo_t *g_list = NULL;
-MemRange_t *g_range = NULL;
 
 // #define DEBUG
 

--- a/contrib/mpi-proxy-split/mpi_plugin.cpp
+++ b/contrib/mpi-proxy-split/mpi_plugin.cpp
@@ -18,9 +18,6 @@ using namespace dmtcp;
 
 /* Global variables */
 
-proxyDlsym_t pdlsym;
-LowerHalfInfo_t info;
-
 int g_numMmaps = 0;
 MmapInfo_t *g_list = NULL;
 

--- a/contrib/mpi-proxy-split/mpi_plugin.h
+++ b/contrib/mpi-proxy-split/mpi_plugin.h
@@ -27,14 +27,7 @@
 #define PMPI_IMPL(ret, func, ...)                               \
   EXTERNC ret P##func(__VA_ARGS__) __attribute__ ((weak, alias (#func)));
 
-extern struct LowerHalfInfo_t info;
 extern int g_numMmaps;
 extern MmapInfo_t *g_list;
-
-// Pointer to the custom dlsym implementation (see mydlsym() in libproxy.c) in
-// the lower half. This is initialized using the information passed to us by
-// the transient lh_proxy process in DMTCP_EVENT_INIT.
-extern proxyDlsym_t pdlsym;
-
 
 #endif // ifndef _MPI_PLUGIN_H

--- a/contrib/mpi-proxy-split/mpi_plugin.h
+++ b/contrib/mpi-proxy-split/mpi_plugin.h
@@ -30,7 +30,6 @@
 extern struct LowerHalfInfo_t info;
 extern int g_numMmaps;
 extern MmapInfo_t *g_list;
-extern MemRange_t *g_range;
 
 // Pointer to the custom dlsym implementation (see mydlsym() in libproxy.c) in
 // the lower half. This is initialized using the information passed to us by

--- a/contrib/mpi-proxy-split/split_process.cpp
+++ b/contrib/mpi-proxy-split/split_process.cpp
@@ -300,7 +300,8 @@ setLhMemRange()
   }
   close(mapsfd);
   if (found && g_range == NULL) {
-    g_range = (MemRange_t*)info.memRange;
+    // Fill in info.memRange
+    g_range = &info.memRange;
     g_range->start = (VA)area.addr - TWO_GB;
     g_range->end = (VA)area.addr - ONE_GB;
   }

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -466,9 +466,9 @@ main(int argc, char *argv[], char **environ)
       //   the end of stack in the lower half.
       // One gigabyte below those mmaps of the lower half, we are creating space
       //   for the GNI driver data, to be created when the GNI library runs.
-      // FIXME:  Create pointer argument (out parameter) in setLhMemRange(),
-      //    initializeLowerHalf, splitProcess, etc., to remove global variable.
       // This says that we have to reserve only up to the mtcp_restart stack.
+      // FIXME:  splitProcess() should return the lh_info struct.
+      //         Then we can use 'lh_info.memRange->start', below.
       end1 = g_lh_mem_range->start - 1 * GB;
       // start2 == end2:  So, this will not be used.
       start2 = 0;

--- a/src/mtcp/mtcp_split_process.c
+++ b/src/mtcp/mtcp_split_process.c
@@ -163,8 +163,10 @@ startProxy(char *argv0, char **envp)
 
     case 0: // in child
     {
-      mtcp_sys_close(pipefd_out[0]); // close reading end of pipe
-      // FIXME:  This could be done more simply by writing to stdin of lh_proxy.
+      mtcp_sys_dup2(pipefd_out[1], 1); // Will write lh_info to stdout.
+      mtcp_sys_close(pipefd_out[1]);
+      mtcp_sys_close(pipefd_out[0]); // Close reading end of pipe.
+      // FIXME:  Remove buf after verifying can write to stdout instead.
       char buf[10];
       mtcp_itoa(pipefd_out[1], buf);
       char* args[] = {"NO_SUCH_EXECUTABLE", buf, NULL};

--- a/src/mtcp/mtcp_split_process.c
+++ b/src/mtcp/mtcp_split_process.c
@@ -22,12 +22,19 @@
 
 int mtcp_sys_errno;
 LowerHalfInfo_t info;
+// FIXME:  The value of pdlsym must be passed from mtcp_restart to
+//         the upper half, so that NEXT_FNC() in mpi-wrappers in libmana.so in 
+//         can use the updated pdlsym in case the address of the lower half
+//         in the restarted process has changed.
+//         But the lower half is loaded at a fixed address.  So, the address of
+//         pdlsym can be a fixed address that is unused by the upper half.
+//         In this case, we don't need to pass pdlsym to the upper half.
+static proxyDlsym_t pdlsym; // initialized to (proxyDlsym_t)info.lh_dlsym
 MemRange_t *g_lh_mem_range = NULL;
 static MemRange_t g_lh_mem_range_buf;
 
 static unsigned long origPhnum;
 static unsigned long origPhdr;
-static proxyDlsym_t pdlsym;
 
 static void patchAuxv(ElfW(auxv_t) *, unsigned long , unsigned long , int );
 static int mmap_iov(const struct iovec *, int );

--- a/src/mtcp/mtcp_split_process.c
+++ b/src/mtcp/mtcp_split_process.c
@@ -205,19 +205,22 @@ getMappedArea(Area *area, char *name) {
   return 0; // not found
 }
 
-static void
+static MemRange_t
 setLhMemRange()
 {
   Area area;
 
   const uint64_t ONE_GB = 0x40000000;
   const uint64_t TWO_GB = 0x80000000;
+  MemRange_t lh_mem_range;
 
   int found = getMappedArea(&area, "[stack]");
-  if (found && g_lh_mem_range == NULL) {
-    g_lh_mem_range = (MemRange_t*)info.memRange;
-    g_lh_mem_range->start = (VA)area.addr - TWO_GB;
-    g_lh_mem_range->end = (VA)area.addr - ONE_GB;
+  if (found) {
+    lh_mem_range.start = (VA)area.addr - TWO_GB;
+    lh_mem_range.end = (VA)area.addr - ONE_GB;
+  } else {
+    DPRINTF("Failed to find [stack] memory segment\n");
+    mtcp_abort();
   }
 }
 

--- a/src/mtcp/mtcp_split_process.h
+++ b/src/mtcp/mtcp_split_process.h
@@ -13,6 +13,22 @@
 
 typedef void (*fnptr_t)();
 
+// FIXME: Much of this is duplicated in ../lower-half/lower_half_api.h
+
+typedef struct __MemRange
+{
+  void *start;
+  void *end;
+} MemRange_t;
+
+typedef struct __MmapInfo
+{
+  void *addr;
+  size_t len;
+  int unmapped;
+  int guard;
+} MmapInfo_t;
+
 // The transient proxy process introspects its memory layout and passes this
 // information back to the main application process using this struct.
 typedef struct _LowerHalfInfo
@@ -35,22 +51,8 @@ typedef struct _LowerHalfInfo
   void *updateEnvironFptr;
   void *getMmappedListFptr;
   void *resetMmappedListFptr;
-  void *memRange;
+  MemRange_t memRange;
 } LowerHalfInfo_t;
-
-typedef struct __MemRange
-{
-  void *start;
-  void *end;
-} MemRange_t;
-
-typedef struct __MmapInfo
-{
-  void *addr;
-  size_t len;
-  int unmapped;
-  int guard;
-} MmapInfo_t;
 
 extern LowerHalfInfo_t info;
 extern MemRange_t *g_lh_mem_range;


### PR DESCRIPTION
**_[ This works now.  Please review. ]_**

setLhMemRange() has been moved to src/mtcp/mtcp_split_process.c.  (And another version of it is defined in contrib/mpi-proxy-split/split-process.cpp.)  Please review this, so I can push it in, and build on top of it.

Once this is in 'refactoring', I can then test PR #2 and ask for that also to be reviewed.  With that in place, I will then modify setLhMemRange() to set the lh_memory_range based on other memory layouts, including CentOS/Ubuntu.

Right now, MANA is not working on CentOS/Ubuntu because the lh_mem_range is conflicting with the stack on CentOS/Ubuntu.  The libs and stack, there, have only 128 MB free between them.

We can then port to other layouts of the stack, vdso, libs, etc..  So, the choice of where to put the LhMemRange() will be based on an analysis of the current memory layout.

This code continues to work on Cori., and should not break anything.

Other simplifications were also made in the code:
  1. lh_proxy reads the lh_mem_range on its stdin, and writes back the lh_info struct on its stdout.  So, lh_proxy (the child process) doesn't need special coding with pipes; that's only for the parent process now.
  2.  This also means that we don't need to pass buf as arg[1] of lh_proxy, holding the pipe fd that will be used by lh_proxy.
 3.  We now have only one routine, setLhMemRange() (in mtcp_restart), instead of two of them in the contrib/mpi-proxy-split plugin.
 4. Various comments were added to make clear the logic flow in splitProcess(), and how the lh_info struct and lh_mem_range are passed back and forth.
 5. 'info' and 'pdlsym' are now declared and allocated in lower-half-api.h and split-process.cpp.  So, now split-process.cpp no longer depends on mpi_plugin.h.