### PR TITLE
[MANA-73] Fix make install not installing certain binaries

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -354,6 +354,11 @@ install: all create-dirs
 	cd plugin && make DESTDIR=$(DESTDIR) $(INSTALL_FLAGS)
 	cd contrib && make DESTDIR=$(DESTDIR) $(INSTALL_FLAGS)
 	cd manpages && make ${INSTALL_FLAGS}
+	cp ${targetdir}/bin/mana_launch $(DESTDIR)$(bindir)
+	cp ${targetdir}/bin/mana_restart $(DESTDIR)$(bindir)
+	cp ${targetdir}/bin/mana_coordinator $(DESTDIR)$(bindir)
+	cp ${targetdir}/bin/mana_start_coordinator $(DESTDIR)$(bindir)
+	cp ${targetdir}/bin/mana_status $(DESTDIR)$(bindir) 
 ifeq ($(M32),0)
 	${INSTALL_DATA} $(top_srcdir)/QUICK-START.md $(DESTDIR)$(docdir)
 	${INSTALL_DATA} $(top_srcdir)/COPYING $(DESTDIR)$(docdir)
@@ -368,6 +373,11 @@ uninstall:
 	cd src && make DESTDIR=$(DESTDIR) $(UNINSTALL_FLAGS)
 	cd plugin && make DESTDIR=$(DESTDIR) $(UNINSTALL_FLAGS)
 	cd contrib && make DESTDIR=$(DESTDIR) $(UNINSTALL_FLAGS)
+	cd $(DESTDIR)$(bindir) && rm mana_launch
+	cd $(DESTDIR)$(bindir) && rm mana_restart
+	cd $(DESTDIR)$(bindir) && rm mana_coordinator
+	cd $(DESTDIR)$(bindir) && rm mana_start_coordinator
+	cd $(DESTDIR)$(bindir) && rm mana_status
 ifeq ($(M32),0)
 	rm -Rf "$(DESTDIR)$(docdir)"
 	cd $(DESTDIR)$(mandir)/man1 && rm -f ${MANPAGES} ${MANPAGES_AUTOGEN}

--- a/Makefile.in
+++ b/Makefile.in
@@ -354,11 +354,11 @@ install: all create-dirs
 	cd plugin && make DESTDIR=$(DESTDIR) $(INSTALL_FLAGS)
 	cd contrib && make DESTDIR=$(DESTDIR) $(INSTALL_FLAGS)
 	cd manpages && make ${INSTALL_FLAGS}
-	cp ${targetdir}/bin/mana_launch $(DESTDIR)$(bindir)
-	cp ${targetdir}/bin/mana_restart $(DESTDIR)$(bindir)
-	cp ${targetdir}/bin/mana_coordinator $(DESTDIR)$(bindir)
-	cp ${targetdir}/bin/mana_start_coordinator $(DESTDIR)$(bindir)
-	cp ${targetdir}/bin/mana_status $(DESTDIR)$(bindir) 
+	install ${targetdir}/bin/mana_launch $(DESTDIR)$(bindir)
+	install ${targetdir}/bin/mana_restart $(DESTDIR)$(bindir)
+	install ${targetdir}/bin/mana_coordinator $(DESTDIR)$(bindir)
+	install ${targetdir}/bin/mana_start_coordinator $(DESTDIR)$(bindir)
+	install ${targetdir}/bin/mana_status $(DESTDIR)$(bindir) 
 ifeq ($(M32),0)
 	${INSTALL_DATA} $(top_srcdir)/QUICK-START.md $(DESTDIR)$(docdir)
 	${INSTALL_DATA} $(top_srcdir)/COPYING $(DESTDIR)$(docdir)
@@ -373,11 +373,11 @@ uninstall:
 	cd src && make DESTDIR=$(DESTDIR) $(UNINSTALL_FLAGS)
 	cd plugin && make DESTDIR=$(DESTDIR) $(UNINSTALL_FLAGS)
 	cd contrib && make DESTDIR=$(DESTDIR) $(UNINSTALL_FLAGS)
