### PR TITLE
[MANA-73] Fix Makefile behavior to copy gethostbyname_proxy to bin

### DIFF
--- a/contrib/mpi-proxy-split/Makefile
+++ b/contrib/mpi-proxy-split/Makefile
@@ -98,6 +98,8 @@ ${DMTCP_ROOT}/lib/dmtcp/libmpidummy.so:
 	make -C ${WRAPPERS_SRCDIR} install
 ${DMTCP_ROOT}/bin/lh_proxy:
 	make -C ${LOWER_HALF_SRCDIR} install
+${DMTCP_ROOT}/bin/gethostbyname_proxy:
+	make -C ${LOWER_HALF_SRCDIR}/gethostbyname-static install
 
 # ${WRAPPERS_SRCDIR}/libmpiwrappers.a ia a prerequisite for libmana.so,
 #   which is a prerequisite for ${DMTCP_ROOT}/lib/dmtcp/libmana.so
@@ -108,6 +110,7 @@ install: ${MANA_COORD_OBJS}
 	make ${DMTCP_ROOT}/lib/dmtcp/libmana.so
 	make ${DMTCP_ROOT}/lib/dmtcp/libmpidummy.so
 	make ${DMTCP_ROOT}/bin/lh_proxy
+	make ${DMTCP_ROOT}/bin/gethostbyname_proxy
 
 tidy:
 	rm -f *~ .*.swp dmtcp_restart_script*.sh ckpt_*.dmtcp

--- a/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
+++ b/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
@@ -23,3 +23,8 @@ clean:
 dist: clean
 	dir=`basename $$PWD` && cd .. && tar zcvf ./$$dir.tar.gz ./$$dir
 	dir=`basename $$PWD` && ls -l ../$$dir.tar.gz
+
+install:
+	make gethostbyname_proxy
+	cp gethostbyname_proxy -f ../../../../bin
+


### PR DESCRIPTION
The current implementation does not copy `gethostbyname_proxy` to the `bin` directory as it's part of the `lh_proxy` rule, so if `lh_proxy` is found in the `bin` directory, then `gethostbyname_proxy` will not be copied out. This can be fixed by simply forcing a `gethostbyname_proxy` check.