### PR TITLE
Add Fortran MPI_Ibarrier test (& ref. more tests)

### DIFF
--- a/contrib/mpi-proxy-split/test/Makefile
+++ b/contrib/mpi-proxy-split/test/Makefile
@@ -1,6 +1,11 @@
 PLATFORM=${shell echo $$HOST}
 include ../Makefile_config
 
+###############################################################
+# NOTE:  More Fortran/C examples (under LGPL license) at:  
+#        https://people.math.sc.edu/Burkardt/f_src/mpi/mpi.html
+###############################################################
+
 ifndef DMTCP_ROOT
   DMTCP_ROOT=../../..
 endif
@@ -14,7 +19,8 @@ DEMO_PORT=7787
 # FILES=mpi_hello_world Abort_test Allreduce_test Alltoall_test \
 #       Alltoallv_test Barrier_test Bcast_test Comm_split_test Reduce_test \
 #       send_recv send_recv_many ping_pong Comm_dup_test Sendrecv_test \
-#       Waitall_test Allgather_test Group_size_rank Type_commit_contiguous
+#       Waitall_test Allgather_test Group_size_rank Type_commit_contiguous \
+#       Irecv_test Alloc_mem f_ibarrier
 ## Reordering the tests:
 FILES=mpi_hello_world \
       hello_mpi_init_thread \
@@ -26,7 +32,8 @@ FILES=mpi_hello_world \
       Ibcast_test Ibarrier_test Isend_test \
       Abort_test Allreduce_test Alltoall_test Alltoallv_test \
       Allgather_test Group_size_rank Type_commit_contiguous \
-      Irecv_test Alloc_mem
+      Irecv_test Alloc_mem \
+      f_ibarrier
 
 OBJS=$(addsuffix .o, ${FILES})
 
@@ -132,6 +139,12 @@ check-integrated_dmtcp_text: tidy integrated_dmtcp_test
 
 %.o: %.c
 	 $(MPICC) -g3 -O0 -c -o $@ $< $(MPI_CFLAGS)
+
+%.exe: %.f90
+	ftn -g3 -O0 -o $@ $< -fPIC
+
+%.mana.exe: %.f90
+	ftn -g3 -O0 -o $@ $< -fPIC ${LDFLAGS_DUMMY}
 
 %.exe: %.o
 	 $(MPICC) -o $@ $< ${MPI_LDFLAGS}

--- a/contrib/mpi-proxy-split/test/f_ibarrier.f90
+++ b/contrib/mpi-proxy-split/test/f_ibarrier.f90
@@ -1,0 +1,20 @@
+PROGRAM hello_world_mpi
+include 'mpif.h'
+
+integer process_Rank, size_Of_Cluster, ierror, tag, flag
+integer request, status(MPI_STATUS_SIZE)
+logical dummy
+
+call MPI_INIT(ierror)
+call MPI_COMM_SIZE(MPI_COMM_WORLD, size_Of_Cluster, ierror)
+call MPI_COMM_RANK(MPI_COMM_WORLD, process_Rank, ierror)
+call MPI_IBARRIER(MPI_COMM_WORLD, request, ierror)
+dummy = .true.
+do while (dummy)
+end do
+call MPI_Wait(request, status, ierror)
+
+print *, 'Hello World from process: ', process_Rank, 'of ', size_Of_Cluster
+
+call MPI_FINALIZE(ierror)
+END PROGRAM


### PR DESCRIPTION
This is the original commit by @xuyao0127 on branch `interface8_fs`.  I've cherry-picked it and slightly updated it for the master branch.  @xuyao0127 is still the author of the commit.

I've also added to the top of `test/Makefile` a comment on a source of LGPL Fortran programs:
```
###############################################################
# NOTE:  More Fortran/C examples (under LGPL license) at:  
#        https://people.math.sc.edu/Burkardt/f_src/mpi/mpi.html
###############################################################
```