-	cd $(DESTDIR)$(bindir) && rm mana_launch
-	cd $(DESTDIR)$(bindir) && rm mana_restart
-	cd $(DESTDIR)$(bindir) && rm mana_coordinator
-	cd $(DESTDIR)$(bindir) && rm mana_start_coordinator
-	cd $(DESTDIR)$(bindir) && rm mana_status
+	rm -f $(DESTDIR)$(bindir)/mana_launch
+	rm -f $(DESTDIR)$(bindir)/mana_restart
+	rm -f $(DESTDIR)$(bindir)/mana_coordinator
+	rm -f $(DESTDIR)$(bindir)/mana_start_coordinator
+	rm -f $(DESTDIR)$(bindir)/mana_status
 ifeq ($(M32),0)
 	rm -Rf "$(DESTDIR)$(docdir)"
 	cd $(DESTDIR)$(mandir)/man1 && rm -f ${MANPAGES} ${MANPAGES_AUTOGEN}

--- a/Makefile.in
+++ b/Makefile.in
@@ -75,7 +75,7 @@ mana: mana_prereqs
 	$(MAKE) mana_part2
 mana_part2: default \
 	bin/mana_launch bin/mana_restart bin/mana_coordinator bin/mana_status
-	cd contrib/mpi-proxy-split && make install && make -j tests
+	cd contrib/mpi-proxy-split && make mana && make -j tests
 
 ${targetdir}/bin/mana_launch: src/mana_launch.sh
 	cp src/mana_launch.sh ${targetdir}/bin/mana_launch

--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -74,6 +74,7 @@ install: all
 	test -e $(DESTDIR)$(libdir) || $(MKDIR_P) $(DESTDIR)$(libdir)
 	test -e $(DESTDIR)$(includedir) || $(MKDIR_P) $(DESTDIR)$(includedir)
 	for p in $(plugins); do (cd $$p && $(MAKE) install); done
+	cd mpi-proxy-split && $(MAKE) install DESTDIR=$(bindir)
 
 uninstall:
 	for p in $(plugins); do (cd $$p && $(MAKE) uninstall); done

--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -12,6 +12,7 @@ exec_prefix=@exec_prefix@
 datarootdir=@datarootdir@
 bindir=@bindir@
 libdir=@libdir@
+pkglibdir = @libdir@/@PACKAGE@
 docdir=@docdir@
 includedir=@includedir@
 mandir=@mandir@
@@ -74,7 +75,8 @@ install: all
 	test -e $(DESTDIR)$(libdir) || $(MKDIR_P) $(DESTDIR)$(libdir)
 	test -e $(DESTDIR)$(includedir) || $(MKDIR_P) $(DESTDIR)$(includedir)
 	for p in $(plugins); do (cd $$p && $(MAKE) install); done
-	cd mpi-proxy-split && $(MAKE) install DESTDIR=$(bindir)
+	cd mpi-proxy-split && $(MAKE) install BINDIR=$(DESTDIR)$(bindir) \
+		PKGLIBDIR=$(DESTDIR)$(pkglibdir)
 
 uninstall:
 	for p in $(plugins); do (cd $$p && $(MAKE) uninstall); done

--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -76,11 +76,12 @@ install: all
 	test -e $(DESTDIR)$(includedir) || $(MKDIR_P) $(DESTDIR)$(includedir)
 	for p in $(plugins); do (cd $$p && $(MAKE) install); done
 	cd mpi-proxy-split && $(MAKE) install BINDIR=$(DESTDIR)$(bindir) \
-		PKGLIBDIR=$(DESTDIR)$(pkglibdir)
+	  PKGLIBDIR=$(DESTDIR)$(pkglibdir)
 
 uninstall:
 	for p in $(plugins); do (cd $$p && $(MAKE) uninstall); done
-	cd mpi-proxy-split && $(MAKE) uninstall DESTDIR=$(bindir)
+	cd mpi-proxy-split && $(MAKE) uninstall BINDIR=$(DESTDIR)$(bindir) \
+	  PKGLIBDIR=$(DESTDIR)$(pkglibdir)
 
 uninstall-libs:
 	for p in $(plugins); do (cd $$p && $(MAKE) uninstall-libs); done

