### PR TITLE
[MANA-58] Save lower-half BSS region information if the region exists

### DIFF
--- a/contrib/mpi-proxy-split/lower-half/lower_half_api.h
+++ b/contrib/mpi-proxy-split/lower-half/lower_half_api.h
@@ -72,6 +72,7 @@ typedef struct _LowerHalfInfo
   void *startText; // Start address of text segment (R-X) of lower half
   void *endText;   // End address of text segmeent (R-X) of lower half
   void *startData; // Start address of data segment (RW-) of lower half
+  void *startBSS; // Start address of BSS segment (RW-) of lower half
   void *endOfHeap; // Pointer to the end of heap segment of lower half
   void *libc_start_main; // Pointer to libc's __libc_start_main function in statically-linked lower half
   void *main;      // Pointer to the main() function in statically-linked lower half

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -1305,7 +1305,8 @@ skip_lh_memory_region_ckpting(const Area *area, LowerHalfInfo_t *lh_info)
       mtcp_strstr(area->name, "/dev/xpmem") ||
       mtcp_strstr(area->name, "/dev/shm") ||
       mtcp_strstr(area->name, "/SYS") ||
-      area->addr == lh_info->startData) {
+      area->addr == lh_info->startData ||
+      ((lh_info->startBSS != NULL) && area->addr == lh_info->startBSS)) {
     return 1;
   }
   if (!g_list) return 0;

--- a/src/mtcp/mtcp_split_process.h
+++ b/src/mtcp/mtcp_split_process.h
@@ -36,6 +36,7 @@ typedef struct LowerHalfInfo
   void *startText;
   void *endText;
   void *startData;
+  void *startBSS;
   void *endOfHeap;
   void *libc_start_main;
   void *main;


### PR DESCRIPTION
The current MANA code assumes that there's no BSS section for `lh_proxy` binary. However, this may not be true for all platforms. The restart will fail if MANA checkpoints on such a platform where the BSS region exists. Because we never saved this information and `mtcp_restart` will unmap this essential region of the lower half on restart.
The commit generalizes the code and works whether the BSS region exists or not.