### PR TITLE
[MANA-48] Dynamically find a memory region for LH to avoid overlap

### DIFF
--- a/contrib/mpi-proxy-split/split_process.cpp
+++ b/contrib/mpi-proxy-split/split_process.cpp
@@ -378,8 +378,7 @@ findLHMemRange(MemRange_t *lh_mem_range)
     // stack.
     if (strcmp(next_path_name, "[heap]") == 0) {
       next_addr_end += ONEGB;
-    }
-    if (strcmp(next_path_name, "[stack]") == 0) {
+    } else if (strcmp(next_path_name, "[stack]") == 0) {
       next_addr_start -= ONEGB;
     }
 

--- a/contrib/mpi-proxy-split/split_process.cpp
+++ b/contrib/mpi-proxy-split/split_process.cpp
@@ -388,13 +388,8 @@ setLhMemRange()
   FILE* f = fopen("/proc/self/maps", "r");
   if (f) {
     fscanf(f, "%llx-%llx %[^\n]\n", &next_start, &curr_end, line);
-    printf("%llx-%llx %s\n", next_start, curr_end, line);
     while (fscanf(f, "%llx-%llx %[^\n]\n", &next_start, &next_end, line) != EOF) {
-      printf("%llx-%llx %s\n", next_start, next_end, line);
-      printf("pre-align: 0x%llx, ", curr_end);
       curr_end = alignMemAddr(curr_end);
-      printf("post-align: 0x%llx\n", curr_end);
-      printf("comparison: 0x%llx, 0x%llx\n", curr_end, next_start);
       if (curr_end + TWO_GB <= next_start) {
         lh_mem_range.start = (VA)curr_end;
         lh_mem_range.end =   (VA)curr_end + TWO_GB;

--- a/contrib/mpi-proxy-split/split_process.cpp
+++ b/contrib/mpi-proxy-split/split_process.cpp
@@ -21,7 +21,7 @@
 
 // Needed for process_vm_readv
 #ifndef _GNU_SOURCE
-  #define _GNU_SOURCE
+# define _GNU_SOURCE
 #endif
 
 #include <asm/prctl.h>
@@ -48,6 +48,10 @@
 #include "procmapsutils.h"
 #include "util.h"
 #include "dmtcp.h"
+
+#ifndef CENTOS
+# define CENTOS
+#endif
 
 static unsigned long origPhnum;
 static unsigned long origPhdr;
@@ -368,7 +372,12 @@ setLhMemRange()
   close(mapsfd);
   static MemRange_t lh_mem_range;
   if (found) {
-#if !defined(USE_MANA_LH_FIXED_ADDRESS)
+#if defined(CENTOS)
+    // FIXME: we need to write a function that automatically determines
+    // addresses from procmaps
+    lh_mem_range.start = (VA)0x10000000;
+    lh_mem_range.end =   (VA)0x10000000 + TWO_GB;
+#elif !defined(USE_MANA_LH_FIXED_ADDRESS)
     lh_mem_range.start = (VA)area.addr - TWO_GB;
     lh_mem_range.end = (VA)area.addr - ONE_GB;
 #else

--- a/contrib/mpi-proxy-split/split_process.cpp
+++ b/contrib/mpi-proxy-split/split_process.cpp
@@ -48,10 +48,6 @@
 #include "util.h"
 #include "dmtcp.h"
 
-#ifndef CENTOS
-# define CENTOS
-#endif
-
 static unsigned long origPhnum;
 static unsigned long origPhdr;
 LowerHalfInfo_t lh_info;
@@ -421,14 +417,17 @@ setLhMemRange()
   close(mapsfd);
   static MemRange_t lh_mem_range;
   if (found) {
-#if defined(CENTOS)
     findLHMemRange(&lh_mem_range);
-#elif !defined(USE_MANA_LH_FIXED_ADDRESS)
+// This segment is only here until I ascertain whether the generalized code
+// works on Cori too. The above function works on CentOS. - Illio
+#if 0
+#if !defined(USE_MANA_LH_FIXED_ADDRESS)
     lh_mem_range.start = (VA)area.addr - 2 * ONEGB;
     lh_mem_range.end =   (VA)area.addr - ONEGB;
 #else
     lh_mem_range.start = 0x2aab00000000;
     lh_mem_range.end =   0x2aab00000000 + ONEGB;
+#endif
 #endif
   } else {
     JASSERT(false).Text("Failed to find [stack] memory segment\n");

--- a/contrib/mpi-proxy-split/split_process.cpp
+++ b/contrib/mpi-proxy-split/split_process.cpp
@@ -30,6 +30,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/mman.h>
+#include <libgen.h>
 #include <limits.h>
 #include <link.h>
 #include <unistd.h>
@@ -384,7 +385,7 @@ findLHMemRange(MemRange_t *lh_mem_range)
 
     if (prev_addr_end + 2 * ONEGB <= next_addr_start) {
       lh_mem_range->start = (VA)prev_addr_end;
-      lh_mem_range->end =   (VA)prev_addr_end + 2 * ONEGB;
+      lh_mem_range->end = (VA)prev_addr_end + 2 * ONEGB;
       is_set = true;
       break; 
     }
@@ -397,9 +398,8 @@ findLHMemRange(MemRange_t *lh_mem_range)
     .Text("No memory region can be found for the lower half");
 }
 
-// Sets the address range for the lower half. The lower half gets a fixed
-// address range of 1 GB at a high address before the stack region of the
-// current process. All memory allocations done by the lower half are restricted
+// Sets the address range for the lower half, dynamically determined by the
+// above function. All memory allocations done by the lower half are restricted
 // to the specified address range.
 static MemRange_t
 setLhMemRange()
@@ -418,17 +418,6 @@ setLhMemRange()
   static MemRange_t lh_mem_range;
   if (found) {
     findLHMemRange(&lh_mem_range);
-// This segment is only here until I ascertain whether the generalized code
-// works on Cori too. The above function works on CentOS. - Illio
-#if 0
-#if !defined(USE_MANA_LH_FIXED_ADDRESS)
-    lh_mem_range.start = (VA)area.addr - 2 * ONEGB;
-    lh_mem_range.end =   (VA)area.addr - ONEGB;
-#else
-    lh_mem_range.start = 0x2aab00000000;
-    lh_mem_range.end =   0x2aab00000000 + ONEGB;
-#endif
-#endif
   } else {
     JASSERT(false).Text("Failed to find [stack] memory segment\n");
   }

--- a/contrib/mpi-proxy-split/split_process.cpp
+++ b/contrib/mpi-proxy-split/split_process.cpp
@@ -403,10 +403,7 @@ dynamicMemRangeHelper(MemRange_t *lh_mem_range, const uint64_t *region_size)
     }
     fclose(f);
   }
-  if (!is_set) {     
-    lh_mem_range->start = (VA)0x10000000;
-    lh_mem_range->end =   (VA)0x10000000 + *region_size;
-  }
+  JASSERT(is_set)(JASSERT_ERRNO).Text("No memory region can be found for the lower half");
 }
 
 // Sets the address range for the lower half. The lower half gets a fixed

--- a/contrib/mpi-proxy-split/split_process.cpp
+++ b/contrib/mpi-proxy-split/split_process.cpp
@@ -352,8 +352,8 @@ startProxy()
 static inline unsigned long long
 alignMemAddr(unsigned long addr)
 {
-  return (addr >> 20) + 0x1 << 20;
-}  
+  return (addr + 0x1fffff) & ~0x1fffff;
+}
 
 // Sets the address range for the lower half. The lower half gets a fixed
 // address range of 1 GB at a high address before the stack region of the
