### PR TITLE
Misc changes

### DIFF
--- a/contrib/mpi-proxy-split/.gitignore
+++ b/contrib/mpi-proxy-split/.gitignore
@@ -3,3 +3,4 @@ unit-test/*.exe
 proxy
 mpi-wrappers/*.c*
 mpi-wrappers/*.so*
+Makefile_config

--- a/contrib/mpi-proxy-split/lower-half/.gitignore
+++ b/contrib/mpi-proxy-split/lower-half/.gitignore
@@ -1,0 +1,1 @@
+lh_proxy

--- a/contrib/mpi-proxy-split/lower-half/gethostbyname-static/.gitignore
+++ b/contrib/mpi-proxy-split/lower-half/gethostbyname-static/.gitignore
@@ -1,0 +1,1 @@
+gethostbyname_proxy

--- a/contrib/mpi-proxy-split/lower-half/shm_internal.h
+++ b/contrib/mpi-proxy-split/lower-half/shm_internal.h
@@ -38,7 +38,7 @@ extern void* __real_shmat(int shmid, const void *shmaddr, int shmflg);
 extern int __real_shmget(key_t key, size_t size, int shmflg);
 
 extern int getShmIdx(int shmid);
-extern int addShm(int shmid, size_t size);
+extern void addShm(int shmid, size_t size);
 
 // FIXME: Make this dynamic
 #define MAX_SHM_TRACK 20

--- a/contrib/mpi-proxy-split/lower-half/shmget.c
+++ b/contrib/mpi-proxy-split/lower-half/shmget.c
@@ -38,7 +38,7 @@ getShmIdx(int shmid)
   return -1;
 }
 
-int
+void
 addShm(int shmid, size_t size)
 {
   shms[shmidx].shmid = shmid;

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
@@ -58,7 +58,7 @@ USER_DEFINED_WRAPPER(int, Cart_create, (MPI_Comm) old_comm, (int) ndims,
   retval = NEXT_FUNC(Cart_create)(realComm, ndims, dims,
                                   periods, reorder, comm_cart);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Comm virtComm = ADD_NEW_COMM(*comm_cart);
     VirtualGlobalCommId::instance().createGlobalId(virtComm);
     *comm_cart = virtComm;
@@ -95,7 +95,7 @@ USER_DEFINED_WRAPPER(int, Cart_map, (MPI_Comm) comm, (int) ndims,
   // FIXME: Need to virtualize this newrank??
   retval = NEXT_FUNC(Cart_map)(realComm, ndims, dims, periods, newrank);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     FncArg ds = CREATE_LOG_BUF(dims, ndims * sizeof(int));
     FncArg ps = CREATE_LOG_BUF(periods, ndims * sizeof(int));
     LOG_CALL(restoreCarts, Cart_map, comm, ndims, ds, ps, newrank);
@@ -127,7 +127,7 @@ USER_DEFINED_WRAPPER(int, Cart_shift, (MPI_Comm) comm, (int) direction,
   retval = NEXT_FUNC(Cart_shift)(realComm, direction,
                                  disp, rank_source, rank_dest);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     LOG_CALL(restoreCarts, Cart_shift, comm, direction,
              disp, rank_source, rank_dest);
   }
@@ -145,7 +145,7 @@ USER_DEFINED_WRAPPER(int, Cart_sub, (MPI_Comm) comm,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Cart_sub)(realComm, remain_dims, new_comm);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     int ndims = 0;
     MPI_Cartdim_get(comm, &ndims);
     MPI_Comm virtComm = ADD_NEW_COMM(*new_comm);

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -103,7 +103,7 @@ USER_DEFINED_WRAPPER(int, Ibcast,
   retval = NEXT_FUNC(Ibcast)(buffer, count, realType,
       root, realComm, request);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Request virtRequest = ADD_NEW_REQUEST(*request);
     *request = virtRequest;
     LOG_CALL(restoreRequests, Ibcast, buffer, count, datatype,
@@ -159,7 +159,7 @@ USER_DEFINED_WRAPPER(int, Ibarrier, (MPI_Comm) comm, (MPI_Request *) request)
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Ibarrier)(realComm, request);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Request virtRequest = ADD_NEW_REQUEST(*request);
     *request = virtRequest;
     LOG_CALL(restoreRequests, Ibarrier, comm, *request);
@@ -233,7 +233,7 @@ USER_DEFINED_WRAPPER(int, Ireduce,
   retval = NEXT_FUNC(Ireduce)(sendbuf, recvbuf, count,
       realType, realOp, root, realComm, request);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Request virtRequest = ADD_NEW_REQUEST(*request);
     *request = virtRequest;
     LOG_CALL(restoreRequests, Ireduce, sendbuf, recvbuf,
@@ -481,7 +481,7 @@ USER_DEFINED_WRAPPER(int, Comm_split, (MPI_Comm) comm, (int) color, (int) key,
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Comm_split)(realComm, color, key, newcomm);
     RETURN_TO_UPPER_HALF();
-    if (retval == MPI_SUCCESS && LOGGING()) {
+    if (retval == MPI_SUCCESS && MPI_LOGGING()) {
       MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
       VirtualGlobalCommId::instance().createGlobalId(virtComm);
       *newcomm = virtComm;
@@ -503,7 +503,7 @@ USER_DEFINED_WRAPPER(int, Comm_dup, (MPI_Comm) comm, (MPI_Comm *) newcomm)
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Comm_dup)(realComm, newcomm);
     RETURN_TO_UPPER_HALF();
-    if (retval == MPI_SUCCESS && LOGGING()) {
+    if (retval == MPI_SUCCESS && MPI_LOGGING()) {
       MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
       VirtualGlobalCommId::instance().createGlobalId(virtComm);
       *newcomm = virtComm;

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
@@ -70,7 +70,7 @@ USER_DEFINED_WRAPPER(int, Comm_create, (MPI_Comm) comm, (MPI_Group) group,
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Comm_create)(realComm, realGroup, newcomm);
     RETURN_TO_UPPER_HALF();
-    if (retval == MPI_SUCCESS && LOGGING()) {
+    if (retval == MPI_SUCCESS && MPI_LOGGING()) {
       MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
       VirtualGlobalCommId::instance().createGlobalId(virtComm);
       *newcomm = virtComm;
@@ -124,7 +124,7 @@ USER_DEFINED_WRAPPER(int, Comm_free, (MPI_Comm *) comm)
 {
   DMTCP_PLUGIN_DISABLE_CKPT();
   int retval = MPI_Comm_free_internal(comm);
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     // NOTE: We cannot remove the old comm from the map, since
     // we'll need to replay this call to reconstruct any other comms that
     // might have been created using this comm.
@@ -147,7 +147,7 @@ USER_DEFINED_WRAPPER(int, Comm_set_errhandler,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Comm_set_errhandler)(realComm, errhandler);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     LOG_CALL(restoreComms, Comm_set_errhandler, comm, errhandler);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
@@ -176,7 +176,7 @@ USER_DEFINED_WRAPPER(int, Comm_split_type, (MPI_Comm) comm, (int) split_type,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Comm_split_type)(realComm, split_type, key, inf, newcomm);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
     VirtualGlobalCommId::instance().createGlobalId(virtComm);
     *newcomm = virtComm;
@@ -211,7 +211,7 @@ USER_DEFINED_WRAPPER(int, Attr_delete, (MPI_Comm) comm, (int) keyval)
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Attr_delete)(realComm, realCommKeyval);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     LOG_CALL(restoreComms, Attr_delete, comm, keyval);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
@@ -228,7 +228,7 @@ USER_DEFINED_WRAPPER(int, Attr_put, (MPI_Comm) comm,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Attr_put)(realComm, realCommKeyval, attribute_val);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     LOG_CALL(restoreComms, Attr_put, comm, keyval, attribute_val);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
@@ -247,7 +247,7 @@ USER_DEFINED_WRAPPER(int, Comm_create_keyval,
                                          comm_delete_attr_fn,
                                          comm_keyval, extra_state);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     int virtCommKeyval = ADD_NEW_COMM_KEYVAL(*comm_keyval);
     *comm_keyval = virtCommKeyval;
     LOG_CALL(restoreComms, Comm_create_keyval,
@@ -266,7 +266,7 @@ USER_DEFINED_WRAPPER(int, Comm_free_keyval, (int *) comm_keyval)
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Comm_free_keyval)(&realCommKeyval);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     // NOTE: We cannot remove the old comm_keyval from the map, since
     // we'll need to replay this call to reconstruct any other comms that
     // might have been created using this comm_keyval.
@@ -296,7 +296,7 @@ USER_DEFINED_WRAPPER(int, Comm_create_group, (MPI_Comm) comm,
 {
   std::function<int()> realBarrierCb = [=]() {
     int retval = MPI_Comm_create_group_internal(comm, group, tag, newcomm);
-    if (retval == MPI_SUCCESS && LOGGING()) {
+    if (retval == MPI_SUCCESS && MPI_LOGGING()) {
       MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
       VirtualGlobalCommId::instance().createGlobalId(virtComm);
       *newcomm = virtComm;

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
@@ -41,7 +41,7 @@ USER_DEFINED_WRAPPER(int, Comm_group, (MPI_Comm) comm, (MPI_Group *) group)
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Comm_group)(realComm, group);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Group virtGroup = ADD_NEW_GROUP(*group);
     *group = virtGroup;
     LOG_CALL(restoreGroups, Comm_group, comm, *group);
@@ -77,7 +77,7 @@ USER_DEFINED_WRAPPER(int, Group_free, (MPI_Group *) group)
 {
   DMTCP_PLUGIN_DISABLE_CKPT();
   int retval = MPI_Group_free_internal(group);
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     // NOTE: We cannot remove the old group, since we'll need
     // to replay this call to reconstruct any comms that might
     // have been created using this group.
@@ -125,7 +125,7 @@ USER_DEFINED_WRAPPER(int, Group_incl, (MPI_Group) group, (int) n,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Group_incl)(realGroup, n, ranks, newgroup);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Group virtGroup = ADD_NEW_GROUP(*newgroup);
     *newgroup = virtGroup;
     FncArg rs = CREATE_LOG_BUF(ranks, n * sizeof(int));

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
@@ -42,7 +42,7 @@ USER_DEFINED_WRAPPER(int, Op_create,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Op_create)(user_fn, commute, op);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Op virtOp = ADD_NEW_OP(*op);
     *op = virtOp;
     LOG_CALL(restoreOps, Op_create, user_fn, commute, virtOp);
@@ -62,7 +62,7 @@ USER_DEFINED_WRAPPER(int, Op_free, (MPI_Op*) op)
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Op_free)(&realOp);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     // NOTE: We cannot remove the old op, since we'll need
     // to replay this call to reconstruct any new op that might
     // have been created using this op.

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -97,7 +97,7 @@ USER_DEFINED_WRAPPER(int, Test, (MPI_Request*) request,
     fflush(stdout);
 #endif
   }
-  if (retval == MPI_SUCCESS && *flag && LOGGING()) {
+  if (retval == MPI_SUCCESS && *flag && MPI_LOGGING()) {
     clearPendingRequestFromLog(*request);
     REMOVE_OLD_REQUEST(*request);
     *request = MPI_REQUEST_NULL;
@@ -206,7 +206,7 @@ USER_DEFINED_WRAPPER(int, Wait, (MPI_Request*) request, (MPI_Status*) status)
       fflush(stdout);
 #endif
     }
-    if (flag && LOGGING()) {
+    if (flag && MPI_LOGGING()) {
       clearPendingRequestFromLog(*request);
       REMOVE_OLD_REQUEST(*request);
       *request = MPI_REQUEST_NULL;

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
@@ -52,7 +52,7 @@ USER_DEFINED_WRAPPER(int, Type_free, (MPI_Datatype *) type)
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Type_free)(&realType);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     // NOTE: We cannot remove the old type, since we'll need
     // to replay this call to reconstruct any new type that might
     // have been created using this type.
@@ -75,7 +75,7 @@ USER_DEFINED_WRAPPER(int, Type_commit, (MPI_Datatype *) type)
   if (retval != MPI_SUCCESS) {
     realType = REMOVE_OLD_TYPE(*type);
   } else {
-    if (LOGGING()) {
+    if (MPI_LOGGING()) {
       LOG_CALL(restoreTypes, Type_commit, *type);
     }
   }
@@ -92,7 +92,7 @@ USER_DEFINED_WRAPPER(int, Type_contiguous, (int) count, (MPI_Datatype) oldtype,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Type_contiguous)(count, realType, newtype);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Datatype virtType = ADD_NEW_TYPE(*newtype);
     *newtype = virtType;
     LOG_CALL(restoreTypes, Type_contiguous, count, oldtype, virtType);
@@ -112,7 +112,7 @@ USER_DEFINED_WRAPPER(int, Type_vector, (int) count, (int) blocklength,
   retval = NEXT_FUNC(Type_vector)(count, blocklength,
                                   stride, realType, newtype);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Datatype virtType = ADD_NEW_TYPE(*newtype);
     *newtype = virtType;
     LOG_CALL(restoreTypes, Type_vector, count, blocklength,
@@ -145,7 +145,7 @@ USER_DEFINED_WRAPPER(int, Type_create_struct, (int) count,
                                    array_of_displacements,
                                    realTypes, newtype);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Datatype virtType = ADD_NEW_TYPE(*newtype);
     *newtype = virtType;
     FncArg bs = CREATE_LOG_BUF(array_of_blocklengths, count * sizeof(int));
@@ -170,7 +170,7 @@ USER_DEFINED_WRAPPER(int, Type_indexed, (int) count,
                                    array_of_displacements,
                                    realType, newtype);
   RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Datatype virtType = ADD_NEW_TYPE(*newtype);
     *newtype = virtType;
     FncArg bs = CREATE_LOG_BUF(array_of_blocklengths, count * sizeof(int));

--- a/contrib/mpi-proxy-split/record-replay.h
+++ b/contrib/mpi-proxy-split/record-replay.h
@@ -59,7 +59,8 @@
 // Returns true if we are currently replaying the MPI calls from the saved MPI
 // calls log; false, otherwise. Normally, this would be true while restoring
 // the MPI state at restart time. All other times, this would return false.
-#define LOGGING() \
+// We cannot use LOGGING since it's used for enabling JTRACE
+#define MPI_LOGGING() \
   dmtcp_mpi::MpiRecordReplay::instance().isReplayOn()
 
 // Calls the wrapper function corresponding to the given type 'type'. (The

--- a/contrib/mpi-proxy-split/two-phase-algo.cpp
+++ b/contrib/mpi-proxy-split/two-phase-algo.cpp
@@ -95,11 +95,11 @@ int
 TwoPhaseAlgo::commit(MPI_Comm comm, const char *collectiveFnc,
                      std::function<int(void)>doRealCollectiveComm)
 {
-  if (!LOGGING() || comm == MPI_COMM_NULL) {
+  if (!MPI_LOGGING() || comm == MPI_COMM_NULL) {
     return doRealCollectiveComm(); // lambda function: already captured args
   }
 
-  if (!LOGGING()) {
+  if (!MPI_LOGGING()) {
     return doRealCollectiveComm();
   }
 

--- a/include/dmtcp_dlsym.h
+++ b/include/dmtcp_dlsym.h
@@ -40,9 +40,10 @@ EXTERNC void *dmtcp_dlvsym(void *handle, char *symbol, const char *version);
 EXTERNC void *dmtcp_dlsym_lib(const char *libname, const char *symbol);
 /*
  * Returns the offset of the given function within the given shared library
- * or -1 if the function does not exist in the library
+ * or LIB_FNC_OFFSET_FAILED if the function does not exist in the library
  */
