### PR TITLE
Add several Fortran90 test samples

### DIFF
--- a/contrib/mpi-proxy-split/test/Makefile
+++ b/contrib/mpi-proxy-split/test/Makefile
@@ -33,7 +33,8 @@ FILES=mpi_hello_world \
       Abort_test Allreduce_test Alltoall_test Alltoallv_test \
       Allgather_test Group_size_rank Type_commit_contiguous \
       Irecv_test Alloc_mem \
-      f_ibarrier
+      f_ibarrier \
+      wave_mpi day1_mpi quad_mpi poisson_nonblock_mpi
 
 OBJS=$(addsuffix .o, ${FILES})
 

--- a/contrib/mpi-proxy-split/test/day1_mpi.f90
+++ b/contrib/mpi-proxy-split/test/day1_mpi.f90
@@ -1,0 +1,291 @@
+program main
+
+!*****************************************************************************80
+!
+!! MAIN is the main program for DAY1.
+!
+!  Discussion:
+!
+!    DAY1_EX3 is exercise 3 for first day of the MPI workshop.
+!
+!    The instructions say:
+!
+!    Process 1 computes the squares of the first 200 integers.
+!    It sends this data to process 3.
+!
+!    Process 3 should divide the integers between 20 and 119 by 53,
+!    getting a real result, and passes this data back to process 1.
+!
+!    * I presume the first 200 integers are the numbers 0 through 199.
+!
+!    * The instructions literally mean that process 3 should look
+!      at integers whose VALUES are between 20 and 119.  I doubt that
+!      is what the instructor meant, but it's more interesting than
+!      simply picking the entries with index between 20 and 119,
+!      so that's what I'll do.
+!
+!    * It is also not completely clear whether only the selected data
+!      should be sent back, or the entire array.  Again, it is more
+!      interesting to send back only part of the data.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    18 October 2005
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Reference:
+!
+!    William Gropp, Ewing Lusk, Anthony Skjellum,
+!    Using MPI: Portable Parallel Programming with the
+!    Message-Passing Interface,
+!    Second Edition,
+!    MIT Press, 1999,
+!    ISBN: 0262571323.
+!
+  use mpi
+
+  integer, parameter :: i_dim = 200
+  integer, parameter :: r_dim = 200
+
+  integer count
+  integer count2
+  integer dest
+  integer i
+  integer i_buffer(i_dim)
+  integer id
+  integer ierr
+  integer num_procs
+  real r_buffer(r_dim)
+  integer source
+  integer status(MPI_Status_size)
+  integer tag
+!
+!  Initialize MPI.
+!
+  call MPI_Init ( ierr )
+!
+!  Determine this process's id.
+!
+  call MPI_Comm_rank ( MPI_COMM_WORLD, id, ierr )
+!
+!  Have Process 0 say hello.
+!
+  if ( id == 0 ) then
+    call timestamp ( )
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) 'DAY1:'
+    write ( *, '(a)' ) '  FORTRAN90 version'
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) '  MPI exercise #3 for day 1.'
+    write ( *, '(a,i8)' ) '  The number of processes available is ', num_procs
+  end if
+!
+!  Get the number of processes.
+!
+  call MPI_Comm_size ( MPI_COMM_WORLD, num_procs, ierr )
+!
+!  If we don't have at least 4 processes, then bail out now.
+!
+  if ( num_procs < 4 ) then
+    write ( *, '(a)' ) ' '
+    write ( *, '(a,i8)' ) 'DAY1 - Process ', id
+    write ( *, '(a)' ) '  Not enough processes for this task!'
+    write ( *, '(a)' ) '  Bailing out now!'
+    call MPI_Finalize ( ierr )
+    stop
+  end if
+!
+!  Process 1 knows that it will generate 200 integers, and may receive no more
+!  than 200 reals.
+!
+  if ( id == 1 ) then
+
+    count = 200
+
+    do i = 1, count
+      i_buffer(i) = ( i - 1 )**2
+    end do
+
+    dest = 3
+    tag = 1
+
+    call MPI_Send ( i_buffer, count, MPI_INTEGER, dest, tag, &
+      MPI_COMM_WORLD, ierr )
+
+    write ( *, '(a,i1,a,i3,a,i1)' ) 'P:', id, ' sent ', count, &
+      ' integers to process ', dest
+
+    source = 3
+    tag = 2
+
+    call MPI_Recv ( r_buffer, r_dim, MPI_REAL, source, tag, &
+      MPI_COMM_WORLD, status, ierr )
+
+    write ( *, '(a,i1,a,i1)' ) 'P:', id, &
+      ' received real values from process 3.'
+
+    call MPI_Get_count ( status, MPI_REAL, count, ierr )
+
+    write ( *, '(a,i1,a,i3,a)' ) 'P:', id, &
+      ' Number of real values received is ', count
+
+    write ( *, '(a,i1,a,3f8.4)' ) 'P:', id, &
+      ' First 3 values = ', r_buffer(1:3)
+!
+!  Process 3 receives the integer data from process 1, selects some 
+!  of the data, does a real computation on it, and sends that part 
+!  back to process 1.
+!
+  else if ( id == 3 ) then
+ 
+    source = 1
+    tag = 1
+
+    call MPI_Recv ( i_buffer, i_dim, MPI_INTEGER, source, tag, &
+      MPI_COMM_WORLD, status, ierr )
+
+    write ( *, '(a)' ) ' '
+    write ( *, '(a,i1,a)' ) 'P:', id, &
+      ' received integer values from process 1.'
+
+    call MPI_Get_count ( status, MPI_INTEGER, count, ierr )
+
+    write ( *, '(a,i1,a,i8)' ) 'P:', id, &
+      ' - Number of integers received is ', count
+    write ( *, '(a,i1,a,3i8)' ) 'P:', id, ' First 3 values = ', i_buffer(1:3)
+
+    count2 = 0
+
+    do i = 1, count
+     
+      if ( 20 <= i_buffer(i) .and. i_buffer(i) <= 119 ) then
+
+        count2 = count2 + 1
+        r_buffer(count2) = real ( i_buffer(i) ) / 53.0E+00
+
+        if ( count2 <= 3 ) then
+          write ( *, '(a,i1,a,i8,a,f8.4)' ) 'P:', id, ' Input integer ', &
+            i_buffer(i), ' becomes ', r_buffer(count2)
+        end if
+
+      end if
+
+    end do
+
+    dest = 1
+    tag = 2
+  
+    call MPI_Send ( r_buffer, count2, MPI_REAL, dest, tag, &
+      MPI_COMM_WORLD, ierr )
+
+    write ( *, '(a,i1,a,i3,a,i1)' ) 'P:', id, ' sent ', count2, &
+      ' reals to process ', dest
+
+  else
+
+    write ( *, '(a)' ) ' '
+    write ( *, '(a,i1,a)' ) 'P:', id, ' - MPI has no work for me!'
+
+  end if
+!
+!  Terminate MPI.
+!
+  call MPI_Finalize ( ierr )
+!
+!  Terminate.
+!
+  if ( id == 0 ) then
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) 'DAY1:'
+    write ( *, '(a)' ) '  Normal end of execution.'
+    write ( *, '(a)' ) ' '
+    call timestamp ( )
+  end if
+
+  stop
+end
+subroutine timestamp ( )
+
+!*****************************************************************************80
+!
+!! TIMESTAMP prints the current YMDHMS date as a time stamp.
+!
+!  Example:
+!
+!    31 May 2001   9:45:54.872 AM
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    18 May 2013
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    None
+!
+  implicit none
+
+  character ( len = 8 ) ampm
+  integer ( kind = 4 ) d
+  integer ( kind = 4 ) h
+  integer ( kind = 4 ) m
+  integer ( kind = 4 ) mm
+  character ( len = 9 ), parameter, dimension(12) :: month = (/ &
+    'January  ', 'February ', 'March    ', 'April    ', &
+    'May      ', 'June     ', 'July     ', 'August   ', &
+    'September', 'October  ', 'November ', 'December ' /)
+  integer ( kind = 4 ) n
+  integer ( kind = 4 ) s
+  integer ( kind = 4 ) values(8)
+  integer ( kind = 4 ) y
+
+  call date_and_time ( values = values )
+
+  y = values(1)
+  m = values(2)
+  d = values(3)
+  h = values(5)
+  n = values(6)
+  s = values(7)
+  mm = values(8)
+
+  if ( h < 12 ) then
+    ampm = 'AM'
+  else if ( h == 12 ) then
+    if ( n == 0 .and. s == 0 ) then
+      ampm = 'Noon'
+    else
+      ampm = 'PM'
+    end if
+  else
+    h = h - 12
+    if ( h < 12 ) then
+      ampm = 'PM'
+    else if ( h == 12 ) then
+      if ( n == 0 .and. s == 0 ) then
+        ampm = 'Midnight'
+      else
+        ampm = 'AM'
+      end if
+    end if
+  end if
+
+  write ( *, '(i2.2,1x,a,1x,i4,2x,i2,a1,i2.2,a1,i2.2,a1,i3.3,1x,a)' ) &
+    d, trim ( month(m) ), y, h, ':', n, ':', s, '.', mm, trim ( ampm )
+
+  return
+end

