### PR TITLE
Change the hash function to avoid collision

### DIFF
--- a/contrib/mpi-proxy-split/virtual-ids.h
+++ b/contrib/mpi-proxy-split/virtual-ids.h
@@ -309,7 +309,7 @@ namespace dmtcp_mpi
         MPI_Allgather(&worldRank, 1, MPI_INT, rbuf, 1, MPI_INT, comm);
 #endif
         for (int i = 0; i < commSize; i++) {
-          gid ^= hash(rbuf[i]);
+          gid ^= hash(rbuf[i] + 1);
         }
         // FIXME: We assume the hash collision between communicators who
         // have different members is low.


### PR DESCRIPTION
We hash each rank number of the communicator and combine them with XOR to get the global comm id. If the list of rank numbers starts with rank 0, then the result will be the same as the communicator without rank 0. For example, communicator (0, 1) and communicator (1) will have the same global comm id. This is because the hash function multiplies the rank number with an expression. So hash(0) = 0. and any number XOR 0 is the number itself. Maybe because of the implementation of Cray MPICH, if the rank number list contains 0, it's always the first one.

With the original two-phase-commit algorithm, this collision may not cause any bug. However, the sequence number algorithm is very sensitive to any collision in the hash function. When a collision happens, the sequence number is no longer accurate and will hang because of the wrong target sequence number. 