--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -78,6 +78,7 @@ install: all
 
 uninstall:
 	for p in $(plugins); do (cd $$p && $(MAKE) uninstall); done
+	cd mpi-proxy-split && $(MAKE) uninstall DESTDIR=$(bindir)
 
 uninstall-libs:
 	for p in $(plugins); do (cd $$p && $(MAKE) uninstall-libs); done

--- a/contrib/mpi-proxy-split/Makefile
+++ b/contrib/mpi-proxy-split/Makefile
@@ -50,7 +50,7 @@ override CXXFLAGS += -fPIC -I${DMTCP_INCLUDE} -I${JALIB_INCLUDE} \
                      -I${DMTCP_ROOT}/src -I${LOWER_HALF_SRCDIR} -std=c++11
 
 # ${WRAPPERS_SRCDIR}/libmpiwrappers.a ia a prerequisite for libmana.so
-# Always do 'make default' or 'make install' -- not 'make libmana.so'
+# Always do 'make default' or 'make mana' -- not 'make libmana.so'
 default: ${MANA_COORD_OBJS}
 	make -C ${WRAPPERS_SRCDIR} libmpiwrappers.a
 	@make libmana.so
@@ -95,17 +95,17 @@ check-unit: libmana.so
 ${DMTCP_ROOT}/lib/dmtcp/libmana.so: libmana.so
 	cp -f $< $@
 ${DMTCP_ROOT}/lib/dmtcp/libmpidummy.so:
-	make -C ${WRAPPERS_SRCDIR} install
+	make -C ${WRAPPERS_SRCDIR} mana 
 ${DMTCP_ROOT}/bin/lh_proxy:
-	make -C ${LOWER_HALF_SRCDIR} install
+	make -C ${LOWER_HALF_SRCDIR} mana
 ${DMTCP_ROOT}/bin/gethostbyname_proxy:
-	make -C ${LOWER_HALF_SRCDIR}/gethostbyname-static install
+	make -C ${LOWER_HALF_SRCDIR}/gethostbyname-static mana
 
 # ${WRAPPERS_SRCDIR}/libmpiwrappers.a ia a prerequisite for libmana.so,
 #   which is a prerequisite for ${DMTCP_ROOT}/lib/dmtcp/libmana.so
-# Always do 'make default' or 'make install' -- not 'make libmana.so'
+# Always do 'make default' or 'make mana' -- not 'make libmana.so'
 # MANA_COORD_OBJS needed for 'make mana' at top level.
-install: ${MANA_COORD_OBJS}
+mana: ${MANA_COORD_OBJS}
 	make -C ${WRAPPERS_SRCDIR} libmpiwrappers.a
 	make ${DMTCP_ROOT}/lib/dmtcp/libmana.so
 	make ${DMTCP_ROOT}/lib/dmtcp/libmpidummy.so
@@ -132,4 +132,4 @@ dist: distclean
 	dir=`basename $$PWD` && ls -l ../$$dir.tgz
 
 .PHONY: default clean dist distclean vi vim touch gdb tidy check \
-        tests check-unit install
+        tests check-unit mana 

--- a/contrib/mpi-proxy-split/Makefile
+++ b/contrib/mpi-proxy-split/Makefile
@@ -93,13 +93,10 @@ check-unit: libmana.so
 	@make -C unit-test/ check
 
 ${DMTCP_ROOT}/lib/dmtcp/libmana.so: libmana.so
-	cp -f $< $@
-${DMTCP_ROOT}/lib/dmtcp/libmpidummy.so:
-	make -C ${WRAPPERS_SRCDIR} mana 
-${DMTCP_ROOT}/bin/lh_proxy:
-	make -C ${LOWER_HALF_SRCDIR} mana
-${DMTCP_ROOT}/bin/gethostbyname_proxy:
-	make -C ${LOWER_HALF_SRCDIR}/gethostbyname-static mana
+	install $< $@
+libmpidummy.so=-C ${WRAPPERS_SRCDIR}
+lh_proxy=-C ${LOWER_HALF_SRCDIR}
+gethostbyname_proxy=-C ${LOWER_HALF_SRCDIR}/gethostbyname-static
 
 # ${WRAPPERS_SRCDIR}/libmpiwrappers.a ia a prerequisite for libmana.so,
 #   which is a prerequisite for ${DMTCP_ROOT}/lib/dmtcp/libmana.so
