### PR TITLE
Enable deterministic point-to-point mode

### DIFF
--- a/contrib/mpi-proxy-split/Makefile
+++ b/contrib/mpi-proxy-split/Makefile
@@ -100,6 +100,8 @@ ${DMTCP_ROOT}/bin/lh_proxy:
 	make -C ${LOWER_HALF_SRCDIR} install
 ${DMTCP_ROOT}/bin/gethostbyname_proxy:
 	make -C ${LOWER_HALF_SRCDIR}/gethostbyname-static install
+${DMTCP_ROOT}/bin/mana_p2p_update_logs: ${WRAPPERS_SRCDIR}/mana_p2p_update_logs.c
+	make -C ${WRAPPERS_SRCDIR} install
 
 # ${WRAPPERS_SRCDIR}/libmpiwrappers.a ia a prerequisite for libmana.so,
 #   which is a prerequisite for ${DMTCP_ROOT}/lib/dmtcp/libmana.so
@@ -111,6 +113,7 @@ install: ${MANA_COORD_OBJS}
 	make ${DMTCP_ROOT}/lib/dmtcp/libmpidummy.so
 	make ${DMTCP_ROOT}/bin/lh_proxy
 	make ${DMTCP_ROOT}/bin/gethostbyname_proxy
+	make ${DMTCP_ROOT}/bin/mana_p2p_update_logs
 
 tidy:
 	rm -f *~ .*.swp dmtcp_restart_script*.sh ckpt_*.dmtcp

--- a/contrib/mpi-proxy-split/mpi-wrappers/Makefile
+++ b/contrib/mpi-proxy-split/mpi-wrappers/Makefile
@@ -18,6 +18,7 @@ LIBWRAPPER_OBJS = mpi_p2p_wrappers.o mpi_collective_wrappers.o \
                   mpi_unimplemented_wrappers.o mpi_fortran_wrappers.o \
                   mpi_wrappers.o get_fortran_constants.o fortran_constants.o \
 		  mpi_win_wrappers.o \
+		  p2p-deterministic.o
 
 # Modify if your DMTCP_ROOT is located elsewhere.
 ifndef DMTCP_ROOT
@@ -51,7 +52,17 @@ mpi_unimplemented_wrappers.cpp: generate-mpi-unimplemented-wrappers.py \
 .c.o:
 	${MPICC} ${CFLAGS} -g3 -O0 -c -o $@ $<
 
+mana_p2p_update_logs: mana_p2p_update_logs.c
+	${MPICC} ${CFLAGS} -g3 -O0 -o $@ $<
+
 .cpp.o: ../virtual-ids.h
+	${MPICXX} ${CXXFLAGS} -g3 -O0 -c -o $@ $<
+
+p2p-deterministic.h: p2p-deterministic.txt p2p-deterministic.py
+	./p2p-deterministic.py $< > $@
+mpi_p2p_wrappers.o: mpi_p2p_wrappers.cpp p2p-deterministic.h
+	${MPICXX} ${CXXFLAGS} -g3 -O0 -c -o $@ $<
+mpi_request_wrappers.o: mpi_request_wrappers.cpp p2p-deterministic.h
 	${MPICXX} ${CXXFLAGS} -g3 -O0 -c -o $@ $<
 
 fortran_constants.o: fortran_constants.f90
@@ -110,7 +121,7 @@ tidy:
 	rm -f *~ .*.swp dmtcp_restart_script*.sh ckpt_*.dmtcp
 	rm -rf ckpt_rank_*
 
-install: libmpidummy.so
+install: libmpidummy.so mana_p2p_update_logs
 	cp -f libmpidummy.so ${DMTCP_ROOT}/lib/dmtcp/
 	cd ${DMTCP_ROOT}/lib/dmtcp && \
 		ln -sf libmpidummy.so libmpich_intel.so.3.0.1 && \
