### PR TITLE
Minor fix to commit 84d37fb01 for gdb-dmtcp-utlls

### DIFF
--- a/util/gdb-dmtcp-utils
+++ b/util/gdb-dmtcp-utils
@@ -179,7 +179,11 @@ class ShowFilenameAtAddress(gdb.Command):
         else:
           memory_region = "%s 0x%x-0x%x (%s)" % \
                           memory_region_at_address(memory_address)
-          gdb.execute('print "' + memory_region + '"', False, False)
+          #GDB-8:  For some unknown reason (e.g., after: 'bt' and 'frame 4' in MANA),
+          #  the 'gdb.execute' reports '"' not allowed, and (') doesn't work.
+          #  Perhaps it's an interaction between GDB and the Python API.
+          #WAS: gdb.execute('print "' + memory_region + '"', False, False)
+          print(memory_region)
 # This will add the new gdb command: show-filename-at-address MEMORY_ADDRESS
 ShowFilenameAtAddress()
 try:


### PR DESCRIPTION
This was a weird bug, and I still don't know how to reproduce it deterministically.  But @xuyao0127 encountered this bug while working in MANA, doing something like this patter:
```
add-symbol-files-all
bt
frame 4
whereis-address 0xffff7ade0000
```

It appears to be a weird interaction between GDB-8 and its Python interface.  When the bug occurs, `whereis-address` thinks there is a `"` in the address.  At that point, `(gdb) print "abc"` fails with the same error, but `(gdb) print 'abc'` succeeds (even though it should not succeed, since `'` is used to indicate the beginning of the full signature for a C++ method or variable.