### PR TITLE
Fix bug in commit 79bd117: affects collectiveToP2P

### DIFF
--- a/contrib/mpi-proxy-split/mpi-wrappers/Makefile
+++ b/contrib/mpi-proxy-split/mpi-wrappers/Makefile
@@ -61,6 +61,8 @@ mpi_collective_wrappers.o: mpi_collective_wrappers.cpp ../virtual-ids.h \
                            mpi_collective_p2p.c
 	if [ ! -z "$$MPI_COLLECTIVE_P2P" ]; then \
 	  DEFINE_mpi_collective_p2p="-DMPI_COLLECTIVE_P2P"; \
+	else \
+	  DEFINE_mpi_collective_p2p=""; \
 	fi && \
 	${MPICXX} ${CXXFLAGS} -Wall -g3 -O0 -DDEBUG \
 	  $$DEFINE_mpi_collective_p2p -fPIC -I../../../include \

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
@@ -662,11 +662,17 @@ int MPI_Iexscan(const void* sendbuf, void* recvbuf, int count,
 }
 #endif  // #ifdef ADD_UNDEFINED
 
+#if 0
+//FIXME:  Delete this, once we confirm it's not needed.  When MPI_COLLECTIVE_P2P is
+//        defined, the file p2p_drain_send_recv.cpp should call the C++ version
+//        of this, defined in mpi-wrappers/mpi_collective_wrappers.cpp.  (See the
+//        comment in the latter file.)  That is a call to the C++ version of
+//        MPI_Alltoall_internal.  So, this C version should never be used.
 // This routine is called from mpi-proxy-split/p2p_drain_send_recv.cpp.
 // The code in that file is invoked only at checkpoint time. It uses
 // MPI_Alltoall to drain any remaining Send/Recv messages.
 // So, it must not convert MPI_Alltoall_internal to use use point-to-point
-// communication. This is an excption that makes a collective call to the
+// communication. This is an exception that makes a collective call to the
 // lower half.
 int
 MPI_Alltoall_internal(const void *sendbuf, int sendcount,
@@ -685,6 +691,7 @@ MPI_Alltoall_internal(const void *sendbuf, int sendcount,
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
+#endif
 
 #ifdef __cplusplus
 } // end of: extern "C"

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -271,7 +271,15 @@ USER_DEFINED_WRAPPER(int, Reduce_scatter,
   };
   return twoPhaseCommit(comm, realBarrierCb);
 }
+#endif // #ifndef MPI_COLLECTIVE_P2P
 
+// NOTE:  This C++ function in needed by p2p_drain_send_recv.cpp
+//        both when MPI_COLLECTIVE_P2P is not defined and when it's defined.
+//        With MPI_COLLECTIVE_P2P, p2p_drain_send_recv.cpp will need this
+//        at checkpoint time, to make a direct call to the lower half, as part
+//        of draining the point-to-point MPI calls.  p2p_drain_send_recv.cpp
+//        cannot use the C version in mpi-wrappers/mpi_collective_p2p.c,
+//        which would generate extra point-to-point MPI calls.
 int
 MPI_Alltoall_internal(const void *sendbuf, int sendcount,
                       MPI_Datatype sendtype, void *recvbuf, int recvcount,
@@ -290,6 +298,7 @@ MPI_Alltoall_internal(const void *sendbuf, int sendcount,
   return retval;
 }
 
+#ifndef MPI_COLLECTIVE_P2P
 USER_DEFINED_WRAPPER(int, Alltoall,
                      (const void *) sendbuf, (int) sendcount,
                      (MPI_Datatype) sendtype, (void *) recvbuf, (int) recvcount,

--- a/contrib/mpi-proxy-split/p2p_drain_send_recv.cpp
+++ b/contrib/mpi-proxy-split/p2p_drain_send_recv.cpp
@@ -31,11 +31,7 @@
 #include "mpi_nextfunc.h"
 #include "virtual-ids.h"
 
-#ifdef MPI_COLLECTIVE_P2P
-extern "C" int MPI_Alltoall_internal(const void *sendbuf, int sendcount,
-#else
 extern int MPI_Alltoall_internal(const void *sendbuf, int sendcount,
-#endif
                                  MPI_Datatype sendtype, void *recvbuf,
                                  int recvcount, MPI_Datatype recvtype,
                                  MPI_Comm comm);


### PR DESCRIPTION
This fixes commit 79bd117 used in PR #72 (actually from an earlier PR, but the commit was later captured in feature/collectiveToP2P and merged into master).

The earlier commit made MANA work when `MPI_COLLECTIVE_P2P` was defined, but it stopped working when `MPI_COLLECTIVE_P2P` was not defined.  (The bug was that the commit implicitly assumed that the C and C++ symbols for `MPI_Alltoall_internal` were the same.)

In this version, we _only_ define the C++ version of `MPI_Alltoall_internal`, and it is available in `mpi-wrappers/mpi_collective_wrappers.cpp:MPI_Alltoall_internal`, independently of whether `MPI_COLLECTIVE_P2P` is defined or not.

===

This also fixes a bug in the attempt of PR #80 (commit 838aa20) to fix the earlier bug.  PR #80 would cause `p2p_drain_send_recv.cpp` to use the C version of `MPI_Alltoall_internal` when `MPI_COLLECTIVE_P2P` is defined.  But the C version of that function was going to generate extra point-to-point calls at checkpoint time, when `p2p_drain_send_recv.cpp` tries to drain the point-to-point calls.  So, checkpoint would fail for any MPI application with pending point-to-point calls in this situation.
    Also, I was seeing a problem with and undefined C symbol for  `MPI_Alltoall_internal`  when `MPI_COLLECTIVE_P2P` was not defined, but I've lost track of why by now.

===

@xuyao0127, @fyshhh , and @jungan, please check my logic on this.  I'm trying to fix commits that created this logic error.  And as part of this, I'm trying to also ensure that there's only one copy of `MPI_Alltoall_internal`!  This will avoid the logic traps that we fell into with the two preceding commits.