### PR TITLE
Update instructions in CI test script

### DIFF
--- a/ci/unit-test.sh
+++ b/ci/unit-test.sh
@@ -7,7 +7,7 @@ cd $SCRIPT_DIR/..
 
 ./configure
 make clean
-make -j 8
+make -j 8 mana
 
 cd $SCRIPT_DIR/../contrib/mpi-proxy-split/unit-test
 make


### PR DESCRIPTION
This pull request updates `ci/unit-test.sh` to use `make mana` instead of `make`, as it is the more correct way of building MANA.