@@ -388,9 +388,14 @@ setLhMemRange()
   FILE* f = fopen("/proc/self/maps", "r");
   if (f) {
     fscanf(f, "%llx-%llx %[^\n]\n", &next_start, &curr_end, line);
+    printf("%llx-%llx %s\n", next_start, curr_end, line);
     while (fscanf(f, "%llx-%llx %[^\n]\n", &next_start, &next_end, line) != EOF) {
+      printf("%llx-%llx %s\n", next_start, next_end, line);
+      printf("pre-align: 0x%llx, ", curr_end);
       curr_end = alignMemAddr(curr_end);
-      if (next_start - curr_end >= TWO_GB) {
+      printf("post-align: 0x%llx\n", curr_end);
+      printf("comparison: 0x%llx, 0x%llx\n", curr_end, next_start);
+      if (curr_end + TWO_GB <= next_start) {
         lh_mem_range.start = (VA)curr_end;
         lh_mem_range.end =   (VA)curr_end + TWO_GB;
         is_set = true;

--- a/contrib/mpi-proxy-split/split_process.cpp
+++ b/contrib/mpi-proxy-split/split_process.cpp
@@ -379,8 +379,10 @@ dynamicMemRangeHelper(MemRange_t *lh_mem_range, const uint64_t *region_size)
   // For now, we hope it doesn't change the calculation.
   FILE* f = fopen("/proc/self/maps", "r");
   if (f) {
-    fscanf(f, "%llx-%llx %s %lx %s %lx %s\n", &prev_addr_start, &prev_addr_end, perms, &offset, device, &inode, prev_path_name);
-    while (fscanf(f, "%llx-%llx %s %lx %s %lx %s\n", &next_addr_start, &next_addr_end, perms, &offset, device, &inode, next_path_name) != EOF) {
+    fscanf(f, "%llx-%llx %s %lx %s %lx %s\n",
+           &prev_addr_start, &prev_addr_end, perms, &offset, device, &inode, prev_path_name);
+    while (fscanf(f, "%llx-%llx %s %lx %s %lx %s\n",
+           &next_addr_start, &next_addr_end, perms, &offset, device, &inode, next_path_name) != EOF) {
       // alignMemAddr aligns the address such that HUGEPAGES/2MB can also be used.
       prev_addr_end = alignMemAddr(prev_addr_end);
 

--- a/include/procmapsarea.h
+++ b/include/procmapsarea.h
@@ -57,8 +57,7 @@
 #define ONEGB (uint64_t)(1024 * 1024 * 1024)
 
 // Rounds the given address up to the nearest region size, given as an input.
-#define ROUNDADDRUP(addr, size)	\
-	((addr + size - 1) & ~(size - 1)) 
+#define ROUNDADDRUP(addr, size) ((addr + size - 1) & ~(size - 1)) 
 
 typedef char *VA;  /* VA = virtual address */
 

--- a/include/procmapsarea.h
+++ b/include/procmapsarea.h
@@ -53,6 +53,12 @@
 #define DELETED_FILE_SUFFIX " (deleted)"
 
 #define FILENAMESIZE        1024
+#define ONEMB (uint64_t)(1024 * 1024)
+#define ONEGB (uint64_t)(1024 * 1024 * 1024)
+
+// Rounds the given address up to the nearest region size, given as an input.
+#define ROUNDADDRUP(addr, size)	\
+	((addr + size - 1) & ~(size - 1)) 
 
 typedef char *VA;  /* VA = virtual address */
 


### PR DESCRIPTION
This pull request fixes a bug where the assigned lower half memory region would overlap with some of the libraries before the stack on CentOS, as it is automatically assigned one gigabyte before the stack on Cori. It now searches for the first available two gigabyte memory region to assign the memory region to - we use two gigabytes to give it some buffer space; it also leaves a one gigabyte buffer region if it's placed after the heap or before the stack in case either of them grow. From what I've seen, this ends up being much before the hardcoded location, usually just after the heap.

This has been tested on both Cori and CentOS by running all the programs in `contrib/mpi-proxy-split/test` directories, and the results seen are the same as without this pull request. If an available region is not found, it fails an assertion, so this should mean that the algorithm is working, but to be safe I have inspected the memory map of these programs and found them to be fine.