@@ -118,6 +129,7 @@ install: libmpidummy.so
 	cd ${DMTCP_ROOT}/lib/dmtcp && \
 		ln -sf libmpidummy.so libpmi.so.0.5.0 && \
 		ln -sf libpmi.so.0.5.0 libpmi.so.0
+	cp -f mana_p2p_update_logs ${DMTCP_ROOT}/bin/
 
 clean: tidy
 	rm -f ${LIBWRAPPER_OBJS}

--- a/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
@@ -1,0 +1,78 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <mpi.h>
+// To support MANA_P2P_LOG and MANA_P2P_REPLAY:
+#define USE_READALL
+#define USE_WRITEALL
+#include "p2p-deterministic.h"
+
+void fill_in_log(struct p2p_log_msg *p2p_log);
+
+int main() {
+  char buf[100];
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  snprintf(buf, sizeof(buf)-1, P2P_LOG_MSG, rank);
+  int fd_log = open(buf, O_RDWR);
+  if (fd_log == -1) {
+    perror("get_next_msg: open");
+    fprintf(stderr, "rank: %d\n", rank); fflush(stdout);
+    exit(1);
+  }
+
+  while (1) {
+    struct p2p_log_msg p2p_log;
+    off_t offset = lseek(fd_log, 0, SEEK_CUR);
+    int rc = readall(fd_log, &p2p_log, sizeof(p2p_log));
+    if (rc == 0) {
+      break;
+    }
+    if (p2p_log.request != MPI_REQUEST_NULL) {
+      fill_in_log(&p2p_log);
+    }
+    lseek(fd_log, offset, SEEK_SET);
+    writeall(fd_log, &p2p_log, sizeof(p2p_log));
+  }
+
+  return 0;
+}
+
+void fill_in_log(struct p2p_log_msg *p2p_log) {
+  static int fd_request = -2;
+  if (fd_request == -2) {
+    char buf[100];
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    snprintf(buf, sizeof(buf)-1, P2P_LOG_REQUEST, rank);
+    fd_request = open(buf, O_RDONLY);
+    if (fd_request == -1) {
+      perror("update_requests: get next msg: open");
+      exit(1);
+    }
+  }
+
+  static off_t request_start = 0;
+  struct p2p_log_request p2p_request;
+  int fd2 = dup(fd_request);
+  while (1) {
+    readall(fd2, &p2p_request, sizeof(p2p_request));
+    if (p2p_request.request == p2p_log->request) {
+      p2p_log->source = p2p_request.source;
+      p2p_log->tag = p2p_request.tag;
+      p2p_log->request = MPI_REQUEST_NULL;
+      break;
+    }
+  }
+  close(fd2);
+  fd2 = dup(fd_request);
+  while (1) {
+    readall(fd2, &p2p_request, sizeof(p2p_request));
+    if (p2p_request.request == MPI_REQUEST_NULL) {
+      readall(fd_request, &p2p_request, sizeof(p2p_request));
+    }
+  }
+}

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
@@ -32,6 +32,8 @@
 #include "mpi_nextfunc.h"
 #include "virtual-ids.h"
 #include "record-replay.h"
