### PR TITLE
[MANA-3]Fix gethostbyname static

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -289,9 +289,6 @@ clean: tidy
 	   fi; \
 	 fi; \
 	 rm -rf $$DMTCP_TMPDIR
-	- if test -e contrib/mpi-proxy-split; then \
-	   cd contrib/mpi-proxy-split && make clean; \
-	  fi
 
 # Obsolete, remove in 2.5.0.
 clean-64: clean

--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -52,6 +52,9 @@ tidy:
 
 clean: tidy
 	for p in $(plugins); do (cd $$p && $(MAKE) clean); done
+	- if test -e mpi-proxy-split; then \
+	   cd mpi-proxy-split && make clean; \
+	  fi
 
 distclean: clean
 	for p in $(plugins); do \

--- a/contrib/mpi-proxy-split/lower-half/Makefile
+++ b/contrib/mpi-proxy-split/lower-half/Makefile
@@ -27,8 +27,9 @@ override CXXFLAGS += -g3 -O0 -fPIC -I${DMTCP_INCLUDE} -I${JALIB_INCLUDE} \
 
 PROXY_LD_FLAGS=-static -Wl,-Ttext-segment -Wl,0xE000000 -Wl,--wrap -Wl,__munmap -Wl,--wrap -Wl,shmat -Wl,--wrap -Wl,shmget
 
-default: ${PROXY_BIN}
+default: ${PROXY_BIN} ${STATIC_GETHOSTBYNAME}
 
+# We should remove the special case for Cori, once we know this works on Cori.
 ifeq ($(findstring cori,$(PLATFORM)),cori)
   STATIC_GETHOSTBYNAME=
 else
@@ -54,7 +55,7 @@ endif
 # ***        ./configure --disable-xml2 --disable-libxml2 ...
 # ***        or unless you installed the necessary libaries.
 # ***        See ./README.mpich-static here, for how to install the libaries
-${PROXY_BIN}: ${PROXY_OBJS} ${LIBPROXY}.a ${STATIC_GETHOSTBYNAME}
+${PROXY_BIN}: ${PROXY_OBJS} ${LIBPROXY}.a
 	if ${MPICC} -v 2>&1 | grep -q 'MPICH version'; then \
 	  rm -f tmp.sh; \
 	  ${MPICC} -show ${PROXY_LD_FLAGS} -o $@ -Wl,-start-group \
@@ -70,8 +71,8 @@ ${PROXY_BIN}: ${PROXY_OBJS} ${LIBPROXY}.a ${STATIC_GETHOSTBYNAME}
 ${LIBPROXY}.a: ${LIBPROXY_OBJS}
 	ar cr $@ $^
 
-install: ${PROXY_BIN}
-	cp -f $< ${DMTCP_ROOT}/bin/
+install: ${PROXY_BIN} ${STATIC_GETHOSTBYNAME}
+	cp -f $^ ${DMTCP_ROOT}/bin/
 
 tidy:
 	rm -f *~ .*.swp dmtcp_restart_script*.sh ckpt_*.dmtcp

--- a/contrib/mpi-proxy-split/lower-half/gethostbyname-static/NOTICE
+++ b/contrib/mpi-proxy-split/lower-half/gethostbyname-static/NOTICE
@@ -1,3 +1,3 @@
-The two files, gethostbyname_r.c and gethostbyname_r_aux.c, are
+The two files, gethostbyname_static.c and gethostbyname_proxy.c, are
 copyright under the Apache 2.0 license by Gene Cooperman (gene@ccs.neu.edu).
 See the file LICENSE for details.

--- a/contrib/mpi-proxy-split/lower-half/gethostbyname-static/README
+++ b/contrib/mpi-proxy-split/lower-half/gethostbyname-static/README
@@ -1,0 +1,19 @@
+This program is free software, copyright under Apache 2.0
+by Gene Cooperman (gene@ccs.neu.edu).
+
+This is a definition of gethostbyname/getaddrinfo that can be statically
+linked into your executable;  the code forks a child, which execs
+into a dynamically linked program, which can then call gethostbyname
+or getaddrinfo dynamically, and report back the results to the
+statically linked parent.
+
+See:
+  https://www.ccs.neu.edu/home/gene/cs-info.html#gethostbyname
+
+for a longer description of the history of how glibc decided that
+gethostbyname/getaddrinfo would be deprecated and eventually completely
+removed from all statically linked programs in Linux.
+
+This author does not agree with the arguments for not allowing
+statically linked programs to call gethostbyname.  musl continues
+to support this.  And if glibc will not support it, then this author will.


### PR DESCRIPTION
The important commit does:
  Update gethostbyname-static to latest version
  * This fixes a bug that occurred when getaddrinfo() was called
     with a hints parameter that was non-NULL. 

In addition, there is a second commit that modifies `mpi-proxy-split/lower-half/Makefile`.  It does a little cleanup, and hopefully fixes the bug in which 'make mana' was not installing `gethostbyname_proxy` to the MANA bin directory.

This fix is especially important in porting MANA to CentOS, since getaddrinfo() is called with a non-NULL `hints` parameter in MPICH on CentOS.