### PR TITLE
Handle variable number of lower-half's core regions

### DIFF
--- a/contrib/mpi-proxy-split/lower-half/lower_half_api.h
+++ b/contrib/mpi-proxy-split/lower-half/lower_half_api.h
@@ -32,6 +32,9 @@
 #define PAGE_SIZE              0x1000
 #define HUGE_PAGE              0x200000
 
+/* Maximum core regions Lower-half can have */
+#define MAX_REGIONS 10
+
 #ifdef MAIN_AUXVEC_ARG
 /* main gets passed a pointer to the auxiliary.  */
 # define MAIN_AUXVEC_DECL , void *
@@ -65,13 +68,20 @@ typedef struct __MmapInfo
   int guard;    // 1 if the region has additional guard pages around it; 0 otherwise
 } MmapInfo_t;
 
+typedef struct __LhCoreRegions
+{
+  void * start_addr; // Start address of core region
+  void * end_addr; // End address of the same region
+  int prot;
+} LhCoreRegions_t;
+
 // The transient lh_proxy process introspects its memory layout and passes this
 // information back to the main application process using this struct.
 typedef struct _LowerHalfInfo
 {
   void *startText; // Start address of text segment (R-X) of lower half
   void *endText;   // End address of text segmeent (R-X) of lower half
-  void *startData; // Start address of data segment (RW-) of lower half
+  // void *startData; // Start address of data segment (RW-) of lower half
   void *endOfHeap; // Pointer to the end of heap segment of lower half
   void *libc_start_main; // Pointer to libc's __libc_start_main function in statically-linked lower half
   void *main;      // Pointer to the main() function in statically-linked lower half
@@ -87,6 +97,7 @@ typedef struct _LowerHalfInfo
   void *updateEnvironFptr; // Pointer to updateEnviron() function in the lower half
   void *getMmappedListFptr; // Pointer to getMmapedList() function in the lower half
   void *resetMmappedListFptr; // Pointer to resetMmapedList() function in the lower half
+  int numCoreRegions; // total number of core regions
   MemRange_t memRange; // MemRange_t object in the lower half
 } LowerHalfInfo_t;
 
@@ -130,6 +141,7 @@ extern LowerHalfInfo_t lh_info;
 // the transient lh_proxy process in DMTCP_EVENT_INIT.
 // initializeLowerHalf() will initialize this to: (proxyDlsym_t)lh_info.lh_dlsym
 extern proxyDlsym_t pdlsym;
+extern LhCoreRegions_t lh_regions_list[MAX_REGIONS];
 
 // API
 