@@ -108,17 +105,21 @@ ${DMTCP_ROOT}/bin/gethostbyname_proxy:
 mana: ${MANA_COORD_OBJS}
 	make -C ${WRAPPERS_SRCDIR} libmpiwrappers.a
 	make ${DMTCP_ROOT}/lib/dmtcp/libmana.so
-	make ${DMTCP_ROOT}/lib/dmtcp/libmpidummy.so
-	make ${DMTCP_ROOT}/bin/lh_proxy
-	make ${DMTCP_ROOT}/bin/gethostbyname_proxy
+	make $(libmpidummy.so) mana
+	make $(lh_proxy) mana
+	make $(gethostbyname_proxy) mana
 
 install:
-	cp ${DMTCP_ROOT}/bin/lh_proxy ${DESTDIR}
-	cp ${DMTCP_ROOT}/bin/gethostbyname_proxy ${DESTDIR}
+	install ${DMTCP_ROOT}/lib/dmtcp/libmana.so $(PKGLIBDIR)
+	make $(libmpidummy.so) install DESTDIR=$(PKGLIBDIR)
+	make $(lh_proxy) install DESTDIR=$(BINDIR)
+	make $(gethostbyname_proxy) install DESTDIR=$(BINDIR)
 
 uninstall:
-	rm ${DESTDIR}/lh_proxy
-	rm ${DESTDIR}/gethostbyname_proxy
+	rm -f $(PKGLIBDIR)/libmana.so
+	rm -f $(PKGLIBDIR)/libmpidummy.so
+	rm -f $(BINDIR)/lh_proxy
+	rm -f $(BINDIR)/gethostbyname_proxy
 
 tidy:
 	rm -f *~ .*.swp dmtcp_restart_script*.sh ckpt_*.dmtcp

--- a/contrib/mpi-proxy-split/Makefile
+++ b/contrib/mpi-proxy-split/Makefile
@@ -112,6 +112,10 @@ mana: ${MANA_COORD_OBJS}
 	make ${DMTCP_ROOT}/bin/lh_proxy
 	make ${DMTCP_ROOT}/bin/gethostbyname_proxy
 
+install:
+	cp ${DMTCP_ROOT}/bin/lh_proxy ${DESTDIR}
+	cp ${DMTCP_ROOT}/bin/gethostbyname_proxy ${DESTDIR}
+
 tidy:
 	rm -f *~ .*.swp dmtcp_restart_script*.sh ckpt_*.dmtcp
 	rm -rf ckpt_rank_*
@@ -132,4 +136,4 @@ dist: distclean
 	dir=`basename $$PWD` && ls -l ../$$dir.tgz
 
 .PHONY: default clean dist distclean vi vim touch gdb tidy check \
-        tests check-unit mana 
+        tests check-unit mana install 

--- a/contrib/mpi-proxy-split/Makefile
+++ b/contrib/mpi-proxy-split/Makefile
@@ -116,6 +116,10 @@ install:
 	cp ${DMTCP_ROOT}/bin/lh_proxy ${DESTDIR}
 	cp ${DMTCP_ROOT}/bin/gethostbyname_proxy ${DESTDIR}
 
+uninstall:
+	rm ${DESTDIR}/lh_proxy
+	rm ${DESTDIR}/gethostbyname_proxy
+
 tidy:
 	rm -f *~ .*.swp dmtcp_restart_script*.sh ckpt_*.dmtcp
 	rm -rf ckpt_rank_*
@@ -136,4 +140,4 @@ dist: distclean
 	dir=`basename $$PWD` && ls -l ../$$dir.tgz
 
 .PHONY: default clean dist distclean vi vim touch gdb tidy check \
-        tests check-unit mana install 
+        tests check-unit mana install uninstall 

