### PR TITLE
[MANA-59] Implement dynamic memory region allocation for mtcp_restart.c

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -510,7 +510,8 @@ uint64_t vvarStartTmp = -1;
 uint64_t vdsoStartTmp = -1;
 
 // This function searches for a free memory region to temporarily remap the vdso
-// and vvar regions to, as these regions will be unmapped later on.
+// and vvar regions to, so that mtcp's vdso and vvar do not overlap with the
+// checkpointed process' vdso and vvar.
 static void
 remap_vdso_and_vvar_regions() {
   Area area;
@@ -537,8 +538,8 @@ remap_vdso_and_vvar_regions() {
     mtcp_abort();
   }
 
-  // We have to iterate through the memory map separately to ensure that
-  // temporary regions have been found before we remap.
+  // We have to iterate through the memory map twice, this time to ensure that
+  // free regions have been found for us to remap to.
   mapsfd = mtcp_sys_open2("/proc/self/maps", O_RDONLY);
   if (mapsfd < 0) {
     MTCP_PRINTF("error opening /proc/self/maps; errno: %d\n", mtcp_sys_errno);

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -67,7 +67,7 @@
 #define HUGEPAGES
 #define GNI
 
-/*TODO: @Illio, this macro is used for CentOS specific changes for now.
+/*TODO: This macro is used for CentOS specific changes for now.
  * Later, we want to merge the code that works both for CentOS and Cori. 
  */
 // if we define both GNI and CENTOS, assume we are running on CentOS
@@ -534,22 +534,6 @@ setupTempRegions() {
   }
 }
 
-#if 0
-#define PAGESIZE 4096 /* We hardwire this, since we can't make libc calls. */
-// We choose this address based on our observation on CORI that it won't overlap
-// with any other memory segments. We might change this address in the future,
-// for now, it doesn't matters.
-#define vvarStartTmp (0x40000 - 5*PAGESIZE)
-#define vdsoStartTmp (0x40000 - 2*PAGESIZE)
-/* @Illio, this is hardwired for now and seem to work. Can we figure out the
- * location dynamically? or can we use only one area that we are reserving for
- * LH anyway?
- *
- * As it turns out, any free region is fine, as long as it's PAGESIZE aligned
- * and greater than 0x10000.
- */
-#endif
-
 #define shift argv++; argc--;
 NO_OPTIMIZE
 int
@@ -678,23 +662,6 @@ main(int argc, char *argv[], char **environ)
     //   before vvar and after vdso, and verify that we get an EFAULT.
     // In May, 2020, on Cori and elsewhere, vvar is 3 pages and vdso is 2 pages.
     char *vdsoStart = (char *)mygetauxval(environ, AT_SYSINFO_EHDR);
-    /* @Illio
-     * Problem 1: the vvar location is Cori-specific and assumed to be 3 pages
-     *    lower than vDSO. However, on CentOS VM, we do not see any vvar section
-     *    at all on restart.
-     * Fix: There should not be any assumptions. We should be checking procmaps
-     *      to get the location of both vvar and vdso regions. And, move only if
-     *      they exist in procmaps. This code can be made generic.
-     * Problem 2: These mapped regions will be removed in
-     *    unmap_memory_areas_and_restore_vdso function as mtcp unmap all its
-     *    regions. And, we'll not be able to move it back to original program's
-     *    vdso region.
-     * What-we-do:
-     * 1. move mtcp's vdso and vvar regions temporarily at a temporary location
-     * 2. unmap all mtcp's memory regions
-     * 3. move from temp locations to ckpt'ed process' vdso vvar location.
-     * Fix: We should be bookeeping regions that we don't want MTCP to unmap 
-     */
     setupTempRegions();
     Area area;
     int mapsfd = mtcp_sys_open2("/proc/self/maps", O_RDONLY);
@@ -719,23 +686,6 @@ main(int argc, char *argv[], char **environ)
       }
     }
     mtcp_sys_close(mapsfd);
-
-#if 0
-    char *vvarStart = vdsoStart - 3 * PAGESIZE;
-//    void *rc1 = mtcp_sys_mremap(vvarStart, 3*PAGESIZE, 3*PAGESIZE,
-//		                MREMAP_FIXED | MREMAP_MAYMOVE, vvarStartTmp);
-    void *rc2 = mtcp_sys_mremap(vdsoStart, 2*PAGESIZE, 2*PAGESIZE,
-		                MREMAP_FIXED | MREMAP_MAYMOVE, vdsoStartTmp);
-    if (rc2 == MAP_FAILED) { // vdso segment can be one page or two pages.
-      rc2 = mtcp_sys_mremap(vdsoStart, 1*PAGESIZE, 1*PAGESIZE,
-		            MREMAP_FIXED | MREMAP_MAYMOVE, vdsoStartTmp);
-    }
-    void * rc1 = 0x0; // @Illio: this should go away in the final code
-    if (rc1 == MAP_FAILED || rc2 == MAP_FAILED) {
-      MTCP_PRINTF("mtcp_restart failed: "
-		  "gdb --mpi \"DMTCP_ROOT/bin/mtcp_restart\" to debug.\n");
-    }
-#endif
 
     // Now that we moved vdso/vvar, we need to update the vdso address
     //   in the auxv vector.  This will be needed when the lower half
