### PR TITLE
Log value instead of pointer in MPI_Cart_shift

### DIFF
--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
@@ -129,7 +129,7 @@ USER_DEFINED_WRAPPER(int, Cart_shift, (MPI_Comm) comm, (int) direction,
   RETURN_TO_UPPER_HALF();
   if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     LOG_CALL(restoreCarts, Cart_shift, comm, direction,
-             disp, rank_source, rank_dest);
+             disp, *rank_source, *rank_dest);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;


### PR DESCRIPTION
When testing `poisson_nonblock_mpi`, we saw following error when restart:
```
[40000] ERROR at record-replay.cpp:649 in restoreCartShift; REASON='JASSERT(oldsrc == rank_source && olddest == rank_dest) failed'
     oldsrc = -42144
     olddest = -42140
     rank_source = -1
     rank_dest = 1
Message: Different ranks
poisson_nonblock_mpi.mana.exe (40000): Terminating...
```

It turns out it's because MANA records the pointer instead of the real value.

BTW, I also saw this in the code:

```
  if (retval == MPI_SUCCESS) {
    // FIXME: Virtualize rank?
    int oldsrc = rec.args(3);
    int olddest = rec.args(4);
    JASSERT(oldsrc == rank_source && olddest == rank_dest)
           (oldsrc)(olddest)(rank_source)(rank_dest).Text("Different ranks");
  }
```

Looked at the `FIXME`, wondering is it possible the ranks change after C/R? Even we do, will this be a problem? 