### PR TITLE
[MANA-43] Fix gethostbyname static again

### DIFF
--- a/contrib/mpi-proxy-split/lower-half/Makefile
+++ b/contrib/mpi-proxy-split/lower-half/Makefile
@@ -55,7 +55,7 @@ endif
 # ***        ./configure --disable-xml2 --disable-libxml2 ...
 # ***        or unless you installed the necessary libaries.
 # ***        See ./README.mpich-static here, for how to install the libaries
-${PROXY_BIN}: ${PROXY_OBJS} ${LIBPROXY}.a
+${PROXY_BIN}: ${PROXY_OBJS} ${LIBPROXY}.a ${STATIC_GETHOSTBYNAME}
 	if ${MPICC} -v 2>&1 | grep -q 'MPICH version'; then \
 	  rm -f tmp.sh; \
 	  ${MPICC} -show ${PROXY_LD_FLAGS} -o $@ -Wl,-start-group \

--- a/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
+++ b/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
@@ -1,8 +1,12 @@
 CFLAGS=-g3 -O0
 
+# getaddrinfo ntp-wwv.nist.gov time: sin_port: 9472; sin_addr: 132.163.97.5
 test: a.out
 	./a.out localhost
 	./a.out localhost time
+	./a.out ntp-wwv.nist.gov time
+	@ test `./a.out ntp-wwv.nist.gov time | sed -e 's%^.*sin_addr '%%` == \
+	     132.163.97.5 || echo "ERROR:  Wrong addr of ntp-wwv.nist.gov"
 
 gdb: a.out
 	gdb --args ./a.out localhost

--- a/contrib/mpi-proxy-split/lower-half/gethostbyname-static/gethostbyname_proxy.c
+++ b/contrib/mpi-proxy-split/lower-half/gethostbyname-static/gethostbyname_proxy.c
@@ -124,7 +124,7 @@ int do_getaddrinfo(const char *node, const char *service,
     struct sockaddr *ai_addr = (void *)(tmp + sizeof(*res));
     char *ai_canonname = (char *)ai_addr + res->ai_addrlen;
     char *end = (char *)ai_canonname +
-                (res->ai_canonname == NULL ? 0 : strlen(ai_canonname) + 1);
+                (res->ai_canonname == NULL ? 0 : strlen(res->ai_canonname) + 1);
     assert(end - addrinfo_result.padding < sizeof(addrinfo_result.padding));
     memcpy(ai_addr, res->ai_addr, res->ai_addrlen);
     if (res->ai_canonname != NULL) {


### PR DESCRIPTION
This is needed for MANA on CentOS, so that mana_launch/dmtcp_launch finds `gethostbyname_proxy`.

There are now three commits (used to be two).

1.  Look for gethostbyname_proxy in PATH environment.  This modifies `gethostbyname-static` directory, and I have tested that directory locally.  It now will find gethostbyname_proxy from ~/bin in PATH, even when `gethostbyname_proxy` has been deleted from the `gethostbyname-static` directory.  (I tested with `./a.out localhost` and `./a.out localhost time`.)

2. Add the DMTCP bin directory to the PATH environment.  It adds about 8 new lines of code to `split-process.cpp`.  I tested this commit in a local example inside DMTCP, but not in MANA.  I didn't have time to test this directly in MANA, and I won't have time for that any time soon.  As part of the review, please rebase feature/centos on top of this branch, and <br>&nbsp;&nbsp; *verify that `mana_launch` on CentOS now works in a new build*.

3.  Several bug fixes (This is a new commit, in response the review comments.)

@jungan and @fyshhh , I've now fixed the bugs from PR #27.  Thanks for the excellent comments.  Please review it again now.

@fyshhh , You said that `make -j mana` wasn't automatically compiling the gethostbyname_static directory.  In the interests of timeliness, let's review and push this in.  If you see how to force 'make' to compile the gethostbyname_static directory before me, please generate a PR for it.