### PR TITLE
[MANA-77] Fix ip command not found bug in configure-mana

### DIFF
--- a/configure-mana
+++ b/configure-mana
@@ -1,13 +1,13 @@
 #!/bin/sh
 
 # These optional autoconf variables will be configured
-#     via contrib/mpi-proxy-split/Makefie_config.in
+#     via contrib/mpi-proxy-split/Makefile_config.in
 
 # Do not add spaces to the next two lines.
 # If MPI will be used on a different computer than where you configure,
 #   then maybe replace this with the result of 'ip addr' on the compute nodes.
 MPI_ETHERNET_INTERFACE=\
-`ip addr |grep -B1 link/ether | head -1 |sed -e 's%[^ ]*: \([^ ]*\): .*%\1%'`
+`PATH=$PATH:/usr/sbin ip addr |grep -B1 link/ether | head -1 |sed -e 's%[^ ]*: \([^ ]*\): .*%\1%'`
 
 # Note: modify this path according to your environment.
 if [[ -z "${MPI__INSTALL_DIR}" ]]; then


### PR DESCRIPTION
This pull request fixes a bug where the `ip` command cannot be found in the default path for root users by adding `/usr/sbin` to the path temporarily while executing the script.