--- a/contrib/mpi-proxy-split/test/poisson_nonblock_mpi.f90
+++ b/contrib/mpi-proxy-split/test/poisson_nonblock_mpi.f90
@@ -1,0 +1,788 @@
+program main
+
+!*****************************************************************************80
+!
+!! MAIN is the main program for POISSON_NONBLOCK_MPI.
+!
+!  Discussion:
+!
+!    POISSON_NONBLOCK_MPI solves the Poisson problem using nonblocking MPI.
+!
+!    This program differs from POISSON_MPI only in the routine EXCHANGE_BAND.
+!    There, instead of calling MPI_RECV and MPI_SEND, the routine calls
+!    MPI_IRECV and MPI_ISEND, which are nonblocking data transfer routines. 
+!
+!    Theoretically, this could make the program run twice as fast.
+!
+!    This program runs in parallel.  Its output should be compared with that
+!    of POISSON_SERIAL.
+!
+!    The Poisson equation
+!
+!      DEL^2 U(X,Y) = F(X,Y)
+!
+!    is solved on the unit square [0,1] x [0,1] using a grid of [0,NX+1] by
+!    [0,NY+1] evenly spaced points.  
+!
+!    The boundary conditions and F are set so that the exact solution is
+!
+!      U(X,Y) = sin ( X * Y )
+!
+!    The Jacobi iteration is repeatedly applied until convergence is detected.
+!
+!    For parallel execution, the domain is divided up into parallel horizontal
+!    strips.  Each strip is assigned to a process.  A process must communicate
+!    with the processes "above" and "below" it to get information about the
+!    solution value along their common interface.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    08 October 2002
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Reference:
+!
+!    William Gropp, Ewing Lusk, Anthony Skjellum,
+!    Using MPI: Portable Parallel Programming with the
+!    Message-Passing Interface,
+!    Second Edition,
+!    MIT Press, 1999,
+!    ISBN: 0262571323.
+!
+  use mpi
+
+  integer, parameter :: ndim = 1
+! integer, parameter :: nx = 9
+! integer, parameter :: ny = 9
+  integer, parameter :: nx = 999
+  integer, parameter :: ny = 999
+
+  real, allocatable, dimension ( :, : ) :: a
+  real anorm
+  real, allocatable, dimension ( :, : ) :: b
+  real bnorm
+  integer bot
+  integer cartesian_comm
+  integer cartesian_id
+  integer, parameter :: cartesian_master = 0
+  logical converged
+  real diff
+  real diff_part
+  integer dim
+  integer dims(ndim)
+  real dx
+  real dy
+  integer e
+  integer error
+  real, allocatable, dimension ( :, : ) :: f
+  real fnorm
+  integer i
+  integer it
+! integer, parameter :: it_max = 100
+  integer, parameter :: it_max = 2000
+  integer j
+  integer, parameter :: master = 0
+  integer num_procs
+  logical periodic(ndim)
+  logical reorder
+  integer s
+  integer shift
+  integer top
+! real, parameter :: tolerance = 0.001E+00
+  real, parameter :: tolerance = 0.0001E+00
+  integer world_id
+!
+!  Initialize MPI.
+!
+  call MPI_Init ( error )
+!
+!  Get the number of processes.
+!
+  call MPI_Comm_size ( MPI_COMM_WORLD, num_procs, error )
+!
+!  Get the individual process ID.
+!
+  call MPI_Comm_rank ( MPI_COMM_WORLD, world_id, error )
+!
+!  Print a message.
+!
+  if ( world_id == master ) then
+    call timestamp ( )
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) 'POISSON_NONBLOCK_MPI:'
+    write ( *, '(a)' ) '  FORTRAN90 version'
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) '  An MPI example program to solve the Poisson equation.'
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) '  This version used NONBLOCKING communication'
+    write ( *, '(a)' ) '  with MPI_Isend and MPI_Irecv.'
+    write ( *, '(a)' ) ' '
+    write ( *, '(a,i8)' ) '  The number of interior X grid lines is ', nx
+    write ( *, '(a,i8)' ) '  The number of interior Y grid lines is ', ny
+    write ( *, '(a)' ) ' '
+    write ( *, '(a,i8)' ) '  The number of processes is ', num_procs
+    write ( *, '(a)' ) ' '
+  end if
+
+  write ( *, '(a,i8,a)' ) '  Process ', world_id, ' is active'
+!
+!  Get a communicator for the Cartesian decomposition of the domain.
+!
+  dims(1) = num_procs
+  periodic(1) = .false.
+  reorder = .true.
+
+  call MPI_Cart_create ( MPI_COMM_WORLD, ndim, dims, periodic, reorder, &
+    cartesian_comm, error )
+!
+!  Get this processor's rank within the Cartesian communicator.
+!
+  call MPI_Comm_rank ( cartesian_comm, cartesian_id, error )
+!
+!  Determine the bottom and top neighbors of each processor.
+!
+!  Note that MPI_Cart_shift counts dimensions using 0-based arithmetic!
+!  We only have one dimension, but to inquire about a shift in dimension 1
+!  we actually ask about dimension 0!
+!
+  dim = 0
+  shift = 1
+
+  call MPI_Cart_shift ( cartesian_comm, dim, shift, bot, top, error )
+!
+!  Compute the rows "S" through "E" of data that are to be assigned to this
+!  process.
+!
+!  (There's an MPE routine MPE_DECOMP1D that does this, but I don't know where
+!  MPE is, so I wrote my own!)
+!
+  call decomp_band ( ny, num_procs, cartesian_id, s, e )
+!
+!  Once we have the sizes S and E, we can allocate A, B, and F.
+!
+  allocate ( a(0:nx+1,s-1:e+1) )
+  allocate ( b(0:nx+1,s-1:e+1) )
+  allocate ( f(0:nx+1,s-1:e+1) )
+!
+!  Initialize the right hand side and initial solution guess.
+!
+  call init_band ( nx, ny, s, e, cartesian_id, cartesian_comm, num_procs, &
+    dx, dy, f, a, b )
+
+  call get_norm ( nx, s, e, f, cartesian_comm, cartesian_master, fnorm )
+
+  if ( cartesian_id == cartesian_master ) then
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) 'POISSON_NONBLOCK_MPI - Master Cartesian process:'
+    write ( *, '(a,g14.6)' ) &
+      '  Max norm of right hand side F at interior nodes = ', fnorm
+  end if
+!
+!  Do the iteration.
+!  We do two steps of iteration each time.
+!
+  converged = .false.
+
+  if ( cartesian_id == cartesian_master ) then
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) 'Step    ||U||         ||Unew||     ||Unew-U||'
+    write ( *, '(a)' ) ' '
+  end if
+
+  do it = 1, it_max
+!
+!  Share with neighbor processes the value of A at "ghost" points.
+!
+    call exchange_band ( nx, s, e, cartesian_comm, bot, top, a )
+!
+!  Perform a Jacobi sweep, computing B from A.
+!
+    call sweep_band ( nx, s, e, dx, dy, f, a, b )
+
+    call get_norm ( nx, s, e, b, cartesian_comm, cartesian_master, bnorm )
+!
+!  Share with neighbor processes the value of B at "ghost" points.
+!
+    call exchange_band ( nx, s, e, cartesian_comm, bot, top, b )
+!
+!  Perform a Jacobi sweep, computing A from B.
+!
+    call sweep_band ( nx, s, e, dx, dy, f, b, a )
+
+    call get_norm ( nx, s, e, a, cartesian_comm, cartesian_master, anorm )
+!
+!  Check for convergence.
+!
+    diff_part = 0.0E+00
+    do j = s, e
+      do i = 1, nx
+        diff_part = max ( diff_part, abs ( a(i,j) - b(i,j) ) )
+      end do
+    end do
+
+    call MPI_Allreduce ( diff_part, diff, 1, MPI_REAL, MPI_MAX, &
+      cartesian_comm, error )
+
+    if ( cartesian_id == cartesian_master ) then
+      write ( *, '(i8,3g14.6)' ) it, bnorm, anorm, diff
+    end if
+
+    if ( diff <= tolerance ) then
+      converged = .true.
+      exit
+    end if
+
+  end do
+
+  if ( world_id == master ) then
+
+    if ( converged ) then
+      write ( *, '(a)' ) ' '
+      write ( *, '(a)' ) 'POISSON_NONBLOCK_MPI - Master process:'
+      write ( *, '(a)' ) '  The iteration has converged'
+    else
+      write ( *, '(a)' ) ' '
+      write ( *, '(a)' ) 'POISSON_NONBLOCK_MPI - Master process:'
+      write ( *, '(a)' ) '  The iteration has NOT converged'
+    end if
+
+  end if
+!
+!  Free memory.
+!
+  deallocate ( a )
+  deallocate ( b )
+  deallocate ( f )
+!
+!  Terminate MPI.
+!
+  call MPI_Finalize ( error )
+!
+!  Terminate.
+!
+  if ( world_id == master ) then
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) 'POISSON_NONBLOCK_MPI - Master process:'
+    write ( *, '(a)' ) '  Normal end of execution.'
+    write ( *, '(a)' ) ' '
+    call timestamp ( )
+  end if
+
+  stop
+end
+subroutine get_norm ( nx, s, e, a, cartesian_comm, cartesian_master, anorm )
+
+!*****************************************************************************80
+!
+!! GET_NORM gets the max norm of a shared quantity, over the grid interior.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    24 September 2002
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    Input, integer NX, the X grid dimension.
+!
+!    Input, integer S, E, indicates the first and last indices of Y data
+!    to be controlled by this process.
+!
+!    Input, real A(0:NX+1,S-1:E+1), the quantity whose max norm is desired.
+!
+!    Input, integer CARTESIAN_COMM, the id of the Cartesian communicator.
+!
+!    Input, integer CARTESIAN_MASTER, the id of the master Cartesian process.
+!
+!    Output, real ANORM, the maximum absolute value of A, over the whole
+!    interior grid.
+!
+  use mpi
+
+  integer e
+  integer nx
+  integer s
+
+  real a(0:nx+1,s-1:e+1)
+  real anorm
+  real anorm_part
+  integer cartesian_comm
+  integer cartesian_master
+  integer error
+  integer i
+  integer j
+
+  anorm_part = 0.0E+00
+  do j = s, e
+    do i = 1, nx
+      anorm_part = max ( anorm_part, abs ( a(i,j) ) )
+    end do
+  end do
+
+  call MPI_Reduce ( anorm_part, anorm, 1, MPI_REAL, MPI_MAX, cartesian_master, &
+    cartesian_comm, error )
+
+  return
+end
+subroutine decomp_band ( m, n, r, s, e )
+
+!*****************************************************************************80
+!
+!! DECOMP_BAND determines the part of the work to be done by this process.
+!
+!  Discussion:
+!
+!    This routine is a replacement for the routine MPE_Decomp1d, and
+!    is an informed guess as to how it works.
+!
+!    Given M things in a row, divide them up in consecutive chunks among 
+!    N processes so that the number assigned to each process is nearly
+!    equal.
+!
+!    If M is exactly divisible by N, then each process gets M/N consecutive
+!    tasks.
+!
+!    Otherwise, if there is a remainder of P, then the first P processes get
+!    M/N+1 tasks, and the last (N-P) processes get M/N tasks.
+!
+!  Example:
+!
+!    M = 27, N = 10
+!
+!    R    S   E
+!   --   --  --
+!    0:   1   3
+!    1:   4   6
+!    2:   7   9
+!    3:  10  12
+!    4:  13  15
+!    5:  16  18
+!    6:  19  21
+!    7:  22  23
+!    8:  24  25
+!    9:  26  27
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    19 September 2002
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    Input, integer M, the number of tasks to be divided among processes.
+!
+!    Input, integer N, the number of processes.
+!
+!    Input, integer R, the rank of a particular process.  Because of
+!    peculiarities of MPI, R will be between 0 and N-1.
+!
+!    Output, integer S, E, the first and last tasks to be given to process R.
+!    S will be 1 or greater, E will be M or less.
+!
+  implicit none
+
+  integer e
+  integer m
+  integer n
+  integer part
+  integer r
+  integer s
+  integer whole
+
+  whole = m / n
+  part = m - whole * n
+
+  if ( r + 1 <= part ) then
+    s =    r             * ( whole + 1 ) + 1
+    e =  ( r + 1 )       * ( whole + 1 )
+  else
+    s =   r             * whole + 1 + part
+    e = ( r + 1 )       * whole     + part
+  end if
+
+  return
+end
+subroutine init_band ( nx, ny, s, e, cartesian_id, cartesian_comm, num_procs, &
+  dx, dy, f, a, b )
+
+!*****************************************************************************80
+!
+!! INIT_BAND initializes the arrays.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    19 September 2002
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    Input, integer NX, NY, the X and Y grid dimensions.
+!
+!    Input, integer S, E, indicates the first and last indices of Y data
+!    to be controlled by this process.
+!
+!    Input, integer CARTESIAN_ID, the rank of this process.
+!
+!    Input, integer CARTESIAN_COMM, the id of the Cartesian communicator.
+!
+!    Input, integer NUM_PROCS, the number of processes.
+!
+!    Output, real DX, DY, the spacing between grid points.
+!
+!    Output, real F(0:NX+1,S-1:E+1), the right hand side data.
+!
+!    Output, real A(0:NX+1,S-1:E+1), B(0:NX+1,S-1:E+1), the initial
+!    solution estimates.
+!
+  use mpi
+
+  integer e
+  integer nx
+  integer s
+
+  real a(0:nx+1,s-1:e+1)
+  real b(0:nx+1,s-1:e+1)
+  integer cartesian_id
+  integer cartesian_comm
+  integer, parameter :: cartesian_master = 0
+  real dx
+  real dy
+  integer error
+  real f(0:nx+1,s-1:e+1)
+  real fnorm
+  real fnorm_part
+  integer i
+  integer j
+  integer num_procs
+  integer ny
+  real x
+  real y
+
+  dx = 1.0E+00 / real ( nx + 1 )
+  dy = 1.0E+00 / real ( ny + 1 )
+
+  if ( cartesian_id == cartesian_master ) then
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) 'INIT_BAND - Master Cartesian process:'
+    write ( *, '(a,g14.6)' ) '  The X grid spacing is ', dx
+    write ( *, '(a,g14.6)' ) '  The Y grid spacing is ', dy
+  end if
+!
+!  Set the initial guesses to zero.
+!
+  a(0:nx+1,s-1:e+1) = 0.0E+00
+  b(0:nx+1,s-1:e+1) = 0.0E+00
+!
+!  The "boundary" entries of F will store the boundary values of the solution.
+!
+  fnorm_part = 0.0E+00
+
+  x = 0.0E+00
+  do j = s, e
+    y = real ( j ) / real ( ny + 1 )
+    f(0,j) = sin ( x * y )
+    a(0,j) = f(0,j)
+    b(0,j) = f(0,j)
+    fnorm_part = max ( fnorm_part, abs ( f(0,j) ) )
+  end do
+
+  x = 1.0E+00
+  do j = s, e
+    y = real ( j ) / real ( ny + 1 )
+    f(nx+1,j) = sin ( x * y )
+    a(nx+1,j) = f(nx+1,j)
+    b(nx+1,j) = f(nx+1,j)
+    fnorm_part = max ( fnorm_part, abs ( f(nx+1,j) ) )
+  end do
+
+  if ( cartesian_id == 0 ) then
+    y = 0.0E+00
+    do i = 0, nx+1
+      x = real ( i ) / real ( nx + 1 )
+      f(i,0) = sin ( x * y )
+      a(i,0) = f(i,0)
+      b(i,0) = f(i,0)
+      fnorm_part = max ( fnorm_part, abs ( f(i,0) ) )
+    end do
+  end if
+
+  if ( cartesian_id == num_procs-1 ) then
+    y = 1.0E+00
+    do i = 0, nx+1
+      x = real ( i ) / real ( nx + 1 )
+      f(i,ny+1) = sin ( x * y )
+      a(i,ny+1) = f(i,ny+1)
+      b(i,ny+1) = f(i,ny+1)
+      fnorm_part = max ( fnorm_part, abs ( f(i,ny+1) ) )
+    end do
+  end if
+
+  call MPI_Reduce ( fnorm_part, fnorm, 1, MPI_REAL, MPI_MAX, cartesian_master, &
+    cartesian_comm, error )
+
+  if ( cartesian_id == cartesian_master ) then
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) 'INIT_BAND - Master Cartesian process:'
+    write ( *, '(a,g14.6)' ) '  Max norm of boundary values = ', fnorm
+  end if
+!
+!  The "interior" entries of F will store the right hand sides of the 
+!  Poisson equation.
+!
+  do j = s, e
+    y = real ( j ) / real ( ny + 1 )
+    do i = 1, nx
+      x = real ( i ) / real ( nx + 1 )
+      f(i,j) = - ( x**2 + y**2 ) * sin ( x * y )
+    end do
+  end do
+
+  return
+end
+subroutine exchange_band ( nx, s, e, cartesian_comm, bot, top, a )
+
+!*****************************************************************************80
+!
+!! EXCHANGE_BAND swaps interface information between neighboring processes.
+!
+!  Discussion:
+!
+!    Nonblocking MPI send and receive routines are used.  Control returns
+!    immediately, once the requests have been initiated.  In order to
+!    guarantee that the requests have been COMPLETED, it is necessary to
+!    call a special routine such as MPI_WAIT_ALL.
+!
+!    Theoretically, this routine could run twice as fast as one which
+!    used blocking communication.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!     08 October 2002
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    Input, integer NX, the number of (interior) grid lines in the X direction.
+!
+!    Input, integer S, E, indicates the first and last indices of Y data
+!    to be controlled by this process.
+!
+!    Input, integer CARTESIAN_COMM, the identifier for the Cartesian 
+!    communicator.
+!
+!    Input, integer BOT, TOP, the identifiers of the processes "below" and
+!    "above" this process, with which it must exchange information.
+!
+!    Input/output, real A(0:NX+1,S-1:E+1), an array of data.  Column
+!    S must be sent to the "bottom" process and "E" to the top process.
+!    Values for S-1 and E+1 will be received from the bottom and top
+!    processes.
+!
+  use mpi
+
+  integer e
+  integer nx
+  integer s
+
+  real a(0:nx+1,s-1:e+1)
+  integer bot
+  integer cartesian_comm
+  integer error
+  integer request(4)
+  integer status_array(MPI_STATUS_SIZE,4)
+  integer tag
+  integer top
+
+  tag = 0
+  call MPI_Irecv ( a(1,s-1), nx, MPI_REAL, bot, tag, cartesian_comm, &
+    request(1), error )
+
+  tag = 1
+  call MPI_Irecv ( a(1,e+1), nx, MPI_REAL, top, tag, cartesian_comm, &
+    request(2), error )
+
+  tag = 0
+  call MPI_Isend ( a(1,e),   nx, MPI_REAL, top, tag, cartesian_comm, &
+    request(3), error )
+
+  tag = 1
+  call MPI_Isend ( a(1,s),   nx, MPI_REAL, bot, tag, cartesian_comm, &
+    request(4), error )
+!
+!  Wait for all the communication to complete before proceeding.
+!
+  call MPI_Waitall ( 4, request, status_array, error )
+
+  return
+end
+subroutine sweep_band ( nx, s, e, dx, dy, f, u, unew )
+
+!*****************************************************************************80
+!
+!! SWEEP_BAND carries out one step of the Jacobi iteration.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    16 September 2002
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    Input, integer NX, the X grid dimension.
+!
+!    Input, integer S, E, indicates the first and last indices of Y data
+!    to be controlled by this process.
+!
+!    Input, real DX, DY, the spacing between grid points.
+!
+!    Input, real F(0:NX+1,S-1:E+1), the right hand side data.
+!
+!    Input, real U(0:NX+1,S-1:E+1), the previous solution estimate.
+!
+!    Output, real UNEW(0:NX+1,S-1:E+1), the updated solution estimate.
+!
+  implicit none
+
+  integer e
+  integer nx
+  integer s
+
+  real dx
+  real dy
+  real f(0:nx+1,s-1:e+1)
+  integer i
+  integer j
+  real u(0:nx+1,s-1:e+1)
+  real unew(0:nx+1,s-1:e+1)
+
+  do j = s, e
+    do i = 1, nx
+
+      unew(i,j) = ( u(i-1,j) + u(i,j+1) + u(i,j-1) + u(i+1,j) ) / 4.0E+00 &
+        - f(i,j) * dx * dy
+
+    end do
+  end do
+
+  return
+end
+subroutine timestamp ( )
+
+!*****************************************************************************80
+!
+!! TIMESTAMP prints the current YMDHMS date as a time stamp.
+!
+!  Example:
+!
+!    31 May 2001   9:45:54.872 AM
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    18 May 2013
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    None
+!
+  implicit none
+
+  character ( len = 8 ) ampm
+  integer ( kind = 4 ) d
+  integer ( kind = 4 ) h
+  integer ( kind = 4 ) m
+  integer ( kind = 4 ) mm
+  character ( len = 9 ), parameter, dimension(12) :: month = (/ &
+    'January  ', 'February ', 'March    ', 'April    ', &
+    'May      ', 'June     ', 'July     ', 'August   ', &
+    'September', 'October  ', 'November ', 'December ' /)
+  integer ( kind = 4 ) n
+  integer ( kind = 4 ) s
+  integer ( kind = 4 ) values(8)
+  integer ( kind = 4 ) y
+
+  call date_and_time ( values = values )
+
+  y = values(1)
+  m = values(2)
+  d = values(3)
+  h = values(5)
+  n = values(6)
+  s = values(7)
+  mm = values(8)
+
+  if ( h < 12 ) then
+    ampm = 'AM'
+  else if ( h == 12 ) then
+    if ( n == 0 .and. s == 0 ) then
+      ampm = 'Noon'
+    else
+      ampm = 'PM'
+    end if
+  else
+    h = h - 12
+    if ( h < 12 ) then
+      ampm = 'PM'
+    else if ( h == 12 ) then
+      if ( n == 0 .and. s == 0 ) then
+        ampm = 'Midnight'
+      else
+        ampm = 'AM'
+      end if
+    end if
+  end if
+
+  write ( *, '(i2.2,1x,a,1x,i4,2x,i2,a1,i2.2,a1,i2.2,a1,i3.3,1x,a)' ) &
+    d, trim ( month(m) ), y, h, ':', n, ':', s, '.', mm, trim ( ampm )
+
+  return
+end