--- a/contrib/mpi-proxy-split/mpi_plugin.cpp
+++ b/contrib/mpi-proxy-split/mpi_plugin.cpp
@@ -59,17 +59,23 @@ regionContains(const void *haystackStart,
 EXTERNC int
 dmtcp_skip_memory_region_ckpting(const ProcMapsArea *area)
 {
-  if (area->addr == lh_info.startText ||
-      strstr(area->name, "/dev/zero") ||
+  if (strstr(area->name, "/dev/zero") ||
       strstr(area->name, "/dev/kgni") ||
       // FIXME: must comment out for VASP 5/RPA jobs on 2 knl nodes,
       // don't know why.
       strstr(area->name, "/SYSV") ||
       strstr(area->name, "/dev/xpmem") ||
-      strstr(area->name, "/dev/shm") ||
-      area->addr == lh_info.startData) {
+      strstr(area->name, "/dev/shm")) {
     JTRACE("Ignoring region")(area->name)((void*)area->addr);
     return 1;
+  }
+  if (!lh_regions_list) return 0;
+  for (int i = 0; i < lh_info.numCoreRegions; i++) {
+    void *lhStartAddr = lh_regions_list[i].start_addr;
+    if (area->addr == lhStartAddr) {
+      JTRACE ("Ignoring LH core region") (area->addr);
+      return 1;
+    }
   }
   if (!g_list) return 0;
   for (int i = 0; i < g_numMmaps; i++) {

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -1343,14 +1343,19 @@ skip_lh_memory_region_ckpting(const Area *area, LowerHalfInfo_t *lh_info)
   if (fnc) {
     g_list = fnc(&g_numMmaps);
   }
-  if (area->addr == lh_info->startText ||
-      mtcp_strstr(area->name, "/dev/zero") ||
+  if (mtcp_strstr(area->name, "/dev/zero") ||
       mtcp_strstr(area->name, "/dev/kgni") ||
       mtcp_strstr(area->name, "/dev/xpmem") ||
       mtcp_strstr(area->name, "/dev/shm") ||
-      mtcp_strstr(area->name, "/SYS") ||
-      area->addr == lh_info->startData) {
+      mtcp_strstr(area->name, "/SYS")) {
     return 1;
+  }
+  if (!lh_regions_list) return 0;
+  for (int i = 0; i < lh_info->numCoreRegions; i++) {
+    void *lhStartAddr = lh_regions_list[i].start_addr;
+    if (area->addr == lhStartAddr) {
+      return 1;
+    }
   }
   if (!g_list) return 0;
   for (i = 0; i < g_numMmaps; i++) {

--- a/src/mtcp/mtcp_split_process.c
+++ b/src/mtcp/mtcp_split_process.c
@@ -30,6 +30,7 @@ LowerHalfInfo_t lh_info;
 //         pdlsym can be a fixed address that is unused by the upper half.
 //         In this case, we don't need to pass pdlsym to the upper half.
 static proxyDlsym_t pdlsym; // initialized to (proxyDlsym_t)lh_info.lh_dlsym
+LhCoreRegions_t lh_regions_list[MAX_REGIONS];
 
 static unsigned long origPhnum;
 static unsigned long origPhdr;
@@ -122,35 +123,30 @@ static int
 read_lh_proxy_bits(pid_t childpid, char *argv0)
 {
   int ret = -1;
-  const int IOV_SZ = 2;
+  const int IOV_SZ = lh_info.numCoreRegions;
   struct iovec remote_iov[IOV_SZ];
-  // text segment
-  remote_iov[0].iov_base = lh_info.startText;
-  remote_iov[0].iov_len = (unsigned long)lh_info.endText -
-                          (unsigned long)lh_info.startText;
-  ret = mmap_iov(&remote_iov[0], PROT_READ|PROT_EXEC|PROT_WRITE, argv0);
-  // data segment
-  remote_iov[1].iov_base = lh_info.startData;
-  remote_iov[1].iov_len = (unsigned long)lh_info.endOfHeap -
-                          (unsigned long)lh_info.startData;
-  ret = mmap_iov(&remote_iov[1], PROT_READ|PROT_WRITE, argv0);
-  // NOTE:  In our case local_iov will be same as remote_iov.
-  // NOTE:  This requires same privilege as ptrace_attach (valid for child)
   int i = 0;
   for (i = 0; i < IOV_SZ; i++) {
-    DPRINTF("Reading segment from lh proxy: %p, %lu Bytes\n",
+  // get metadata and map the segment
+    remote_iov[i].iov_base = lh_regions_list[i].start_addr;
+    remote_iov[i].iov_len = (unsigned long)lh_regions_list[i].end_addr -
+                            (unsigned long)lh_regions_list[i].start_addr;
+    ret = mmap_iov(&remote_iov[i], lh_regions_list[i].prot | PROT_WRITE, argv0);
+    MTCP_ASSERT(ret != -1);
+  // NOTE:  In our case local_iov will be same as remote_iov.
+  // NOTE:  This requires same privilege as ptrace_attach (valid for child)
+    DPRINTF("Reading segment from lh proxy: %p, %u Bytes\n",
             remote_iov[i].iov_base, remote_iov[i].iov_len);
     ret = mtcp_sys_process_vm_readv(childpid, remote_iov + i /* local_iov */,
                                     1, remote_iov + i, 1, 0);
     MTCP_ASSERT(ret != -1);
     // If the next assert fails, then we had a partial read.
     MTCP_ASSERT(ret == remote_iov[i].iov_len);
+    // Can remove PROT_WRITE now that we've populated the segment.
+    ret = mtcp_sys_mprotect(remote_iov[i].iov_base, remote_iov[i].iov_len,
+                  lh_regions_list[i].prot);
+    MTCP_ASSERT(ret != -1);
   }
-
-  // Can remove PROT_WRITE now that we've oppulated the text segment.
-  ret = mtcp_sys_mprotect((void *)ROUND_DOWN(remote_iov[0].iov_base),
-                          ROUND_UP(remote_iov[0].iov_len),
-                          PROT_READ | PROT_EXEC);
   return ret;
 }
 
@@ -221,6 +217,11 @@ startProxy(char *argv0, char **envp)
       // Read full lh_info struct from stdout of lh_proxy, including orig memRange.
       mtcp_sys_close(pipefd_out[1]); // close write end of pipe
       if (mtcp_sys_read(pipefd_out[0], &lh_info, sizeof lh_info) < sizeof lh_info) {
+        MTCP_PRINTF("Read fewer bytes than expected");
+        break;
+      }
+      size_t total_bytes = lh_info.numCoreRegions*sizeof(LhCoreRegions_t);
+      if (mtcp_sys_read(pipefd_out[0], &lh_regions_list, total_bytes) < total_bytes) {
         MTCP_PRINTF("Read fewer bytes than expected");
         break;
       }

--- a/src/mtcp/mtcp_split_process.h
+++ b/src/mtcp/mtcp_split_process.h
@@ -7,6 +7,7 @@
 
 // FIXME: Make it dynamic
 #define getpagesize()  4096
+#define MAX_REGIONS 10
 
 #define ROUND_UP(addr) ((addr + getpagesize() - 1) & ~(getpagesize()-1))
 #define ROUND_DOWN(addr) ((unsigned long)addr & ~(getpagesize()-1))
@@ -29,13 +30,20 @@ typedef struct __MmapInfo
   int guard;
 } MmapInfo_t;
 
+typedef struct __LhCoreRegions
+{
+  void * start_addr; // Start address of core region
+  void * end_addr; // End address of the same region
+  int prot;
+} LhCoreRegions_t;
+
 // The transient proxy process introspects its memory layout and passes this
 // information back to the main application process using this struct.
 typedef struct LowerHalfInfo
 {
   void *startText;
   void *endText;
-  void *startData;
+  // void *startData;
   void *endOfHeap;
   void *libc_start_main;
   void *main;
@@ -51,10 +59,12 @@ typedef struct LowerHalfInfo
   void *updateEnvironFptr;
   void *getMmappedListFptr;
   void *resetMmappedListFptr;
+  int numCoreRegions;
   MemRange_t memRange;
 } LowerHalfInfo_t;
 
 extern LowerHalfInfo_t lh_info;
+extern LhCoreRegions_t lh_regions_list[MAX_REGIONS];
 
 // Helper macro to be used whenever making a jump from the upper half to
 // the lower half.


### PR DESCRIPTION
The current implementation of copy-the-bits in MANA only copies `text` and `data` sections. However, on some platforms, the memory layout of lower-half's can have more regions. Moreover, the ordering of the core regions can be different like below: 
```
0e000000-0e001000 r--p 00000000 fd:02 808446429                          /home/twinkle/mana/bin/lh_proxy
0e001000-0e307000 r-xp 00001000 fd:02 808446429                          /home/twinkle/mana/bin/lh_proxy
0e307000-0e487000 r--p 00307000 fd:02 808446429                          /home/twinkle/mana/bin/lh_proxy
0e488000-0e493000 rw-p 00487000 fd:02 808446429                          /home/twinkle/mana/bin/lh_proxy
0e493000-0e503000 rw-p 00000000 00:00 0                                  [heap]
7ffff7ff9000-7ffff7ffd000 r--p 00000000 00:00 0                          [vvar]
7ffff7ffd000-7ffff7fff000 r-xp 00000000 00:00 0                          [vdso]
7ffffffde000-7ffffffff000 rw-p 00000000 00:00 0                          [stack]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
```
This PR handles the issue and generalizes the algorithm to copy lower-half's bits into the upper-half at launch and restart time.

NOTE: The work is in progress and the restart segfaults as of now. I'll update the PR with more information.