--- a/contrib/mpi-proxy-split/lower-half/Makefile
+++ b/contrib/mpi-proxy-split/lower-half/Makefile
@@ -41,8 +41,6 @@ ${STATIC_GETHOSTBYNAME}: gethostbyname-static/gethostbyname_static.c \
 	cd gethostbyname-static && make gethostbyname_proxy
 endif
 
-GETHOSTBYNAME_PROXY=gethostbyname-static/gethostbyname_proxy
-
 .c.o:
 	${MPICC} ${CFLAGS} -g3 -O0 -c -o $@ $<
 
@@ -73,11 +71,11 @@ ${PROXY_BIN}: ${PROXY_OBJS} ${LIBPROXY}.a ${STATIC_GETHOSTBYNAME}
 ${LIBPROXY}.a: ${LIBPROXY_OBJS}
 	ar cr $@ $^
 
-mana: ${PROXY_BIN} ${STATIC_GETHOSTBYNAME}
-	install $< ${GETHOSTBYNAME_PROXY} ${DMTCP_ROOT}/bin/
+mana: ${PROXY_BIN}
+	install $< ${DMTCP_ROOT}/bin/
 
 install: mana
-	install ${PROXY_BIN} ${GETHOSTBYNAME_PROXY} $(DESTDIR)
+	install ${PROXY_BIN} $(DESTDIR)
 
 tidy:
 	rm -f *~ .*.swp dmtcp_restart_script*.sh ckpt_*.dmtcp

--- a/contrib/mpi-proxy-split/lower-half/Makefile
+++ b/contrib/mpi-proxy-split/lower-half/Makefile
@@ -30,6 +30,7 @@ PROXY_LD_FLAGS=-static -Wl,-Ttext-segment -Wl,0xE000000 -Wl,--wrap -Wl,__munmap 
 default: ${PROXY_BIN} ${STATIC_GETHOSTBYNAME}
 
 # We should remove the special case for Cori, once we know this works on Cori.
+# FIXME: this seems duplicated - gethostbyname-static has its own Makefile. 
 ifeq ($(findstring cori,$(PLATFORM)),cori)
   STATIC_GETHOSTBYNAME=
 else
@@ -38,8 +39,9 @@ ${STATIC_GETHOSTBYNAME}: gethostbyname-static/gethostbyname_static.c \
                          gethostbyname-static/gethostbyname_proxy.c
 	cd gethostbyname-static && make gethostbyname_static.o
 	cd gethostbyname-static && make gethostbyname_proxy
-	cp gethostbyname-static/gethostbyname_proxy -f ${DMTCP_ROOT}/bin/
 endif
+
+GETHOSTBYNAME_PROXY=gethostbyname-static/gethostbyname_proxy
 
 .c.o:
 	${MPICC} ${CFLAGS} -g3 -O0 -c -o $@ $<
@@ -72,7 +74,10 @@ ${LIBPROXY}.a: ${LIBPROXY_OBJS}
 	ar cr $@ $^
 
 mana: ${PROXY_BIN} ${STATIC_GETHOSTBYNAME}
-	cp -f $^ ${DMTCP_ROOT}/bin/
+	install $< ${GETHOSTBYNAME_PROXY} ${DMTCP_ROOT}/bin/
+
+install: mana
+	install ${PROXY_BIN} ${GETHOSTBYNAME_PROXY} $(DESTDIR)
 
 tidy:
 	rm -f *~ .*.swp dmtcp_restart_script*.sh ckpt_*.dmtcp
@@ -90,4 +95,4 @@ dist: distclean
 	dir=`basename $$PWD` && cd .. && tar czvf $$dir.tgz ./$$dir
 	dir=`basename $$PWD` && ls -l ../$$dir.tgz
 
-.PHONY: default clean dist distclean mana
+.PHONY: default clean dist distclean mana install

--- a/contrib/mpi-proxy-split/lower-half/Makefile
+++ b/contrib/mpi-proxy-split/lower-half/Makefile
@@ -71,7 +71,7 @@ ${PROXY_BIN}: ${PROXY_OBJS} ${LIBPROXY}.a ${STATIC_GETHOSTBYNAME}
 ${LIBPROXY}.a: ${LIBPROXY_OBJS}
 	ar cr $@ $^
 