-EXTERNC ptrdiff_t dmtcp_dlsym_lib_fnc_offset(const char *libname,
+#define LIB_FNC_OFFSET_FAILED ((uint64_t)-1)
+EXTERNC uint64_t dmtcp_dlsym_lib_fnc_offset(const char *libname,
                                              const char *symbol);
 
 #ifndef STANDALONE

--- a/include/virtualidtable.h
+++ b/include/virtualidtable.h
@@ -213,7 +213,7 @@ class VirtualIdTable
 	// to access _virTableMpiGroup in GDB.
 	// We need a cleaner way to access it.
 	string ss = out.str();
-	printf("Virtual To Real Mappings:\n_idMapTable.size(): %d\n%s\n",
+	printf("Virtual To Real Mappings:\n_idMapTable.size(): %zu\n%s\n",
 	       _idMapTable.size(), ss.c_str());
       }
     }

--- a/src/dmtcp_dlsym.cpp
+++ b/src/dmtcp_dlsym.cpp
@@ -605,13 +605,13 @@ dmtcp_dlsym_lib(const char *libname, const char *symbol)
 
 /*
  * Returns the offset of the given function within the given shared library
- * or -1 if the function does not exist in the library
+ * or LIB_FNC_OFFSET_FAILED if the function does not exist in the library
  */
