### PR TITLE
Fix MPI_Alltoall_internal symbol lookup error in libmana.so

### DIFF
--- a/contrib/mpi-proxy-split/p2p_drain_send_recv.cpp
+++ b/contrib/mpi-proxy-split/p2p_drain_send_recv.cpp
@@ -31,7 +31,11 @@
 #include "mpi_nextfunc.h"
 #include "virtual-ids.h"
 
+#ifdef MPI_COLLECTIVE_P2P
 extern "C" int MPI_Alltoall_internal(const void *sendbuf, int sendcount,
+#else
+extern int MPI_Alltoall_internal(const void *sendbuf, int sendcount,
+#endif
                                  MPI_Datatype sendtype, void *recvbuf,
                                  int recvcount, MPI_Datatype recvtype,
                                  MPI_Comm comm);


### PR DESCRIPTION
This pull request fixes a bug in `libmana.so` where `MPI_Alltoall_internal` couldn't be found if `MPI_COLLECTIVE_P2P` is not defined.