+// To support MANA_P2P_LOG and MANA_P2P_REPLAY:
+#include "p2p-deterministic.h"
 
 USER_DEFINED_WRAPPER(int, Send,
                      (const void *) buf, (int) count, (MPI_Datatype) datatype,
@@ -166,6 +168,7 @@ USER_DEFINED_WRAPPER(int, Irecv,
   size = size * count;
 
   DMTCP_PLUGIN_DISABLE_CKPT();
+  LOG_PRE_Irecv(&status);
   if (isBufferedPacket(source, tag, comm, &flag, &status)) {
     consumeBufferedPacket(buf, count, datatype, source, tag, comm,
                           &status, size);
@@ -189,6 +192,7 @@ USER_DEFINED_WRAPPER(int, Irecv,
     logRequestInfo(*request, IRECV_REQUEST);
 #endif
   }
+  LOG_POST_Irecv(source,tag,comm,&status,request);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -32,6 +32,8 @@
 #include "mpi_plugin.h"
 #include "mpi_nextfunc.h"
 #include "virtual-ids.h"
+// To support MANA_P2P_LOG and MANA_P2P_REPLAY:
+#include "p2p-deterministic.h"
 
 int MPI_Test_internal(MPI_Request *request, int *flag, MPI_Status *status,
                       bool isRealRequest)
@@ -233,11 +235,14 @@ USER_DEFINED_WRAPPER(int, Iprobe,
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
+  LOG_PRE_Iprobe(status);
 
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Iprobe)(source, tag, realComm, flag, status);
   RETURN_TO_UPPER_HALF();
+  LOG_POST_Iprobe(source,tag,comm,status,request);
+  REPLAY_POST_Iprobe(count,datatype,source,tag,comm,status);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
@@ -1,0 +1,169 @@
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <mpi.h>
+// To support MANA_P2P_LOG and MANA_P2P_REPLAY:
+//   Define USE_READALL/WRITEALL if using readall/writeall.
+#define USE_READALL
+#define USE_WRITEALL
+#include "p2p-deterministic.h"
+
+/**********************************************************************************
+ * USAGE (workflow):
+ *   MANA_P2P_LOG=1 mana_launch -i SECONDS ... mpi_executable
+ *   # Allow MANA to continue executing for a minute or two after checkpointing
+ *   # MANA will then complete any pending requests, and use that information
+ *   #   to replace MPI_ANY_TAG/SOURCE by the actual tag and source that were used.
+ *   # This creates the files "p2p_log_%d.txt" and "p2p_log_request_%d.txt"
+ *   # The file "p2p_log_%d.txt" logs each msg received by MPI_Irecv.
+ *   # The file "p2p_log_request_%d.txt" logs the status of each request
+ *   #   completed by MPI_Wait or MPI_Test.
+ *   # FIXME:  Note that MPI_Waitsome/Waitany/Waitall are not handled yet.
+ *   mpirun mana_p2p_update_logs
+ *   MANA_P2P_REPLAY=1 mana_restart ... --restartdir ./DIR
+ *   # OR:
+ *   MANA_P2P_REPLAY=1 mana_launch ... mpi_executable
+ **********************************************************************************/
+
+/***********************************************************
+ * Utilities for point-to-point deterministic log-and-replay
+ ***********************************************************/
+
+static struct p2p_log_msg next_msg_entry;
+static struct p2p_log_msg *next_msg = NULL;
+
+void p2p_log(int count, MPI_Datatype datatype, int source, int tag,
+             MPI_Comm comm, MPI_Status *status, MPI_Request *request) {
+  if (status) {
+    source = status->MPI_SOURCE;
+    tag = status->MPI_TAG;
+    int count;
+    MPI_Get_count(status, MPI_CHAR, &count);
+    datatype = MPI_CHAR;
+  }
+  set_next_msg(count, datatype, source, tag, comm, NULL, request);
+}
+
+void initialize_next_msg(int fd) {
+  next_msg = &next_msg_entry;
+  readall(fd, next_msg, sizeof(*next_msg));
+}
+
+int iprobe_next_msg(struct p2p_log_msg *p2p_msg) {
+  /* FIXME:  This isn't comiling yet.
+  if (!next_msg) {
+    initialize_next_msg(fd);
+  }
+  */
+  if (p2p_msg) {
+    *p2p_msg = next_msg_entry;
+  }
+  return (next_msg_entry.comm != MPI_COMM_NULL);
+}
+
+void get_next_msg(struct p2p_log_msg *p2p_msg) {
+  static int fd = -2;
+  if (fd == -2) {
+    char buf[100];
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    snprintf(buf, sizeof(buf)-1, P2P_LOG_MSG, rank);
+    fd = open(buf, O_RDONLY);
+    if (fd == -1) {
+      perror("get_next_msg: open");
+      exit(1);
+    }
+  }
+  if (!next_msg) {
+    initialize_next_msg(fd);
+  }
+  *p2p_msg = next_msg_entry;
+  readall(fd, next_msg, sizeof(*next_msg));
+}
+
+
+// comm defined
+// Either status and request are non-null, or source, tag defined.
+void set_next_msg(int count, MPI_Datatype datatype,
+                  int source, int tag, MPI_Comm comm,
+                  MPI_Status *status, MPI_Request *request) {
+  struct p2p_log_msg p2p_msg;
+  static int fd = -2;
+  if (fd == -2) {
+    char buf[100];
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    snprintf(buf, sizeof(buf)-1, P2P_LOG_MSG, rank);
+    fd = open(buf, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+    if (fd == -1) {
+      perror("set_next_msg: open: couldn't create log file");
+      exit(1);
+    }
+  }
+  p2p_msg.count = count;
+  p2p_msg.datatype = datatype;
+  p2p_msg.source = source;
+  p2p_msg.tag = tag;
+  p2p_msg.comm = comm;
+  // request is NULL for MPI_Recv (no such arg), and for MPI_Wait (block until done)
+  // We save requests in a separate file.
+  p2p_msg.request = (request ? *request : MPI_REQUEST_NULL);
+  if (status != NULL) {
+    p2p_msg.source = status->MPI_SOURCE;
+    p2p_msg.tag = status->MPI_TAG;
+    if (status->MPI_ERROR) {
+      fprintf(stderr, "Recv with error:  %d\n", status->MPI_ERROR);
+      exit(1);
+    }
+  }
+  writeall(fd, &p2p_msg, sizeof(p2p_msg));
+  static int i = 100;
+  if (i-- == 0) {
+    fflush(stdout);
+    i = 100;
+  }
+}
+
+/* source and tag are INOUT parameters */
+void  p2p_replay(int count, MPI_Datatype datatype, int *source, int *tag,
+                 MPI_Comm comm) {
+  struct p2p_log_msg p2p_msg;
+  get_next_msg(&p2p_msg);
+  *source = p2p_msg.source;
+  *tag = p2p_msg.tag;
+  assert(comm = p2p_msg.comm);
+}
+
+/******************************
+ * Utilities for requests
+ ******************************/
+
+void save_request_info(MPI_Request *request, MPI_Status *status) {
+  struct p2p_log_request p2p_request;
+  static int fd = -2;
+  if (fd == -2) {
+    char buf[100];
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    snprintf(buf, sizeof(buf)-1, P2P_LOG_REQUEST, rank);
+    fd = open(buf, sizeof(buf)-1,
+              O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR );
+    if (fd == -1) {
+      perror("save_request_info: open: couldn't create request file");
+      exit(1);
+    }
+  }
+  p2p_request.source = status->MPI_SOURCE;
+  p2p_request.tag = status->MPI_TAG;
+  p2p_request.request = *request;
+  writeall(fd, &p2p_request, sizeof(p2p_request));
+  static int i = 10;
+  if (i-- == 0) {
+    fflush(stdout);
+    i = 10;
+  }
+}

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.py
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+import sys
+import os
+
+def macroize_line(line):
+  if "//" in line:
+    line = line.replace("//", "/*", 1) + " */"
+  n = max(0, 60 - len(line))
+  return line + n*" " + " \\"
+
+def macroize(lines):
+  in_macro = False
+  out = ["// *** THIS FILE IS AUTO-GENERATED! DO 'make' TO UPDATE. ***", ""]
+  lines = [line.rstrip() for line in lines]
+  for line in lines:
+    if not in_macro and line.startswith("#define ") and "(" in line:
+      in_macro = True
+      out.append(macroize_line(line))
+    elif not in_macro:
+      out.append(line)
+    elif in_macro and line.strip(): # if non-empty line of macro
+      out.append(macroize_line(line))
+    elif in_macro and not line.strip(): # if empty line of macro: end macro
+      out[-1] = out[-1][:-2].rstrip()  # Strip final " \\"
+      out.append("")
+      in_macro = False;
+  return "\n".join(out)
+
+if len(sys.argv) == 2 and os.path.isfile(sys.argv[1]) and \
+   os.access(sys.argv[1], os.R_OK):
+  print(macroize(open(sys.argv[1]).readlines()))
+else:
+  sys.stderr.write("macroize: Can't macroize; no such file or not readable\n" +
+                   "USAGE: macroize.py FILE\n")

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -1,0 +1,260 @@
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <mpi.h>
+
+#define P2P_LOG_MSG "p2p_log_%d.txt"
+#define P2P_LOG_REQUEST "p2p_log_request_%d.txt"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// This is an array in the order of the calls to MPI_Recv/MPI_Irecv
+struct p2p_log_msg {
+  int count;
+  MPI_Datatype datatype;
+  int source;
+  int tag;
+  int MPI_ERROR;
+  MPI_Comm comm; // comm == MPI_COMM_NULL if this logs a failed MPI_Iprobe
+  MPI_Request request;
+};
+struct p2p_log_request {
+  MPI_Request request;
+  int source;
+  int tag;
+};
+
+void p2p_log(int count, MPI_Datatype datatype, int source, int tag,
+             MPI_Comm comm, MPI_Status *status, MPI_Request *request);
+void get_next_msg(struct p2p_log_msg *p2p_msg);
+int iprobe_next_msg(struct p2p_log_msg *p2p_msg);
+void set_next_msg(int count, MPI_Datatype datatype,
+                  int source, int tag, MPI_Comm comm,
+                  MPI_Status *status, MPI_Request *request);
+
+#ifdef USE_READALL
+static
+ssize_t readall(int fd, void *buf, size_t count) {
+  ssize_t rc;
+  char *ptr = (char *)buf;
+  size_t num_read = 0;
+  for (num_read = 0; num_read < count;) {
+    rc = read(fd, ptr + num_read, count - num_read);
+    if (rc == -1 && (errno == EINTR || errno == EAGAIN)) {
+      continue;
+    } else if (rc == -1) {
+      return -1;
+    } else if (rc == 0) {
+      break;
+    } else { // else rc > 0
+      num_read += rc;
+    }
+  }
+  return num_read;
+}
+#endif
+
+#ifdef USE_WRITEALL
+static
+ssize_t writeall(int fd, void *buf, size_t count) {
+  const char *ptr = (const char *)buf;
+  size_t num_written = 0;
+  do {
+    ssize_t rc = write(fd, ptr + num_written, count - num_written);
+    if (rc == -1 && (errno == EINTR || errno == EAGAIN)) {
+      continue;
+    } else if (rc == -1) {
+      return rc;
+    } else if (rc == 0) {
+      break;
+    } else { // else rc > 0
+      num_written += rc;
+    }
+  } while (num_written < count);
+  return num_written;
+}
+#endif
+
+/*************************************
+ * LOG for MPI_Recv/Irecv/Probe/Iprobe
+ *************************************/
+
+// Before MPI_Recv during original launch/log
+// NOT USED:  MPI_Recv wrapper calls MPI_Irecv
+#define LOG_PRE_Recv(status)
+  MPI_Status local_status;
+  if (getenv("MANA_P2P_LOG") && status != MPI_STATUS_IGNORE) {
+    status = &local_status;
+  }
+
+// After MPI_Recv during original launch/log
+// NOT USED:  MPI_Recv wrapper calls MPI_Irecv
+#define LOG_POST_Recv(source,tag,comm,status,request)
+  if (getenv("MANA_P2P_LOG")) {
+    p2p_log(bytesRecvd, MPI_CHAR, source, tag, comm,
+            status, NULL /* no request */);
+  }
+
+// Before MPI_Irecv during original launch/log
+//   no status; nothing to do
+#define LOG_PRE_Irecv(status)
+
+// After MPI_Irecv during original launch/log
+#define LOG_POST_Irecv(source,tag,comm,status,request)
+  if (getenv("MANA_P2P_LOG")) {
+    // source and tag will be filled in later, based on request
+    // (count, datatype) will be replaced by (bytesRecvd, MPI_CHAR)
+    p2p_log(count, datatype, source, tag, comm, status, request);
+  }
+
+// Before MPI_Probe during original launch/log
+// NOT USED:  MPI_Probe wrapper calls MPI_Iprobe
+#define LOG_PRE_Probe(status)
+  MPI_Status local_status;
+  if (getenv("MANA_P2P_LOG") && status != MPI_STATUS_IGNORE) {
+    status = &local_status;
+  }
+
+// After MPI_Probe during original launch/log
+// NOT USED:  MPI_Probe wrapper calls MPI_Iprobe
+#define LOG_POST_Probe(source,tag,comm,status,request)
+  if (getenv("MANA_P2P_LOG")) {
+    p2p_log(count, MPI_CHAR, source, tag, comm, status, NULL /* no request */);
+  }
+
+// Before MPI_Iprobe during original launch/log
+#define LOG_PRE_Iprobe(status)
+  MPI_Status local_status;
+  if (getenv("MANA_P2P_LOG") && status != MPI_STATUS_IGNORE) {
+    status = &local_status;
+  }
+
+// After MPI_Iprobe during original launch/log
+#define LOG_POST_Iprobe(source,tag,comm,status,request)
+  if (getenv("MANA_P2P_LOG")) {
+    int bytesRecvd = -1;
+    if (*flag == 0) {
+      comm = MPI_COMM_NULL; // This implies MPI_Iprobe flag returned false
+    } else {
+      // FIXME:  p2p_log() does a lot of this.
+      MPI_Get_count(status, MPI_CHAR, &bytesRecvd); // Get count in bytes
+      source = status->MPI_SOURCE;
+      tag = status->MPI_TAG;
+    }
+    p2p_log(bytesRecvd, MPI_CHAR, source, tag, comm,
+            status, NULL /* no request */);
+  }
+
+/****************************************
+ * REPLAY for MPI_Recv/Irecv/Probe/Iprobe
+ ****************************************/
+
+// Before MPI_Recv during replay
+// NOT USED:  MPI_Recv wrapper calls MPI_Irecv
+#define REPLAY_PRE_Recv(count,datatype,source,tag,comm)
+  if (getenv("MANA_P2P_REPLAY")) {
+    p2p_replay(count, datatype, &source, &tag, comm);
+  }
+
+// Before call to MPI_Irecv() in lower half during replay
+// NOT USED:  MPI_Recv wrapper calls MPI_Irecv
+#define REPLAY_PRE_Irecv(count,datatype,source,tag,comm)
+  if (getenv("MANA_P2P_REPLAY") && !MPI_Iprobe_recurse) {
+    struct p2p_log_msg p2p_msg;
+    while (!iprobe_next_msg(NULL)) {
+      // consume messages where log says MPI_Iprobe: flag==0
+      get_next_msg(&p2p_msg);
+    } // Now log says MPI_Iprobe returned with flag==1
+    iprobe_next_msg(&p2p_msg);
+    assert(source == MPI_ANY_SOURCE || source == p2p_msg.source);
+    assert(tag == MPI_ANY_TAG || tag == p2p_msg.tag);
+    source = p2p_msg.source;
+    tag = p2p_msg.tag;
+  }
+
+// Before MPI_Probe during replay
+// NOT USED:  MPI_Probe wrapper calls MPI_Iprobe
+#define REPLAY_PRE_Probe(count,datatype,source,tag,comm)
+  if (getenv("MANA_P2P_REPLAY")) {
+    p2p_replay(count, datatype, &source, &tag, comm);
+  }
+
+// After call to MPI_Iprobe() in lower half during replay
+//   Make sure log is in sync with MPI_Iprobe again.
+#define REPLAY_POST_Iprobe(count,datatype,source,tag,comm,status)
+  int MPI_Iprobe_recurse = 0;
+  if (getenv("MANA_P2P_REPLAY") && !MPI_Iprobe_recurse) {
+    struct p2p_log_msg p2p_msg;
+    if (*flag != 0 || iprobe_next_msg(NULL)) { // There is a message.
+      while (!iprobe_next_msg(NULL)) {
+        // consume messages where log says MPI_Iprobe: flag==0
+        get_next_msg(&p2p_msg);
+      } // Now log says MPI_Iprobe returned with flag==1
+      // Call blocking probe until implicit *flag and log agree
+      assert(source == MPI_ANY_SOURCE || source == p2p_msg.source);
+      assert(tag == MPI_ANY_TAG || tag == p2p_msg.tag);
+      MPI_Iprobe_recurse = 1;
+      MPI_Probe(p2p_msg.source, p2p_msg.tag, p2p_msg.comm, status);
+      MPI_Iprobe_recurse = 0;
+      *flag = 1;
+    } else { // else: *flag == 0; log says MPI_Iprobe returned with flag==0
+      get_next_msg(&p2p_msg); // flag and log agree: consume this message
+      *flag = 0;
+    }
+  }
+
+/************************************************
+ * LOG for MPI_Wait/Test/Waitsome/Waitany/Waitall
+ ************************************************/
+
+// Before MPI_Wait, MPI_Test during log/launch
+// NOT USED:  MPI_Wait wrapper calls MPI_Test
+#define LOG_PRE_Wait(status)
+  MPI_Status local_status;
+  if (getenv("MANA_P2P_LOG") && status != MPI_STATUS_IGNORE) {
+    status = &local_status;
+  }
+
+#define LOG_PRE_Test(status) LOG_PRE_Wait(status)
+
+// After MPI_Wait, MPI_Test during log/launch
+// NOT USED:  MPI_Wait wrapper calls MPI_Test
+#define LOG_POST_Wait(request,status)
+  if (getenv("MANA_P2P_LOG")) {
+    if (flag) {
+      save_request_info(request, status);
+    }
+  }
+
+#define LOG_POST_Test(request,status) LOG_POST_Wait(request,status)
+
+// FIXME:  Add MPI_Waitsome/MPI_Waitany/MPI_Waitall
+//         Also, need to take account of MPI_STATUSES_IGNORE
+
+/************************************************
+ * REPLAY for MPI_Wait/Test/Waitsome/Waitany/Waitall
+ ************************************************/
+
+// FIXME:  Are these needed for REPLAY for MPI_Wait and MPI_Test?
+// Before MPI_Wait, MPI_Test during replay
+#define REPLAY_PRE_Wait(status)
+  MPI_Status local_status;
+  if (getenv("MANA_P2P_LOG") && status != MPI_STATUS_IGNORE) {
+    status = &local_status;
+  }
+
+#define REPLAY_PRE_Test(status) REPLAY_PRE_Wait(status)
+
+// FIXME:  Add MPI_Waitsome/MPI_Waitany/MPI_Waitall
+//         Also, need to take account of MPI_STATUSES_IGNORE
+
+#if defined(__cplusplus)
+} // For: extern "C" {
+#endif

--- a/manpages/mana.1
+++ b/manpages/mana.1
@@ -1,5 +1,5 @@
 '\" t
-.\" Manual page created with latex2man on Thu Mar 10 05:08:52 2022
+.\" Manual page created with latex2man on Wed Mar 23 02:36:27 2022
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +10,7 @@
 
 .fi
 ..
-.TH "MANA" "1" "10 March 2022" "MPI\-Agnostic Netw.\-Agnostic Ckpt " "MPI\-Agnostic Netw.\-Agnostic Ckpt "
+.TH "MANA" "1" "23 March 2022" "MPI\-Agnostic Netw.\-Agnostic Ckpt " "MPI\-Agnostic Netw.\-Agnostic Ckpt "
 .SH NAME
 
 \fBmana\fP
@@ -140,6 +140,24 @@ runtime overhead): If this env. var. is set, and if re\-building
 any files in contrib/mpi\-proxy\-split/mpi\-wrappers, then MPI 
 collective communication calls are translated to MPI_Send/Recv 
 at runtime. (Try \&'touch mpi_collective_p2p.c\&' if not re\-building.) 
+.TP
+\fBMANA_P2P_LOG"\fP
+ For debugging: Set this before mana_launch
+in order to log the order of point\-to\-point 
+calls (MPI_Send and family) for later deterministic replay. See 
+details at top of contrib/mpi\-proxy\-split/mpi\-wrappers/p2p\-deterministic.c 
+(IMPORTANT: If you checkpoint, continue running for a few minutes 
+after that, for final updating of the log files.) 
+.TP
+\fBMANA_P2P_REPLAY"\fP
+ For debugging: If a checkpoint was created 
+with MANA_P2P_LOG,
+then execute mana_p2p_update_logs
+and set this variable before mana_restart\&.
+(Currently, 
+you need to set this before mana_launch,
+but this may be 
+fixed later.) 
 .PP
 To see status of ranks (especially during checkpoint), try: 
 .Vb

--- a/manpages/mana.latex2man
+++ b/manpages/mana.latex2man
@@ -90,6 +90,17 @@ the last checkpoint.
 	any files in contrib/mpi-proxy-split/mpi-wrappers, then MPI
 	collective communication calls are translated to MPI_Send/Recv
 	at runtime. (Try 'touch mpi_collective_p2p.c' if not re-building.)
+    \item[\Opt{MANA_P2P_LOG"}] For debugging:  Set this before \texttt{mana_launch}
+	in order to log the order of point-to-point
+	calls (MPI_Send and family) for later deterministic replay.  See
+	details at top of contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
+	(IMPORTANT:  If you checkpoint, continue running for a few minutes
+	after that, for final updating of the log files.)
+    \item[\Opt{MANA_P2P_REPLAY"}] For debugging:  If a checkpoint was created
+	with \texttt{MANA_P2P_LOG}, then execute \texttt{mana_p2p_update_logs}
+	and set this variable before \texttt{mana_restart}.  (Currently,
+	you need to set this before \texttt{mana_launch}, but this may be
+	fixed later.)
 \end{Description}
 To see status of ranks (especially during checkpoint), try:
 \begin{verbatim}


### PR DESCRIPTION
This should be useful for debugging.  For example, using collectiveToP2P and this mode, we can deterministically do the same thing between ckpt-resume and ckpt-restart.  This should give us information on the cause of the bit-for-bit reproducibility bug.

 * env. var. MANA_P2P_LOG: Causes MANA to generate files
                            p2p_log_RANK.txt and p2p_log_request_RANK.txt
 * After checkpointing, call:  mpirun ./p2p-deterministic.py
     + On each rank, this will update p2p_log_RANK.txt.
     + The files p2p_log_request_RANK.txt are not needed after that.
 * env var MANA_P2P_REPLAY : Causes MANA to use p2p_log_%d.txt for determ. replay

Read `manpages/mana.1` or `manpages/mana.latex2man` for how to use it:  `MANA_P2P_LOG` and `MANA_P2P_REPLAY`.

_This compiles correctly.  It's even possible that it now works.  Has someone tested it?  Otherwise, I'll test on Cori when I have a chance._