-install: ${PROXY_BIN} ${STATIC_GETHOSTBYNAME}
+mana: ${PROXY_BIN} ${STATIC_GETHOSTBYNAME}
 	cp -f $^ ${DMTCP_ROOT}/bin/
 
 tidy:
@@ -90,4 +90,4 @@ dist: distclean
 	dir=`basename $$PWD` && cd .. && tar czvf $$dir.tgz ./$$dir
 	dir=`basename $$PWD` && ls -l ../$$dir.tgz
 
-.PHONY: default clean dist distclean install
+.PHONY: default clean dist distclean mana

--- a/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
+++ b/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
@@ -26,6 +26,8 @@ dist: clean
 
 mana:
 	make gethostbyname_proxy
-	cp gethostbyname_proxy -f ../../../../bin
+	install gethostbyname_proxy ../../../../bin
+
+install: mana
 
 .PHONY: gdb clean dist mana

--- a/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
+++ b/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
@@ -28,3 +28,4 @@ mana:
 	make gethostbyname_proxy
 	cp gethostbyname_proxy -f ../../../../bin
 
+.PHONY: gdb clean dist mana

--- a/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
+++ b/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
@@ -30,4 +30,4 @@ mana:
 
 install: mana
 
-.PHONY: gdb clean dist mana
+.PHONY: gdb clean dist mana install

--- a/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
+++ b/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
@@ -24,7 +24,7 @@ dist: clean
 	dir=`basename $$PWD` && cd .. && tar zcvf ./$$dir.tar.gz ./$$dir
 	dir=`basename $$PWD` && ls -l ../$$dir.tar.gz
 
-install:
+mana:
 	make gethostbyname_proxy
 	cp gethostbyname_proxy -f ../../../../bin
 

--- a/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
+++ b/contrib/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
@@ -1,5 +1,10 @@
 CFLAGS=-g3 -O0
 
+# Modify if your DMTCP_ROOT is located elsewhere.
+ifndef DMTCP_ROOT
+  DMTCP_ROOT=../../../..
+endif
+
 # getaddrinfo ntp-wwv.nist.gov time: sin_port: 9472; sin_addr: 132.163.97.5
 test: a.out
 	./a.out localhost
@@ -24,10 +29,10 @@ dist: clean
 	dir=`basename $$PWD` && cd .. && tar zcvf ./$$dir.tar.gz ./$$dir
 	dir=`basename $$PWD` && ls -l ../$$dir.tar.gz
 
-mana:
-	make gethostbyname_proxy
-	install gethostbyname_proxy ../../../../bin
+mana: gethostbyname_proxy
+	install $< ${DMTCP_ROOT}/bin
 
 install: mana
+	install gethostbyname_proxy $(DESTDIR) 
 
 .PHONY: gdb clean dist mana install

--- a/contrib/mpi-proxy-split/mpi-wrappers/Makefile
+++ b/contrib/mpi-proxy-split/mpi-wrappers/Makefile
@@ -121,6 +121,8 @@ mana: libmpidummy.so
 		ln -sf libmpidummy.so libpmi.so.0.5.0 && \
 		ln -sf libpmi.so.0.5.0 libpmi.so.0
 
+install: mana
+
 clean: tidy
 	rm -f ${LIBWRAPPER_OBJS}
 	rm -f ${LIBNAME}.a libmpidummy.so
@@ -138,4 +140,4 @@ dist: distclean
 	dir=`basename $$PWD` && cd .. && tar czvf $$dir.tgz ./$$dir
 	dir=`basename $$PWD` && ls -l ../$$dir.tgz
 
-.PHONY: default clean dist distclean tidy mana
+.PHONY: default clean dist distclean tidy mana install

--- a/contrib/mpi-proxy-split/mpi-wrappers/Makefile
+++ b/contrib/mpi-proxy-split/mpi-wrappers/Makefile
@@ -113,7 +113,7 @@ tidy:
 	rm -rf ckpt_rank_*
 
 mana: libmpidummy.so