@@ -830,13 +780,7 @@ main(int argc, char *argv[], char **environ)
 #endif
     typedef int (*getRankFptr_t)(void);
     int rank = -1;
-    /* FIXME: combine GNI load-unload for both centos and Cori
-    * 
-    * @Illio: Currently, the Gni driver is required only for cori. But, we want
-    *   to generalize this code. So, if on some platform, we need to do extra
-    *   stuff for their network driver or any other library. One can simply add
-    *   here.
-    * */
+    /* FIXME: combine GNI load-unload for both centos and Cori */
 #ifndef CENTOS
     beforeLoadingGniDriverBlockAddressRanges(start1, end1, start2, end2);
 #endif
@@ -1492,9 +1436,6 @@ unmap_memory_areas_and_restore_vdso(RestoreInfo *rinfo, LowerHalfInfo_t *lh_info
       DPRINTF("Skipping lower half memory section: %p-%p\n",
               area.addr, area.endAddr);
     } else if (area.addr == vdsoStartTmpCopy) {
-      // FIXME @Illio: we should replace this with the vDSO and vvar address.
-      // Or if we want to generalize then we can call a function that tells if
-      // the region should not be unmapped.
       DPRINTF("Skipping temporary vDSO section: %p-%p\n",
               area.addr, area.endAddr);
     } else if (area.addr == vvarStartTmpCopy) {

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -771,33 +771,13 @@ main(int argc, char *argv[], char **environ)
       //         mtcp_restart is statically linked, and doesn't need it.
       Area heap_area;
       MTCP_ASSERT(getMappedArea(&heap_area, "[heap]") == 1);
-      // FIXME:  choose higher of this
-      //           and lh_info.memRange.end; // 0x2aab00000000
       start1 = max(heap_area.endAddr, lh_info.memRange.end);
-      // FIXME:  choose lower of this and highMemStart
-      //        and make sure it doesn't intersect with lh_info.memRange
       Area stack_area;
       MTCP_ASSERT(getMappedArea(&stack_area, "[stack]") == 1);
       end1 = min(stack_area.endAddr - 4 * GB, highMemStart - 4 * GB);
-      // end1 = highMemStart - 4 * GB;
       start2 = 0;
       end2 = start2;
     }
