### PR TITLE
Fix python not being found on CentOS 8 Stream

### DIFF
--- a/contrib/mpi-proxy-split/mpi-wrappers/Makefile
+++ b/contrib/mpi-proxy-split/mpi-wrappers/Makefile
@@ -32,12 +32,6 @@ override CXXFLAGS += -g3 -O0 -fPIC -I${DMTCP_INCLUDE} -I${JALIB_INCLUDE} \
                      -I${PLUGIN_HALF_SRCDIR} -I${DMTCP_ROOT}/src \
                      -I${LOWER_HALF_SRCDIR} -std=c++11
 
-ifeq ($(shell which python),python)
-  PYTHON = python
-else
-  PYTHON = python3
-endif
-
 # We don't build libmpiwrappers.a.  Instead, we use *.o to build libmana.so.
 default: ${LIBNAME}.a libmpidummy.so
 
@@ -52,7 +46,7 @@ ${LIBNAME}.a: ${LIBWRAPPER_OBJS}
 
 mpi_unimplemented_wrappers.cpp: generate-mpi-unimplemented-wrappers.py \
 	mpi_unimplemented_wrappers.txt
-	$(PYTHON) $^ > $@
+	python3 $^ > $@
 
 .c.o:
 	${MPICC} ${CFLAGS} -g3 -O0 -c -o $@ $<
@@ -84,7 +78,7 @@ mpi_dummy_wrappers.c: generate-mpi-dummy-wrappers.py mpi_dummy_wrappers.txt
 	tmp=$@.tmp.$$$$ ; \
 	printf "%s\n\n" \
 	 "// *** THIS FILE IS AUTO-GENERATED! DO 'make' TO UPDATE. ***" >$$tmp;\
-	$(PYTHON) $^ >> $$tmp && mv -f $$tmp $@ || (rm -f $$tmp && false)
+	python3 $^ >> $$tmp && mv -f $$tmp $@ || (rm -f $$tmp && false)
 
 mpi_fortran_wrappers.cpp: generate-mpi-fortran-wrappers.py \
                           mpi_fortran_wrappers.txt
@@ -92,7 +86,7 @@ mpi_fortran_wrappers.cpp: generate-mpi-fortran-wrappers.py \
 	tmp=$@.tmp.$$$$ ; \
 	printf "%s\n\n" \
 	 "// *** THIS FILE IS AUTO-GENERATED! DO 'make' TO UPDATE. ***" >$$tmp;\
-	$(PYTHON) $^ >> $$tmp && mv -f $$tmp $@ || (rm -f $$tmp && false)
+	python3 $^ >> $$tmp && mv -f $$tmp $@ || (rm -f $$tmp && false)
 
 mpi_dummy_wrappers.o: mpi_dummy_wrappers.c
 	${MPICC} ${CFLAGS} -g3 -O0 -c -o $@ $<

--- a/contrib/mpi-proxy-split/mpi-wrappers/Makefile
+++ b/contrib/mpi-proxy-split/mpi-wrappers/Makefile
@@ -32,6 +32,12 @@ override CXXFLAGS += -g3 -O0 -fPIC -I${DMTCP_INCLUDE} -I${JALIB_INCLUDE} \
                      -I${PLUGIN_HALF_SRCDIR} -I${DMTCP_ROOT}/src \
                      -I${LOWER_HALF_SRCDIR} -std=c++11
 
+ifeq ($(shell which python),python)
+  PYTHON = python
+else
+  PYTHON = python2.7
+endif
+
 # We don't build libmpiwrappers.a.  Instead, we use *.o to build libmana.so.
 default: ${LIBNAME}.a libmpidummy.so
 
@@ -46,7 +52,7 @@ ${LIBNAME}.a: ${LIBWRAPPER_OBJS}
 
 mpi_unimplemented_wrappers.cpp: generate-mpi-unimplemented-wrappers.py \
 	mpi_unimplemented_wrappers.txt
-	python $^ > $@
+	$(PYTHON) $^ > $@
 
 .c.o:
 	${MPICC} ${CFLAGS} -g3 -O0 -c -o $@ $<