-EXTERNC ptrdiff_t
+EXTERNC uint64_t
 dmtcp_dlsym_lib_fnc_offset(const char *libname, const char *symbol)
 {
   dt_tag tags;
-  ptrdiff_t ret = -1;
+  uint64_t ret = LIB_FNC_OFFSET_FAILED;
   Elf32_Word default_symbol_index = 0;
 
   // Determine where this function will return

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -150,15 +150,15 @@ class RestoreTarget
       .Text("checkpoint file missing");
 
       _fd = readCkptHeader(_path, &_pInfo);
-      ptrdiff_t clock_gettime_offset =
+      uint64_t clock_gettime_offset =
                             dmtcp_dlsym_lib_fnc_offset("linux-vdso",
                                                        "__vdso_clock_gettime");
-      ptrdiff_t getcpu_offset = dmtcp_dlsym_lib_fnc_offset("linux-vdso",
+      uint64_t getcpu_offset = dmtcp_dlsym_lib_fnc_offset("linux-vdso",
                                                            "__vdso_getcpu");
-      ptrdiff_t gettimeofday_offset =
+      uint64_t gettimeofday_offset =
                               dmtcp_dlsym_lib_fnc_offset("linux-vdso",
                                                          "__vdso_gettimeofday");
-      ptrdiff_t time_offset = dmtcp_dlsym_lib_fnc_offset("linux-vdso",
+      uint64_t time_offset = dmtcp_dlsym_lib_fnc_offset("linux-vdso",
                                                          "__vdso_time");
       JWARNING(!_pInfo.vdsoOffsetMismatch(clock_gettime_offset, getcpu_offset,
                                           gettimeofday_offset, time_offset))

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -258,7 +258,6 @@ int reserve_fds_upper_half(int *reserved_fds) {
 }
 
 void unreserve_fds_upper_half(int *reserved_fds, int total_reserved_fds) {
-  int tmp_fd = 0;
     while (--total_reserved_fds >= 0) {
       MTCP_ASSERT((mtcp_sys_close(reserved_fds[total_reserved_fds])) != -1);  
     }

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -757,8 +757,8 @@ ProcessInfo::refreshChildTable()
 }
 
 bool
-ProcessInfo::vdsoOffsetMismatch(ptrdiff_t f1, ptrdiff_t f2,
-                                ptrdiff_t f3, ptrdiff_t f4)
+ProcessInfo::vdsoOffsetMismatch(uint64_t f1, uint64_t f2,
+                                uint64_t f3, uint64_t f4)
 {
   return (f1 != _clock_gettime_offset) || (f2 != _getcpu_offset) ||
          (f3 != _gettimeofday_offset) || (f4 != _time_offset);

--- a/src/processinfo.h
+++ b/src/processinfo.h
@@ -149,8 +149,8 @@ class ProcessInfo
 
     uint64_t endOfStack(void) const { return _endOfStack; }
 
-    bool vdsoOffsetMismatch(ptrdiff_t f1, ptrdiff_t f2,
-                            ptrdiff_t f3, ptrdiff_t f4);
+    bool vdsoOffsetMismatch(uint64_t f1, uint64_t f2,
+                            uint64_t f3, uint64_t f4);
 
     string getCkptFilename() const { return _ckptFileName; }
 

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -324,7 +324,7 @@ prepareMtcpHeaderInfoForMPI(MtcpHeader *mtcpHdr)
     while (1) {
       int rc = read(fd, buf, 1);
       if (rc == 1) break;
-      JASSERT(rc == -1 && errno == EAGAIN || rc == -1 && errno == EINTR);
+      JASSERT(rc == -1 && (errno == EAGAIN || errno == EINTR));
     }
   }
   if (*buf != '0') {

--- a/util/memory_access_tracker/memory_access_tracker.h
+++ b/util/memory_access_tracker/memory_access_tracker.h
@@ -21,6 +21,10 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct MemTracker {
   /* TODO: support multiple trackers */
   // struct list_head node;
@@ -38,4 +42,7 @@ struct MemTracker* StartTrackMemory(void *addr, size_t len, uint32_t max_num, in
 void EndTrackMemory(struct MemTracker *tracker);
 void FreeMemTracker(struct MemTracker *tracker);
 
+#ifdef __cplusplus
+}
+#endif
 #endif


### PR DESCRIPTION
This PR does:
1. Make the "memory access tool" can be used in C++
2. Fix all the warnings, no warnings now.
3. Use MPI_LOGGING instead of LOGGING to avoid conflict