--- a/contrib/mpi-proxy-split/test/quad_mpi.f90
+++ b/contrib/mpi-proxy-split/test/quad_mpi.f90
@@ -1,0 +1,303 @@
+program main
+
+!*****************************************************************************80
+!
+!! MAIN is the main program for QUAD_MPI.
+!
+!  Discussion:
+!
+!    Thanks to Chad Mitchell for pointing out that "status" must be a vector
+!    with dimension MPI_STATUS_SIZE, 16 September 2011.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    16 September 2011
+!
+!  Author:
+!
+!    John Burkardt
+!
+  use mpi
+
+  real ( kind = 8 ) a
+  real ( kind = 8 ) b
+  real ( kind = 8 ) error
+  integer ( kind = 4 ) error_flag
+  real ( kind = 8 ) exact
+  external f
+  real ( kind = 8 ) f
+  integer ( kind = 4 ) i
+  integer ( kind = 4 ) master
+  real ( kind = 8 ) my_a
+  real ( kind = 8 ) my_b
+  integer ( kind = 4 ) my_id
+  integer ( kind = 4 ) my_n
+  real ( kind = 8 ) my_total
+  integer ( kind = 4 ) p
+  integer ( kind = 4 ) p_num
+  integer ( kind = 4 ) n
+  integer ( kind = 4 ) source
+  integer ( kind = 4 ) status(MPI_STATUS_SIZE)
+  integer ( kind = 4 ) tag
+  integer ( kind = 4 ) target
+  real ( kind = 8 ) total
+  real ( kind = 8 ) wtime
+  real ( kind = 8 ) x
+
+  a =  0.0D+00
+  b = 100000.0D+00
+  n = 10000000
+  exact = 0.49936338107645674464D+00
+
+  master = 0
+
+  call MPI_Init ( error_flag )
+
+  call MPI_Comm_size ( MPI_COMM_WORLD, p_num, error_flag )
+
+  call MPI_Comm_rank ( MPI_COMM_WORLD, my_id, error_flag )
+!
+!  Process 0 reads in the quadrature rule, and parcels out the
+!  evaluation points among the processes.
+!
+  if ( my_id == 0 ) then
+!
+!  We want N to be the total number of evaluations.
+!  If necessary, we adjust N to be divisible by the number of processors.
+!
+    my_n = n / ( p_num - 1 )
+    n = ( p_num - 1 ) * my_n
+
+    wtime = MPI_Wtime ( )
+
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) 'QUAD_MPI'
+    write ( *, '(a)' ) '  FORTRAN90/MPI version'
+    write ( *, '(a)' ) '  Estimate an integral of f(x) from A to B.'
+    write ( *, '(a)' ) '  f(x) = 50 / (pi * ( 2500 * x * x + 1 ) )'
+    write ( *, '(a)' ) ' '
+    write ( *, '(a,g14.6)' ) '  A        = ', a
+    write ( *, '(a,g14.6)' ) '  B        = ', b
+    write ( *, '(a,i12)' ) '  N        = ', n
+    write ( *, '(a,g24.16)' ) '  Exact    = ', exact
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) '  Use MPI to divide the computation among'
+    write ( *, '(a)' ) '  multiple processes.'
+
+  end if
+
+  source = master
+
+  call MPI_Bcast ( my_n, 1, MPI_INTEGER, source, MPI_COMM_WORLD, &
+    error_flag )
+!
+!  Process 0 assigns each process a subinterval of [A,B].
+!
+  if ( my_id == 0 ) then
+
+    do p = 1, p_num - 1
+
+      my_a = ( real ( p_num - p,     kind = 8 ) * a   &
+             + real (         p - 1, kind = 8 ) * b ) &
+             / real ( p_num     - 1, kind = 8 )
+
+      target = p
+      tag = 1
+      call MPI_Send ( my_a, 1, MPI_DOUBLE_PRECISION, target, tag, &
+        MPI_COMM_WORLD, error_flag )
+
+      my_b = ( real ( p_num - p - 1, kind = 8 ) * a   &
+             + real (         p,     kind = 8 ) * b ) &
+             / real ( p_num     - 1, kind = 8 )
+
+      target = p
+      tag = 2
+      call MPI_Send ( my_b, 1, MPI_DOUBLE_PRECISION, target, tag, &
+        MPI_COMM_WORLD, error_flag )
+
+    end do
+
+    total = 0.0D+00
+    my_total = 0.0D+00
+!
+!  Processes receive MY_A, MY_B, and compute their part of the integral.
+!
+  else
+
+    source = master
+    tag = 1
+
+    call MPI_Recv ( my_a, 1, MPI_DOUBLE_PRECISION, source, tag, &
+      MPI_COMM_WORLD, status, error_flag )
+
+    source = master
+    tag = 2
+
+    call MPI_Recv ( my_b, 1, MPI_DOUBLE_PRECISION, source, tag, &
+      MPI_COMM_WORLD, status, error_flag )
+
+    my_total = 0.0D+00
+    do i = 1, my_n
+      x = ( real ( my_n - i,     kind = 8 ) * my_a   &
+          + real (        i - 1, kind = 8 ) * my_b ) &
+          / real ( my_n     - 1, kind = 8 )
+      my_total = my_total + f ( x )
+    end do
+
+    my_total = ( my_b - my_a ) * my_total / real ( my_n, kind = 8 )
+
+    write ( *, '(a,i8,a,g14.6)' ) &
+      '  Process ', my_id, ' contributes MY_TOTAL = ', my_total
+
+  end if
+!
+!  Each process sends its value of MY_TOTAL to the master process, to
+!  be summed in TOTAL.
+!
+  call MPI_Reduce ( my_total, total, 1, MPI_DOUBLE_PRECISION, &
+    MPI_SUM, master, MPI_COMM_WORLD, error_flag )
+!
+!  Report the results.
+!
+  if ( my_id == master ) then
+
+    error = abs ( total - exact )
+    wtime = MPI_Wtime ( ) - wtime
+
+    write ( *, '(a)' ) ' '
+    write ( *, '(a,g24.16)' ) '  Estimate = ', total
+    write ( *, '(a,g14.6)' ) '  Error    = ', error
+    write ( *, '(a,g14.6)' ) '  Time     = ', wtime
+
+  end if
+!
+!  Terminate MPI.
+!
+  call MPI_Finalize ( error_flag )
+!
+!  Terminate.
+!
+  if ( my_id == master ) then
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) 'QUAD_MPI:'
+    write ( *, '(a)' ) '  Normal end of execution.'
+  end if
+
+  stop
+end
+function f ( x )
+
+!*****************************************************************************80
+!
+!! F evaluates the function.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    06 August 2005
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    Input, real ( kind = 8 ) X, the argument.
+!
+!    Output, real ( kind = 8 ) F, the function value.
+!
+  implicit none
+
+  real ( kind = 8 ) f
+  real ( kind = 8 ), parameter :: pi = 3.141592653589793D+00
+  real ( kind = 8 ) x
+
+  f = 50.0D+00 / ( pi * ( 2500.0D+00 * x * x + 1.0D+00 ) )
+
+  return
+end
+subroutine timestamp ( )
+
+!*****************************************************************************80
+!
+!! TIMESTAMP prints the current YMDHMS date as a time stamp.
+!
+!  Example:
+!
+!    31 May 2001   9:45:54.872 AM
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    18 May 2013
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    None
+!
+  implicit none
+
+  character ( len = 8 ) ampm
+  integer ( kind = 4 ) d
+  integer ( kind = 4 ) h
+  integer ( kind = 4 ) m
+  integer ( kind = 4 ) mm
+  character ( len = 9 ), parameter, dimension(12) :: month = (/ &
+    'January  ', 'February ', 'March    ', 'April    ', &
+    'May      ', 'June     ', 'July     ', 'August   ', &
+    'September', 'October  ', 'November ', 'December ' /)
+  integer ( kind = 4 ) n
+  integer ( kind = 4 ) s
+  integer ( kind = 4 ) values(8)
+  integer ( kind = 4 ) y
+
+  call date_and_time ( values = values )
+
+  y = values(1)
+  m = values(2)
+  d = values(3)
+  h = values(5)
+  n = values(6)
+  s = values(7)
+  mm = values(8)
+
+  if ( h < 12 ) then
+    ampm = 'AM'
+  else if ( h == 12 ) then
+    if ( n == 0 .and. s == 0 ) then
+      ampm = 'Noon'
+    else
+      ampm = 'PM'
+    end if
+  else
+    h = h - 12
+    if ( h < 12 ) then
+      ampm = 'PM'
+    else if ( h == 12 ) then
+      if ( n == 0 .and. s == 0 ) then
+        ampm = 'Midnight'
+      else
+        ampm = 'AM'
+      end if
+    end if
+  end if
+
+  write ( *, '(i2,1x,a,1x,i4,2x,i2,a1,i2.2,a1,i2.2,a1,i3.3,1x,a)' ) &
+    d, trim ( month(m) ), y, h, ':', n, ':', s, '.', mm, trim ( ampm )
+
+  return
+end

