### PR TITLE
Fixed error on configuration step.

### DIFF
--- a/configure
+++ b/configure
@@ -4946,7 +4946,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 ac_config_headers="$ac_config_headers include/config.h"
 
-ac_config_files="$ac_config_files Makefile contrib/Makefile contrib/ckptfile/Makefile contrib/infiniband/Makefile plugin/Makefile src/Makefile src/mtcp/Makefile src/plugin/Makefile include/dmtcp.h test/Makefile test/autotest_config.py test/plugin/Makefile"
+ac_config_files="$ac_config_files Makefile contrib/Makefile contrib/ckptfile/Makefile contrib/infiniband/Makefile plugin/Makefile src/Makefile src/mtcp/Makefile src/plugin/Makefile include/dmtcp.h"
 
 #AC_CONFIG_FILES([test/credentials/Makefile])
 


### PR DESCRIPTION
config.status: error: cannot find input file: `test/Makefile.in'

Signed-off-by: Junyeon Lee <junyeon2.lee@samsung.com>