### PR TITLE
bug fixes for collective to p2p

### DIFF
--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
@@ -367,6 +367,7 @@ int MPI_Alltoallv(const void* sendbuf, const int sendcounts[],
   return MPI_SUCCESS;
 }
 
+#ifdef ADD_UNDEFINED
 int MPI_Alltoallw(const void* sendbuf, const int sendcounts[],
                   const int sdispls[], const MPI_Datatype sendtypes[],
                   void* recvbuf, const int recvcounts[], const int rdispls[],
@@ -375,6 +376,7 @@ int MPI_Alltoallw(const void* sendbuf, const int sendcounts[],
   ABORT();
   return -1;
 }
+#endif
 
 // MPI standard 3.1:  Section 5.9
 /* NOTE:  MPI-3.1 standard (Section 5.9.1):
@@ -440,6 +442,7 @@ int MPI_Allreduce(const void* sendbuf, void* recvbuf, int count,
   return MPI_SUCCESS;
 }
 
+#ifdef ADD_UNDEFINED
 // MPI standard 3.1:  Section 5.10
 int MPI_Reduce_scatter_block(const void* sendbuf, void* recvbuf,
                              int recvcount, MPI_Datatype datatype, MPI_Op op,
@@ -448,6 +451,8 @@ int MPI_Reduce_scatter_block(const void* sendbuf, void* recvbuf,
   ABORT();
   return -1;
 }
+#endif
+
 int MPI_Reduce_scatter(const void* sendbuf, void* recvbuf,
                        const int recvcounts[], MPI_Datatype datatype, MPI_Op op,
                        MPI_Comm comm) {
@@ -496,7 +501,7 @@ int MPI_Scan(const void* sendbuf, void* recvbuf, int count,
   }
   return MPI_SUCCESS;
 }
-#if ADD_UNDEFINED
+#ifdef ADD_UNDEFINED
 int MPI_Exscan(const void* sendbuf, void* recvbuf, int count,
              MPI_Datatype datatype, MPI_Op op, MPI_Comm comm) {
   fprintf(stderr, "%s not implemented\n", __FUNCTION__);

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
@@ -413,7 +413,7 @@ int MPI_Reduce(const void* sendbuf, void* recvbuf, int count,
   if (rank == root) {
     // Gather data into tmp_sendbuf at root
     int i;
-    char *tmp_sendbuf = (char *)malloc(count * extent);
+    char *tmp_sendbuf = (char *)malloc(count * extent * size);
     MPI_Gather(sendbuf, count, datatype, tmp_sendbuf, count, datatype,
                root, comm);
     // Initialize tmp_recvbuf from sendbuf at rank 0

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
@@ -288,8 +288,8 @@ int MPI_Alltoall(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
   }
   MPI_Aint lower_bound;
   MPI_Aint sendextent, recvextent;
+  MPI_Type_get_extent(sendtype, &lower_bound, &sendextent);
   if (inplace) {
-    MPI_Type_get_extent(sendtype, &lower_bound, &sendextent);
     recvextent = sendextent;
   } else {
     MPI_Type_get_extent(recvtype, &lower_bound, &recvextent);

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_fortran_wrappers.txt
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_fortran_wrappers.txt
@@ -74,6 +74,7 @@ int MPI_Type_free(MPI_Datatype* type);
 int MPI_Type_vector(int count, int blocklength, int stride, MPI_Datatype oldtype, MPI_Datatype* newtype);
 int MPI_Type_create_struct(int count, const int* array_of_blocklengths, const MPI_Aint* array_of_displacements, MPI_Datatype* array_of_types, MPI_Datatype* newtype);
 int MPI_Type_indexed(int count, const int* array_of_blocklengths, const int* array_of_displacements, MPI_Datatype oldtype, MPI_Datatype* newtype);
+int MPI_Type_get_extent(MPI_Datatype type, MPI_Aint* lb, MPI_Aint* extent);
 int MPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm, int* size);
 int MPI_Pack(const void* inbuf, int incount, MPI_Datatype datatype, void* outbuf, int outsize, int* position, MPI_Comm comm);
 

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
@@ -80,8 +80,9 @@ USER_DEFINED_WRAPPER(int, Reduce_local,
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
+  MPI_Op realOp = VIRTUAL_TO_REAL_OP(op);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
-  retval = NEXT_FUNC(Reduce_local)(inbuf, inoutbuf, count, datatype, op);
+  retval = NEXT_FUNC(Reduce_local)(inbuf, inoutbuf, count, datatype, realOp);
   RETURN_TO_UPPER_HALF();
   // This is non-blocking.  No need to log it.
   DMTCP_PLUGIN_ENABLE_CKPT();

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
@@ -181,6 +181,19 @@ USER_DEFINED_WRAPPER(int, Type_indexed, (int) count,
   return retval;
 }
 
+USER_DEFINED_WRAPPER(int, Type_get_extent, (MPI_Datatype) datatype,
+                     (MPI_Aint*) lb, (MPI_Aint*) extent)
+{
+  int retval;
+  DMTCP_PLUGIN_DISABLE_CKPT();
+  MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
+  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
+  retval = NEXT_FUNC(Type_get_extent)(realType, lb, extent);
+  RETURN_TO_UPPER_HALF();
+  DMTCP_PLUGIN_ENABLE_CKPT();
+  return retval;
+}
+
 USER_DEFINED_WRAPPER(int, Pack_size, (int) incount,
                      (MPI_Datatype) datatype, (MPI_Comm) comm,
                      (int*) size)
@@ -225,6 +238,8 @@ PMPI_IMPL(int, MPI_Type_create_struct, int count, const int array_of_blocklength
 PMPI_IMPL(int, MPI_Type_indexed, int count, const int array_of_blocklengths[],
           const int array_of_displacements[], MPI_Datatype oldtype,
           MPI_Datatype *newtype)
+PMPI_IMPL(int, MPI_Type_get_extent, MPI_Datatype datatype, MPI_Aint *lb,
+          MPI_Aint *extent)
 PMPI_IMPL(int, MPI_Pack_size, int incount, MPI_Datatype datatype,
           MPI_Comm comm, int *size)
 PMPI_IMPL(int, MPI_Pack, const void *inbuf, int incount, MPI_Datatype datatype,

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_unimplemented_wrappers.txt
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_unimplemented_wrappers.txt
@@ -270,7 +270,6 @@ int MPI_Type_free_keyval(int *type_keyval);
 int MPI_Type_get_attr(MPI_Datatype type, int type_keyval, void *attribute_val, int *flag);
 int MPI_Type_get_contents(MPI_Datatype mtype, int max_integers, int max_addresses, int max_datatypes, int array_of_integers[], MPI_Aint array_of_addresses[], MPI_Datatype array_of_datatypes[]);
 int MPI_Type_get_envelope(MPI_Datatype type, int *num_integers, int *num_addresses, int *num_datatypes, int *combiner);
-int MPI_Type_get_extent(MPI_Datatype type, MPI_Aint *lb, MPI_Aint *extent);
 int MPI_Type_get_extent_x(MPI_Datatype type, MPI_Count *lb, MPI_Count *extent);
 int MPI_Type_get_name(MPI_Datatype type, char *type_name, int *resultlen);
 int MPI_Type_get_true_extent(MPI_Datatype datatype, MPI_Aint *true_lb, MPI_Aint *true_extent);

--- a/contrib/mpi-proxy-split/p2p_drain_send_recv.cpp
+++ b/contrib/mpi-proxy-split/p2p_drain_send_recv.cpp
@@ -31,7 +31,7 @@
 #include "mpi_nextfunc.h"
 #include "virtual-ids.h"
 
-extern int MPI_Alltoall_internal(const void *sendbuf, int sendcount,
+extern "C" int MPI_Alltoall_internal(const void *sendbuf, int sendcount,
                                  MPI_Datatype sendtype, void *recvbuf,
                                  int recvcount, MPI_Datatype recvtype,
                                  MPI_Comm comm);


### PR DESCRIPTION
It seems checkpointing is working fine with these fixes. However, the feature/dmtcp-master branch still can't restart because of another bug. So I am not sure if we need other fixes.

I decided to move the MPI_Alltoall_internal into p2p_drain_send_recv.cpp. The function is only used in this file, and it's not really a wrapper. The purpose of this function is letting us use it internally without applying the two-phase-commit algorithm.