-	cp -f libmpidummy.so ${DMTCP_ROOT}/lib/dmtcp/
+	install libmpidummy.so ${DMTCP_ROOT}/lib/dmtcp/
 	cd ${DMTCP_ROOT}/lib/dmtcp && \
 		ln -sf libmpidummy.so libmpich_intel.so.3.0.1 && \
 		ln -sf libmpich_intel.so.3.0.1 libmpich_intel.so.3
@@ -122,6 +122,7 @@ mana: libmpidummy.so
 		ln -sf libpmi.so.0.5.0 libpmi.so.0
 
 install: mana
+	install libmpidummy.so $(DESTDIR)
 
 clean: tidy
 	rm -f ${LIBWRAPPER_OBJS}

--- a/contrib/mpi-proxy-split/mpi-wrappers/Makefile
+++ b/contrib/mpi-proxy-split/mpi-wrappers/Makefile
@@ -112,7 +112,7 @@ tidy:
 	rm -f *~ .*.swp dmtcp_restart_script*.sh ckpt_*.dmtcp
 	rm -rf ckpt_rank_*
 
-install: libmpidummy.so
+mana: libmpidummy.so
 	cp -f libmpidummy.so ${DMTCP_ROOT}/lib/dmtcp/
 	cd ${DMTCP_ROOT}/lib/dmtcp && \
 		ln -sf libmpidummy.so libmpich_intel.so.3.0.1 && \
@@ -138,4 +138,4 @@ dist: distclean
 	dir=`basename $$PWD` && cd .. && tar czvf $$dir.tgz ./$$dir
 	dir=`basename $$PWD` && ls -l ../$$dir.tgz
 
-.PHONY: default clean dist distclean tidy install
+.PHONY: default clean dist distclean tidy mana

--- a/manpages/Makefile
+++ b/manpages/Makefile
@@ -8,7 +8,7 @@ default:
 # 	./latex2man -t ./macros.trans $< $@
 
 %.1.gz: %.1
-	gzip --keep $<
+	gzip < $< > $<.gz
 
 install: ${MANPAGES}
 


### PR DESCRIPTION
This pull request installs certain binaries that weren't being installed when `make install` is ran.

Additionally, certain uses of `make install` were not actually installing any binaries, but making them and copying them within the `mana` directory. This pull request fixes that issue by replacing these instances with `make mana`, so what they do are clearer to readers.

`make mana` adds the following files to the MANA directory, and `make install` adds them to `/usr/local`. The install directory can be changed by doing `./configure --prefix=/path/to/dir`.

```
[illios@illios02 install_test]$ ls -R
.:
bin  include  lib  share

./bin:
dmtcp_command      dmtcp_discover_rm  dmtcp_nocheckpoint  dmtcp_rm_loclaunch  dmtcp_ssh   gethostbyname_proxy  mana_coordinator  mana_restart            mana_status
dmtcp_coordinator  dmtcp_launch       dmtcp_restart       dmtcp_srun_helper   dmtcp_sshd  lh_proxy             mana_launch       mana_start_coordinator  mtcp_restart

./include:
dmtcp.h

./lib:
dmtcp

./lib/dmtcp:
libdmtcp_alloc.so        libdmtcp_dl.so   libdmtcp_modify-env.so  libdmtcp_pid.so  libdmtcp_svipc.so  libdmtcp_unique-ckpt.so  libmpidummy.so
libdmtcp_batch-queue.so  libdmtcp_ipc.so  libdmtcp_pathvirt.so    libdmtcp.so      libdmtcp_timer.so  libmana.so

./share:
doc  man

./share/doc:
dmtcp-3.0.0

./share/doc/dmtcp-3.0.0:
AUTHORS  COPYING  NEWS  QUICK-START.md

./share/man:
man1

./share/man/man1:
dmtcp.1.gz  dmtcp_command.1.gz  dmtcp_coordinator.1.gz  dmtcp_discover_rm.1.gz  dmtcp_launch.1.gz  dmtcp_nocheckpoint.1.gz  dmtcp_restart.1.gz  dmtcp_rm_loclaunch.1.gz  dmtcp_ssh.1.gz  dmtcp_sshd.1.gz  mana.1.gz  mtcp_restart.1.gz
```