### PR TITLE
[MANA-78] vdso was not restored properly on CentOS 7

### DIFF
--- a/src/mtcp/mtcp_header.h
+++ b/src/mtcp/mtcp_header.h
@@ -88,6 +88,12 @@ typedef struct RestoreInfo {
   // See note below in the restart_fast_path() function.
   fnptr_t restorememoryareas_fptr;
 
+  // VDSO/VVAR regions for the mtcp_restart program.
+  VA currentVdsoStart;
+  VA currentVdsoEnd;
+  VA currentVvarStart;
+  VA currentVvarEnd;
+
   // void (*post_restart)();
   // void (*post_restart_debug)();
   // void (*restorememoryareas_fptr)();


### PR DESCRIPTION
The root cause is:
1) We saved the temporary vvar&vdso addresses in global variables, the address of which could have been changed.
2) We lost vdso label after `mremap` it.

Found a PR in dmtcp https://github.com/dmtcp/dmtcp/pull/961/files made by @karya0  that handling the same thing. I cannot just cherry-pick it because there're some other differences. But I follow the idea there as much as possible.

Tested on my CentOS 7 and it's working fine now.