--- a/contrib/mpi-proxy-split/test/wave_mpi.f90
+++ b/contrib/mpi-proxy-split/test/wave_mpi.f90
@@ -1,0 +1,651 @@
+program main
+
+!*****************************************************************************80
+!
+!! MAIN is the main program for WAVE_MPI.
+!
+!  Discussion:
+!
+!    WAVE_MPI solves the wave equation in parallel using MPI.
+!
+!    Discretize the equation for u(x,t):
+!      d^2 u/dt^2 - c^2 * d^2 u/dx^2 = 0  for 0 < x < 1, 0 < t
+!    with boundary conditions:
+!      u(0,t) = u0(t) = sin ( 2 * pi * ( 0 - c * t ) )
+!      u(1,t) = u1(t) = sin ( 2 * pi * ( 1 - c * t ) )
+!    and initial conditions:
+!         u(x,0) = g(x,t=0) =                sin ( 2 * pi * ( x - c * t ) )
+!      dudt(x,0) = h(x,t=0) = - 2 * pi * c * cos ( 2 * pi * ( x - c * t ) ) 
+!
+!    by:
+!
+!      alpha = c * dt / dx.
+!
+!      U(x,t+dt) = 2 U(x,t) - U(x,t-dt) 
+!        + alpha^2 ( U(x-dx,t) - 2 U(x,t) + U(x+dx,t) ).
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license. 
+!
+!  Modified:
+!
+!    17 November 2013
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Reference:
+!
+!    Geoffrey Fox, Mark Johnson, Gregory Lyzenga, Steve Otto, John Salmon, 
+!    David Walker,
+!    Solving problems on concurrent processors, 
+!    Volume 1: General Techniques and Regular Problems,
+!    Prentice Hall, 1988,
+!    ISBN: 0-13-8230226,
+!    LC: QA76.5.F627.
+!
+!  Local parameters:
+!
+!    Local, real ( kind = 8 ) DT, the time step.
+!
+!    Local, integer ( kind = 4 ) ID, the MPI process ID.
+!
+!    Local, integer ( kind = 4 ) N_GLOBAL, the total number of points.
+!
+!    Local, integer ( kind = 4 ) N_LOCAL, the number of points visible to 
+!    this process.
+!
+!    Local, integer ( kind = 4 ) NSTEPS, the number of time steps.
+!
+!    Local, integer ( kind = 4 ) P, the number of MPI processes.
+!
+  use mpi
+
+  implicit none
+
+  real ( kind = 8 ), parameter :: dt = 0.0000125
+! real ( kind = 8 ), parameter :: dt = 0.00125
+  integer ( kind = 4 ) error
+  integer ( kind = 4 ) i_global_hi
+  integer ( kind = 4 ) i_global_lo
+  integer ( kind = 4 ) id
+  integer ( kind = 4 ), parameter :: n_global = 40001
+! integer ( kind = 4 ), parameter :: n_global = 401
+! integer ( kind = 4 ), parameter :: n_global = 101
+  integer ( kind = 4 ) n_local
+  integer ( kind = 4 ), parameter :: nsteps = 100000
+! integer ( kind = 4 ), parameter :: nsteps = 4000
+! integer ( kind = 4 ), parameter :: nsteps = 2
+  integer ( kind = 4 ) p
+  real ( kind = 8 ), allocatable :: u1_local(:)
+  real ( kind = 8 ) wtime
+!
+!  Initialize MPI.
+!
+  call MPI_Init ( error )
+
+  call MPI_Comm_rank ( MPI_COMM_WORLD, id, error )
+
+  call MPI_Comm_size ( MPI_COMM_WORLD, p, error )
+
+  if ( id == 0 ) then
+    call timestamp ( )
+    write ( *, '(a)' ) ''
+    write ( *, '(a)' ) 'MPI_WAVE:'
+    write ( *, '(a)' ) '  FORTRAN90 version.'
+    write ( *, '(a)' ) '  Estimate a solution of the wave equation using MPI.'
+    write ( *, '(a)' ) ''
+    write ( *, '(a,i2,a)' ) '  Using ', p, ' processes.'
+    write ( *, '(a,i6,a)' ) '  Using a total of ', n_global, ' points.'
+    write ( *, '(a,i6,a,g14.6)' ) '  Using ', nsteps, ' time steps of size ', dt
+    write ( *, '(a,g14.6)' ) '  Computing final solution at time ', dt * nsteps
+  end if
+
+  wtime = MPI_Wtime ( )
+!
+!  Determine N_LOCAL
+!
+  i_global_lo = (   id       * ( n_global - 1 ) ) / p
+  i_global_hi = ( ( id + 1 ) * ( n_global - 1 ) ) / p
+  if ( 0 < id ) then
+    i_global_lo = i_global_lo - 1
+  end if
+
+  n_local = i_global_hi + 1 - i_global_lo
+  allocate ( u1_local(1:n_local) )
+!
+!  Update N_LOCAL values.
+!
+  call update ( id, p, n_global, n_local, nsteps, dt, u1_local )
+!
+!  Collect local values into global array.
+!
+  call collect ( id, p, n_global, n_local, nsteps, dt, u1_local )
+!
+!  Report elapsed wallclock time.
+!
+  wtime = MPI_Wtime ( ) - wtime
+
+  if ( id == 0 ) then
+    write ( *, '(a)' ) ''
+    write ( *, '(a,g14.6,a)' ) &
+      '  Elapsed wallclock time was ', wtime, ' seconds.'
+  end if
+!
+!  Terminate MPI.
+!
+  call MPI_Finalize ( error )
+!
+!  Free memory.
+!
+  deallocate ( u1_local )
+!
+!  Terminate.
+!
+  if ( id == 0 ) then
+    write ( *, '(a)' ) ''
+    write ( *, '(a)' ) 'WAVE_MPI:'
+    write ( *, '(a)' ) '  Normal end of execution.'
+    write ( *, '(a)' ) ''
+    call timestamp ( )
+  end if
+
+  stop
+end
+subroutine update ( id, p, n_global, n_local, nsteps, dt, u1_local ) 
+
+!*****************************************************************************80
+!
+!! UPDATE advances the solution a given number of time steps.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license. 
+!
+!  Modified:
+!
+!    17 November 2013
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    Input, integer ( kind = 4 ) ID, the identifier of this process.
+!
+!    Input, integer ( kind = 4 ) P, the number of processes.
+!
+!    Input, integer ( kind = 4 ) N_GLOBAL, the total number of points.
+!
+!    Input, integer ( kind = 4 ) N_LOCAL, the number of points visible to 
+!    this process.
+!
+!    Input, integer ( kind = 4 ) NSTEPS, the number of time steps.
+!
+!    Input, real ( kind = 8 ) DT, the size of the time step.
+!
+!    Output, real ( kind = 8 ) U1_LOCAL(N_LOCAL), the portion of the solution
+!    at the last time, as evaluated by this process.
+!
+  use mpi
+
+  implicit none
+
+  integer ( kind = 4 ) n_local
+
+  real ( kind = 8 ) alpha
+  real ( kind = 8 ) c
+  real ( kind = 8 ) dt
+  real ( kind = 8 ) dudt
+  real ( kind = 8 ) dx
+  integer ( kind = 4 ) error
+  real ( kind = 8 ) exact
+  integer ( kind = 4 ) i
+  integer ( kind = 4 ) i_global
+  integer ( kind = 4 ) i_global_hi
+  integer ( kind = 4 ) i_global_lo
+  integer ( kind = 4 ) i_local
+  integer ( kind = 4 ) i_local_hi
+  integer ( kind = 4 ) i_local_lo
+  integer ( kind = 4 ) id
+  integer ( kind = 4 ) j
+  integer ( kind = 4 ), parameter :: ltor = 20
+  integer ( kind = 4 ) n_global
+  integer ( kind = 4 ) nsteps
+  integer ( kind = 4 ) p
+  integer ( kind = 4 ), parameter :: rtol = 10
+  integer ( kind = 4 ) status(MPI_STATUS_SIZE)
+  real ( kind = 8 ) t
+  real ( kind = 8 ) u0_local(n_local)
+  real ( kind = 8 ) u1_local(n_local)
+  real ( kind = 8 ) u2_local(n_local)
+  real ( kind = 8 ) x
+!
+!  Determine the value of ALPHA.
+!
+  c = 1.0D+00
+  dx = 1.0D+00 / real ( n_global - 1, kind = 8 )
+  alpha = c * dt / dx
+
+  if ( 1.0D+00 <= abs ( alpha ) ) then
+
+    if ( id == 0 ) then
+      write ( *, '(a)' ) ''
+      write ( *, '(a)' ) 'UPDATE - Warning!'
+      write ( *, '(a)' ) '  1 <= |ALPHA| = | C * dT / dX |.'
+      write ( *, '(a,g14.6)' ) '  C = ', c
+      write ( *, '(a,g14.6)' ) '  dT = ', dt
+      write ( *, '(a,g14.6)' ) '  dX = ', dx
+      write ( *, '(a,g14.6)' ) '  ALPHA = ', alpha
+      write ( *, '(a)' ) '  Computation will not be stable!'
+    end if
+
+    call MPI_Finalize ( error )
+    stop 1
+
+  end if
+!
+!  The global array of N_GLOBAL points must be divided up among the processes.
+!  Each process stores about 1/P of the total + 2 extra slots.
+!
+  i_global_lo = (   id       * ( n_global - 1 ) ) / p
+  i_global_hi = ( ( id + 1 ) * ( n_global - 1 ) ) / p
+  if ( 0 < id ) then
+    i_global_lo = i_global_lo - 1
+  end if
+
+  i_local_lo = 0
+  i_local_hi = i_global_hi - i_global_lo
+
+  t = 0.0D+00
+  do i_global = i_global_lo, i_global_hi
+    x = real ( i_global, kind = 8 ) / real ( n_global - 1, kind = 8 )
+    i_local = i_global - i_global_lo
+    u1_local(i_local+1) = exact ( x, t )
+  end do
+
+  do i_local = i_local_lo, i_local_hi
+    u0_local(i_local+1) = u1_local(i_local+1)
+  end do
+!
+!  Take NSTEPS time steps.
+!
+  do i = 1, nsteps
+
+    t = dt * real ( i, kind = 8 )
+! 
+!  For the first time step, we need to use the initial derivative information.
+!
+    if ( i == 1 ) then
+
+      do i_local = i_local_lo + 1, i_local_hi - 1
+        i_global = i_global_lo + i_local
+        x = real ( i_global, kind = 8 ) / real ( n_global - 1, kind = 8 )
+        u2_local(i_local+1) = &
+          +         0.5D+00 * alpha * alpha   * u1_local(i_local-1+1) &
+          + ( 1.0D+00 -       alpha * alpha ) * u1_local(i_local+0+1)   &
+          +         0.5D+00 * alpha * alpha   * u1_local(i_local+1+1) &
+          +                                dt * dudt ( x, t )
+      end do
+!
+!  After the first time step, we can use the previous two solution estimates.
+!
+    else
+
+      do i_local = i_local_lo + 1, i_local_hi - 1
+        u2_local(i_local+1) = &
+          +               alpha * alpha   * u1_local(i_local-1+1) &
+          + 2.0 * ( 1.0 - alpha * alpha ) * u1_local(i_local+0+1)   &
+          +               alpha * alpha   * u1_local(i_local+1+1) &
+          -                                 u0_local(i_local+0+1)
+      end do
+
+    end if
+!
+!  Exchange data with "left-hand" neighbor. 
+!
+    if ( 0 < id ) then
+      call MPI_Send ( u2_local(i_local_lo+2), 1, MPI_DOUBLE_PRECISION, &
+        id - 1, rtol, MPI_COMM_WORLD, error )
+      call MPI_Recv ( u2_local(i_local_lo+1), 1, MPI_DOUBLE_PRECISION, &
+        id - 1, ltor, MPI_COMM_WORLD, status, error )
+    else
+      x = 0.0D+00
+      u2_local(i_local_lo+1) = exact ( x, t )
+    end if
+!
+!  Exchange data with "right-hand" neighbor.
+!
+    if ( id < p - 1 ) then
+      call MPI_Send ( u2_local(i_local_hi), 1, MPI_DOUBLE_PRECISION, id + 1, &
+        ltor, MPI_COMM_WORLD, error )
+      call MPI_Recv ( u2_local(i_local_hi+1),   1, MPI_DOUBLE_PRECISION, &
+        id + 1, rtol, MPI_COMM_WORLD, status, error )
+    else
+      x = 1.0D+00
+      u2_local(i_local_hi+1) = exact ( x, t )
+    end if
+!
+!  Shift data for next time step.
+!
+    do i_local = i_local_lo, i_local_hi
+      u0_local(i_local+1) = u1_local(i_local+1)
+      u1_local(i_local+1) = u2_local(i_local+1)
+    end do
+
+  end do
+
+  return
+end
+subroutine collect ( id, p, n_global, n_local, nsteps, dt, u_local ) 
+
+!*****************************************************************************80
+!
+!! COLLECT has workers send results to the master, which prints them.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license. 
+!
+!  Modified:
+!
+!    17 November 2013
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    Input, integer ( kind = 4 ) ID, the identifier of this process.
+!
+!    Input, integer ( kind = 4 ) P, the number of processes.
+!
+!    Input, integer ( kind = 4 ) N_GLOBAL, the total number of points.
+!
+!    Input, integer ( kind = 4 ) N_LOCAL, the number of points visible
+!    to this process.
+!
+!    Input, integer ( kind = 4 ) NSTEPS, the number of time steps.
+!
+!    Input, real ( kind = 8 ) DT, the size of the time step.
+!
+!    Input, real ( kind = 8 ) U_LOCAL(N_LOCAL), the final solution estimate 
+!    computed by this process.
+!
+  use mpi
+
+  implicit none
+
+  integer ( kind = 4 ) n_global
+  integer ( kind = 4 ) n_local
+
+  integer ( kind = 4 ) buffer(2)
+  integer ( kind = 4 ), parameter :: collect1 = 10
+  integer ( kind = 4 ), parameter :: collect2 = 20
+  real ( kind = 8 ) dt
+  integer ( kind = 4 ) error
+  real ( kind = 8 ) exact
+  integer ( kind = 4 ) i
+  integer ( kind = 4 ) i_global
+  integer ( kind = 4 ) i_global_hi
+  integer ( kind = 4 ) i_global_lo
+  integer ( kind = 4 ) i_local
+  integer ( kind = 4 ) i_local_hi
+  integer ( kind = 4 ) i_local_lo
+  integer ( kind = 4 ) id
+  integer ( kind = 4 ) j
+  integer ( kind = 4 ) n_local2
+  integer ( kind = 4 ) nsteps
+  integer ( kind = 4 ) p
+  integer ( kind = 4 ) status(MPI_STATUS_SIZE)
+  real ( kind = 8 ) t
+  real ( kind = 8 ), allocatable :: u_global(:)
+  real ( kind = 8 ) u_local(n_local)
+  real ( kind = 8 ) x
+
+  i_global_lo = (   id       * ( n_global - 1 ) ) / p
+  i_global_hi = ( ( id + 1 ) * ( n_global - 1 ) ) / p
+  if ( 0 < id ) then
+    i_global_lo = i_global_lo - 1
+  end if
+
+  i_local_lo = 0
+  i_local_hi = i_global_hi - i_global_lo
+!
+!  Master collects worker results into the U_GLOBAL array.
+!
+  if ( id == 0 ) then
+!
+!  Create the global array.
+!
+    allocate ( u_global(1:n_global) )
+!
+!  Copy the master's results into the global array.
+!
+    do i_local = i_local_lo, i_local_hi
+      i_global = i_global_lo + i_local - i_local_lo
+      u_global(i_global+1) = u_local(i_local+1)
+    end do
+!
+!  Contact each worker.
+!
+    do i = 1, p - 1
+!
+!  Message "collect1" contains the global index and number of values.
+!
+      call MPI_Recv ( buffer, 2, MPI_INTEGER, i, collect1, MPI_COMM_WORLD, &
+        status, error )
+
+      i_global_lo = buffer(1)
+      n_local2 = buffer(2)
+
+      if ( i_global_lo < 0 ) then
+        write ( *, '(a,i6)' ) '  Illegal I_GLOBAL_LO = ', i_global_lo
+        call MPI_Finalize ( error )
+        stop 1
+      else if ( n_global <= i_global_lo + n_local2 - 1 ) then
+        write ( *, '(a,i6)' ) '  Illegal I_GLOBAL_LO + N_LOCAL = ', &
+          i_global_lo + n_local2
+        call MPI_Finalize ( error )
+        stop 1
+      end if
+!
+!  Message "collect2" contains the values.
+!
+      call MPI_Recv ( u_global(i_global_lo+1), n_local2, MPI_DOUBLE_PRECISION, &
+        i, collect2, MPI_COMM_WORLD, status, error )
+
+    end do
+!
+!  Print the results.
+!
+    t = dt * real ( nsteps, kind = 8 )
+    write ( *, '(a)' ) ''
+    write ( *, '(a)' ) '    I      X     F(X)   Exact'
+    write ( *, '(a)' ) ''
+    do i_global = 0, n_global - 1
+      x = real ( i_global, kind = 8 ) / real ( n_global - 1, kind = 8 )
+      write ( *, '(2x,i3,2x,f6.3,2x,f6.3,2x,f6.3)' ) &
+        i_global, x, u_global(i_global+1), exact ( x, t )
+    end do
+
+    deallocate ( u_global )
+!
+!  Workers send results to process 0.
+!
+  else
+!
+!  Message "collect1" contains the global index and number of values.
+!
+    buffer(1) = i_global_lo
+    buffer(2) = n_local
+    call MPI_Send ( buffer, 2, MPI_INTEGER, 0, collect1, MPI_COMM_WORLD, error )
+!
+!  Message "collect2" contains the values.
+!
+    call MPI_Send ( u_local, n_local, MPI_DOUBLE_PRECISION, 0, collect2, &
+      MPI_COMM_WORLD, error )
+
+  end if
+
+  return
+end
+function exact ( x, t )
+
+!*****************************************************************************80
+!
+!! EXACT evaluates the exact solution
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license. 
+!
+!  Modified:
+!
+!    17 November 2013
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    Input, real ( kind = 8 ) X, the location.
+!
+!    Input, real ( kind = 8 ) T, the time.
+!
+!    Output, real ( kind = 8 ) EXACT, the value of the exact solution.
+!
+  implicit none
+
+  real ( kind = 8 ), parameter :: c = 1.0D+00
+  real ( kind = 8 ) exact
+  real ( kind = 8 ), parameter :: pi = 3.141592653589793D+00
+  real ( kind = 8 ) t
+  real ( kind = 8 ) x
+
+  exact = sin ( 2.0D+00 * pi * ( x - c * t ) )
+
+  return
+end
+function dudt ( x, t )
+
+!*****************************************************************************80
+!
+!! DUDT evaluates the partial derivative dudt.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license. 
+!
+!  Modified:
+!
+!    17 November 2013
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    Input, real ( kind = 8 ) X, the location.
+!
+!    Input, real ( kind = 8 ) T, the time.
+!
+!    Output, real ( kind = 8 ) DUDT, the value of the time derivative of 
+!    the solution.
+!
+  implicit none
+
+  real ( kind = 8 ), parameter :: c = 1.0D+00
+  real ( kind = 8 ) dudt
+  real ( kind = 8 ), parameter :: pi = 3.141592653589793D+00
+  real ( kind = 8 ) t
+  real ( kind = 8 ) x
+
+  dudt = - 2.0D+00 * pi * c * cos ( 2.0D+00 * pi * ( x - c * t ) )
+
+  return
+end
+subroutine timestamp ( )
+
+!*****************************************************************************80
+!
+!! TIMESTAMP prints the current YMDHMS date as a time stamp.
+!
+!  Example:
+!
+!    31 May 2001   9:45:54.872 AM
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    18 May 2013
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    None
+!
+  implicit none
+
+  character ( len = 8 ) ampm
+  integer ( kind = 4 ) d
+  integer ( kind = 4 ) h
+  integer ( kind = 4 ) m
+  integer ( kind = 4 ) mm
+  character ( len = 9 ), parameter, dimension(12) :: month = (/ &
+    'January  ', 'February ', 'March    ', 'April    ', &
+    'May      ', 'June     ', 'July     ', 'August   ', &
+    'September', 'October  ', 'November ', 'December ' /)
+  integer ( kind = 4 ) n
+  integer ( kind = 4 ) s
+  integer ( kind = 4 ) values(8)
+  integer ( kind = 4 ) y
+
+  call date_and_time ( values = values )
+
+  y = values(1)
+  m = values(2)
+  d = values(3)
+  h = values(5)
+  n = values(6)
+  s = values(7)
+  mm = values(8)
+
+  if ( h < 12 ) then
+    ampm = 'AM'
+  else if ( h == 12 ) then
+    if ( n == 0 .and. s == 0 ) then
+      ampm = 'Noon'
+    else
+      ampm = 'PM'
+    end if
+  else
+    h = h - 12
+    if ( h < 12 ) then
+      ampm = 'PM'
+    else if ( h == 12 ) then
+      if ( n == 0 .and. s == 0 ) then
+        ampm = 'Midnight'
+      else
+        ampm = 'AM'
+      end if
+    end if
+  end if
+
+  write ( *, '(i2.2,1x,a,1x,i4,2x,i2,a1,i2.2,a1,i2.2,a1,i3.3,1x,a)' ) &
+    d, trim ( month(m) ), y, h, ':', n, ':', s, '.', mm, trim ( ampm )
+
+  return
+end


### PR DESCRIPTION
Several test cases download from https://people.math.sc.edu/Burkardt/f_src/mpi/mpi.html

Managed to make `wave_mpi` and `poisson_nonblock_mpi` to run a much longer time by changing some parameters.

Not user how to make `quad_mpi` `day1_mp` to run longer, I don't want to use `sleep` which I think will hide potential issues, how about simply add more loops to do the same thing again and again?