-# if 0
-    // this is only here for Cori debugging - it will be deleted before this PR
-    // is merged in.
-    // ***** These constants are hardwired for Cori in May, 2020 *****
-    // *****   DELETE THIS WHEN NO LONGER NEEDED FOR DEBUGGING   *****
-    // The dynamic values of start1, end1 above are preferred to this.
-    void *start1 = (const void*)0x2aaaaaaaf000; // End of vdso
-    //  const void *end1 = (const void*)0x2aaaaaaf8000;
-    //  const size_t len1 = end1 - start1;
-    //  const void *start2 = (const void*)0x2aaaaab1b000; // Start of upper half
-    void *end1 = lh_info.memRange.start; //Start of lower half memory
-    size_t len1 = end1 - start1;
-    char *start2 = 0;
-    char *end2 = start2;
-#endif
     typedef int (*getRankFptr_t)(void);
     int rank = -1;
     reserveUpperHalfMemoryRegionsForCkptImgs(start1, end1, start2, end2);

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -566,7 +566,7 @@ remap_vdso_and_vvar_regions() {
   }
 
   if (vdsoStart > 0) {
-    if (vvarStartTmp == 0) {
+    if (vdsoStartTmp == 0) {
       MTCP_PRINTF("No free region found to temporarily map vvar/vdso to\n");
       mtcp_abort();
     }

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -553,7 +553,7 @@ remap_vdso_and_vvar_regions() {
 
   if (vvarStart > 0) {
     if (vvarStartTmp == 0) {
-      MTCP_PRINTF("No free region found to temporarily map vvar/vdso to\n");
+      MTCP_PRINTF("No free region found to temporarily map vvar to\n");
       mtcp_abort();
     }
     rc = mtcp_sys_mremap(vvarStart, vvarSize, vvarSize,
@@ -567,7 +567,7 @@ remap_vdso_and_vvar_regions() {
 
   if (vdsoStart > 0) {
     if (vdsoStartTmp == 0) {
-      MTCP_PRINTF("No free region found to temporarily map vvar/vdso to\n");
+      MTCP_PRINTF("No free region found to temporarily map vdso to\n");
       mtcp_abort();
     }
     rc = mtcp_sys_mremap(vdsoStart, vdsoSize, vdsoSize,

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -499,8 +499,10 @@ mysetauxval(char **evp, unsigned long int type, unsigned long int val)
 /* We hardwire these, since we can't make libc calls. */
 #define PAGESIZE 4096
 #define ROUNDADDRUP(addr, size) ((addr + size - 1) & ~(size - 1))
-// I think we're forced to use global variables, since
-// unmap_memory_areas_and_restore_vdso uses these variables subsequently.
+// We use global variables here, since both remap_vdso_and_vvar_regions and
+// unmap_memory_areas_and_restore_vdso use these variables. They're used to
+// track the temporary regions the vvar and vdso segments are remapped to, so
+// they are not unmapped later.
 uint64_t vvarStartTmp = 0;
 uint64_t vdsoStartTmp = 0;
 

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -503,7 +503,6 @@ mysetauxval(char **evp, unsigned long int type, unsigned long int val)
 
 /* We hardwire these, since we can't make libc calls. */
 #define PAGESIZE 4096
-#define WORKING
 #define ROUNDADDRUP(addr, size) ((addr + size - 1) & ~(size - 1))
 // I think we're forced to use global variables, since
 // unmap_memory_areas_and_restore_vdso uses these variables subsequently.
@@ -696,9 +695,7 @@ main(int argc, char *argv[], char **environ)
      * 3. move from temp locations to ckpt'ed process' vdso vvar location.
      * Fix: We should be bookeeping regions that we don't want MTCP to unmap 
      */
-#ifdef WORKING:
     setupTempRegions();
-#endif
     Area area;
     int mapsfd = mtcp_sys_open2("/proc/self/maps", O_RDONLY);
     if (mapsfd < 0) {

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -718,7 +718,6 @@ main(int argc, char *argv[], char **environ)
       if (mtcp_strcmp(area.name, "[vdso]") == 0) {
         rc = mtcp_sys_mremap(area.addr, area.size, area.size,
                              MREMAP_FIXED | MREMAP_MAYMOVE, vdsoStartTmp);
-	mtcp_printf("%p\n", vdsoStartTmp);
       }
       if (rc == MAP_FAILED) {
         MTCP_PRINTF("mtcp_restart failed: "

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -532,20 +532,20 @@ remap_vdso_and_vvar_regions() {
       vdsoSize = area.size;
     }
 
-    if (vvarStartTmp == 0) {
-      // In May 2020, on Cori and elsewhere, vvar is 3 pages and vdso is 2
-      // pages.
-      if (prev_addr + 5 * PAGESIZE <= area.addr) {
-        vvarStartTmp = prev_addr;
-        vdsoStartTmp = prev_addr + 3 * PAGESIZE;
-      } else {
-        prev_addr = ROUNDADDRUP((uint64_t) area.endAddr, PAGESIZE);
-      }
-    }
-
-    if (vvarStart > 0 && vdsoStart > 0 && vvarStartTmp > 0 && vdsoStartTmp > 0)
-    {
+    if (vvarStart > 0 && vdsoStart > 0) {
       break;
+    }
+  }
+
+  mtcp_sys_lseek(mapsfd, 0, SEEK_SET);
+
+  while (mtcp_readmapsline(mapsfd, &area)) {
+    if (prev_addr + vvarSize + vdsoSize <= area.addr) {
+      vvarStartTmp = prev_addr;
+      vdsoStartTmp = prev_addr + vvarSize;
+      break;
+    } else {
+      prev_addr = ROUNDADDRUP((uint64_t) area.endAddr, PAGESIZE);
     }
   }
 


### PR DESCRIPTION
This pull request enables `mana_restart` functionalities on CentOS. Notably, it dynamically determines whether there are vvar and vDSO segments that need to be temporarily remapped, and finds regions to map them to. This also removes some of the hard-coding done when reserving memory regions, as well as slightly changing the implementation of determining the regions to reserve.

This has been tested on both Cori and CentOS by running all the programs in `contrib/mpi-proxy-split/test` directories, and the results seen are the same as when running `mana_launch`. I also checked the addresses assigned for specific cases to ensure that all the code is necessary.

Eventually, we should seek to remove all uses of the `GNI` and `MANA_USE_LH_FIXED_ADDRESS` macros, but this is a good stopgap.