@@ -78,7 +84,7 @@ mpi_dummy_wrappers.c: generate-mpi-dummy-wrappers.py mpi_dummy_wrappers.txt
 	tmp=$@.tmp.$$$$ ; \
 	printf "%s\n\n" \
 	 "// *** THIS FILE IS AUTO-GENERATED! DO 'make' TO UPDATE. ***" >$$tmp;\
-	python $^ >> $$tmp && mv -f $$tmp $@ || (rm -f $$tmp && false)
+	$(PYTHON) $^ >> $$tmp && mv -f $$tmp $@ || (rm -f $$tmp && false)
 
 mpi_fortran_wrappers.cpp: generate-mpi-fortran-wrappers.py \
                           mpi_fortran_wrappers.txt
@@ -86,7 +92,7 @@ mpi_fortran_wrappers.cpp: generate-mpi-fortran-wrappers.py \
 	tmp=$@.tmp.$$$$ ; \
 	printf "%s\n\n" \
 	 "// *** THIS FILE IS AUTO-GENERATED! DO 'make' TO UPDATE. ***" >$$tmp;\
-	python $^ >> $$tmp && mv -f $$tmp $@ || (rm -f $$tmp && false)
+	$(PYTHON) $^ >> $$tmp && mv -f $$tmp $@ || (rm -f $$tmp && false)
 
 mpi_dummy_wrappers.o: mpi_dummy_wrappers.c
 	${MPICC} ${CFLAGS} -g3 -O0 -c -o $@ $<

--- a/contrib/mpi-proxy-split/mpi-wrappers/Makefile
+++ b/contrib/mpi-proxy-split/mpi-wrappers/Makefile
@@ -35,7 +35,7 @@ override CXXFLAGS += -g3 -O0 -fPIC -I${DMTCP_INCLUDE} -I${JALIB_INCLUDE} \
 ifeq ($(shell which python),python)
   PYTHON = python
 else
-  PYTHON = python2.7
+  PYTHON = python3
 endif
 
 # We don't build libmpiwrappers.a.  Instead, we use *.o to build libmana.so.

--- a/doc/mana-centos-tutorial.txt
+++ b/doc/mana-centos-tutorial.txt
@@ -261,11 +261,6 @@ e. Download and install mpich
   $ ./configure
   $ make -j install
 
-We will also call `python` in the build process. Since Python is generally not
-forward compatible, it's safer to install python2.7.
-
-  $ dnf install -y python2
-
 2. Installing the MANA directory and compiling MANA
 In this tutorial, we'll install MANA in the home directory.
   $ cd $HOME

--- a/doc/mana-centos-tutorial.txt
+++ b/doc/mana-centos-tutorial.txt
@@ -15,6 +15,7 @@ existing packages on your machine.
   $ yum groupinstall 'Development Tools'
   $ yum install -y mlocate vim wget
   $ yum install -y centos-release-scl
+  $ yum install -y python3
   $ yum install -y devtoolset-8-gcc devtoolset-8-gcc-c++ glibc-static.x86_64
   $ echo 'source scl_source enable devtoolset-8' >> ~/.bashrc
   $ source ~/.bashrc

--- a/doc/mana-centos-tutorial.txt
+++ b/doc/mana-centos-tutorial.txt
@@ -261,11 +261,10 @@ e. Download and install mpich
   $ ./configure
   $ make -j install
 
-We will also call `python` in the build process.
+We will also call `python` in the build process. Since Python is generally not
+forward compatible, it's safer to install python2.7.
 
   $ dnf install -y python2
-  $ cd /usr/bin
-  $ ln -s python2.7 python
 
 2. Installing the MANA directory and compiling MANA
 In this tutorial, we'll install MANA in the home directory.


### PR DESCRIPTION
This pull request updates the instances of `python` in MANA to `python3` instead, motivated by the `python` command not being found on CentOS 8 Stream (it doesn't have a default `python`; instead the version has to be specified). This also adds Python 3 installation to the CentOS 7 tutorial.