### PR TITLE
Test env var DEFINE_mpi_collective_p2p & re-build

### DIFF
--- a/contrib/mpi-proxy-split/mpi-wrappers/Makefile
+++ b/contrib/mpi-proxy-split/mpi-wrappers/Makefile
@@ -35,7 +35,13 @@ override CXXFLAGS += -g3 -O0 -fPIC -I${DMTCP_INCLUDE} -I${JALIB_INCLUDE} \
 # We don't build libmpiwrappers.a.  Instead, we use *.o to build libmana.so.
 default: ${LIBNAME}.a libmpidummy.so
 
+# If any .o file is re-built, then re-build mpi_collective_wrappers.o .
+# That recipe will test the environment variable: DEFINE_mpi_collective_p2p
+# If the env. var. is set, then the Makefile will cause
+#   mpi_collective_wrappers.cpp to include mpi_collective_p2p.c .
 ${LIBNAME}.a: ${LIBWRAPPER_OBJS}
+	touch mpi_collective_wrappers.cpp
+	${MAKE} mpi_collective_wrappers.o
 	ar cr $@ $^
 
 mpi_unimplemented_wrappers.cpp: generate-mpi-unimplemented-wrappers.py \
@@ -53,8 +59,12 @@ fortran_constants.o: fortran_constants.f90
 
 mpi_collective_wrappers.o: mpi_collective_wrappers.cpp ../virtual-ids.h \
                            mpi_collective_p2p.c
-	${MPICXX} ${CXXFLAGS} -Wall -g3 -O0 -DDEBUG -fPIC -I../../../include \
-	-I../../../jalib -I.. -I../../../src -I../lower-half -std=c++11 -c $<
+	if [ ! -z "$$MPI_COLLECTIVE_P2P" ]; then \
+	  DEFINE_mpi_collective_p2p="-DMPI_COLLECTIVE_P2P"; \
+	fi && \
+	${MPICXX} ${CXXFLAGS} -Wall -g3 -O0 -DDEBUG \
+	  $$DEFINE_mpi_collective_p2p -fPIC -I../../../include \
+	  -I../../../jalib -I.. -I../../../src -I../lower-half -std=c++11 -c $<
 
 # Some of these functions are also collective; e.g., MPI_Win_allocate_shared
 mpi_win_wrappers.o: mpi_win_wrappers.cpp ../virtual-ids.h

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -34,7 +34,6 @@
 #include "p2p_log_replay.h"
 #include "p2p_drain_send_recv.h"
 
-#define MPI_COLLECTIVE_P2P
 #ifdef MPI_COLLECTIVE_P2P
 # include "mpi_collective_p2p.c"
 #endif

--- a/manpages/mana.1
+++ b/manpages/mana.1
@@ -1,5 +1,5 @@
 '\" t
-.\" Manual page created with latex2man on Sun Jun 20 15:09:00 2021
+.\" Manual page created with latex2man on Thu Mar 10 05:08:52 2022
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +10,7 @@
 
 .fi
 ..
-.TH "MANA" "1" "20 June 2021" "MPI\-Agnostic Netw.\-Agnostic Ckpt " "MPI\-Agnostic Netw.\-Agnostic Ckpt "
+.TH "MANA" "1" "10 March 2022" "MPI\-Agnostic Netw.\-Agnostic Ckpt " "MPI\-Agnostic Netw.\-Agnostic Ckpt "
 .SH NAME
 
 \fBmana\fP
@@ -133,6 +133,13 @@ inside mtcp/mtcp_restart.c shortly before calling splitProcess()
  DMTCP/MANA will 
 pause during restart, before resuming execution, to allow `gdb 
 attach\&' (GDB must be on same node.) 
+.TP
+\fBDEFINE_mpi_collective_p2p\fP
+ For debugging only (high 
+runtime overhead): If this env. var. is set, and if re\-building 
+any files in contrib/mpi\-proxy\-split/mpi\-wrappers, then MPI 
+collective communication calls are translated to MPI_Send/Recv 
+at runtime. (Try \&'touch mpi_collective_p2p.c\&' if not re\-building.) 
 .PP
 To see status of ranks (especially during checkpoint), try: 
 .Vb

--- a/manpages/mana.latex2man
+++ b/manpages/mana.latex2man
@@ -85,6 +85,11 @@ the last checkpoint.
     \item[\Opt{DMTCP_RESTART_PAUSE}] DMTCP/MANA will
 	pause during restart, before resuming execution, to allow `gdb
 	attach' (GDB must be on same node.)
+    \item[\Opt{DEFINE_mpi_collective_p2p}] For debugging only (high
+	runtime overhead): If this env. var. is set, and if re-building
+	any files in contrib/mpi-proxy-split/mpi-wrappers, then MPI
+	collective communication calls are translated to MPI_Send/Recv
+	at runtime. (Try 'touch mpi_collective_p2p.c' if not re-building.)
 \end{Description}
 To see status of ranks (especially during checkpoint), try:
 \begin{verbatim}


### PR DESCRIPTION
This commit supports the `DEFINE_mpi_collective_p2p` environment variable.  When it is set, and if re-building any files in   `contrib/mpi-proxy-split/mpi-wrapper`, then it will include `contrib/mpi-proxy-split/mpi-wrapper/mpi_collective_p2p.c` when building.  At runtime, this will translate MPI collective communication calls to MPI_Send/Recv. 

Please test this PR on Cori, when you review it.  I haven't done enough testing of the various cases.

