### PR TITLE
Deterministic p2p mode - Fix several issues in logging requests

### DIFF
--- a/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
@@ -15,6 +15,7 @@ void fill_in_log(struct p2p_log_msg *p2p_log);
 int main() {
   char buf[100];
   int rank;
+  MPI_Init(NULL, NULL);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   snprintf(buf, sizeof(buf)-1, P2P_LOG_MSG, rank);
   int fd_log = open(buf, O_RDWR);
@@ -37,6 +38,7 @@ int main() {
     lseek(fd_log, offset, SEEK_SET);
     writeall(fd_log, &p2p_log, sizeof(p2p_log));
   }
+  MPI_Finalize();
 
   return 0;
 }

--- a/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
@@ -70,7 +70,7 @@ void fill_in_log(struct p2p_log_msg *p2p_log) {
     }
   }
   close(fd2);
-#ifdef 0
+#if 0
   // The following code has infinite loop. Comment out for now.
   fd2 = dup(fd_request);
   while (1) {
@@ -79,5 +79,5 @@ void fill_in_log(struct p2p_log_msg *p2p_log) {
       readall(fd_request, &p2p_request, sizeof(p2p_request));
     }
   }
-#endif // ifdef 0
+#endif // if 0
 }

--- a/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
@@ -70,14 +70,4 @@ void fill_in_log(struct p2p_log_msg *p2p_log) {
     }
   }
   close(fd2);
-#if 0
-  // The following code has infinite loop. Comment out for now.
-  fd2 = dup(fd_request);
-  while (1) {
-    readall(fd2, &p2p_request, sizeof(p2p_request));
-    if (p2p_request.request == MPI_REQUEST_NULL) {
-      readall(fd_request, &p2p_request, sizeof(p2p_request));
-    }
-  }
-#endif // if 0
 }

--- a/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
@@ -70,6 +70,8 @@ void fill_in_log(struct p2p_log_msg *p2p_log) {
     }
   }
   close(fd2);
+#ifdef 0
+  // The following code has infinite loop. Comment out for now.
   fd2 = dup(fd_request);
   while (1) {
     readall(fd2, &p2p_request, sizeof(p2p_request));
@@ -77,4 +79,5 @@ void fill_in_log(struct p2p_log_msg *p2p_log) {
       readall(fd_request, &p2p_request, sizeof(p2p_request));
     }
   }
+#endif // ifdef 0
 }

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -64,6 +64,7 @@ USER_DEFINED_WRAPPER(int, Test, (MPI_Request*) request,
     return MPI_SUCCESS;
   }
   DMTCP_PLUGIN_DISABLE_CKPT();
+  LOG_PRE_Test(status);
   MPI_Status statusBuffer;
   MPI_Status *statusPtr = status;
   if (statusPtr == MPI_STATUS_IGNORE) {
@@ -99,6 +100,7 @@ USER_DEFINED_WRAPPER(int, Test, (MPI_Request*) request,
     fflush(stdout);
 #endif
   }
+  LOG_POST_Test(request, statusPtr);
   if (retval == MPI_SUCCESS && *flag && MPI_LOGGING()) {
     clearPendingRequestFromLog(*request);
     REMOVE_OLD_REQUEST(*request);
@@ -241,7 +243,7 @@ USER_DEFINED_WRAPPER(int, Iprobe,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Iprobe)(source, tag, realComm, flag, status);
   RETURN_TO_UPPER_HALF();
-  LOG_POST_Iprobe(source,tag,comm,status,request);
+  LOG_POST_Iprobe(source,tag,comm,status);
   REPLAY_POST_Iprobe(count,datatype,source,tag,comm,status);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -172,6 +172,7 @@ USER_DEFINED_WRAPPER(int, Waitall, (int) count,
 USER_DEFINED_WRAPPER(int, Wait, (MPI_Request*) request, (MPI_Status*) status)
 {
   int retval;
+  LOG_PRE_Wait(status);
   if (*request == MPI_REQUEST_NULL) {
     // *request might be in read-only memory. So we can't overwrite it with
     // MPI_REQUEST_NULL later.
@@ -210,6 +211,7 @@ USER_DEFINED_WRAPPER(int, Wait, (MPI_Request*) request, (MPI_Status*) status)
       fflush(stdout);
 #endif
     }
+    LOG_POST_Wait(request, statusPtr);
     if (flag && MPI_LOGGING()) {
       clearPendingRequestFromLog(*request);
       REMOVE_OLD_REQUEST(*request);

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -63,8 +63,8 @@ USER_DEFINED_WRAPPER(int, Test, (MPI_Request*) request,
     *flag = true;
     return MPI_SUCCESS;
   }
-  DMTCP_PLUGIN_DISABLE_CKPT();
   LOG_PRE_Test(status);
+  DMTCP_PLUGIN_DISABLE_CKPT();
   MPI_Status statusBuffer;
   MPI_Status *statusPtr = status;
   if (statusPtr == MPI_STATUS_IGNORE) {
@@ -172,7 +172,6 @@ USER_DEFINED_WRAPPER(int, Waitall, (int) count,
 USER_DEFINED_WRAPPER(int, Wait, (MPI_Request*) request, (MPI_Status*) status)
 {
   int retval;
-  LOG_PRE_Wait(status);
   if (*request == MPI_REQUEST_NULL) {
     // *request might be in read-only memory. So we can't overwrite it with
     // MPI_REQUEST_NULL later.
@@ -211,7 +210,6 @@ USER_DEFINED_WRAPPER(int, Wait, (MPI_Request*) request, (MPI_Status*) status)
       fflush(stdout);
 #endif
     }
-    LOG_POST_Wait(request, statusPtr);
     if (flag && MPI_LOGGING()) {
       clearPendingRequestFromLog(*request);
       REMOVE_OLD_REQUEST(*request);

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
@@ -150,8 +150,7 @@ void save_request_info(MPI_Request *request, MPI_Status *status) {
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     snprintf(buf, sizeof(buf)-1, P2P_LOG_REQUEST, rank);
-    fd = open(buf, sizeof(buf)-1,
-              O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR );
+    fd = open(buf, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR );
     if (fd == -1) {
       perror("save_request_info: open: couldn't create request file");
       exit(1);

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
@@ -150,7 +150,7 @@ void save_request_info(MPI_Request *request, MPI_Status *status) {
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     snprintf(buf, sizeof(buf)-1, P2P_LOG_REQUEST, rank);
-    fd = open(buf, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR );
+    fd = open(buf, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
     if (fd == -1) {
       perror("save_request_info: open: couldn't create request file");
       exit(1);

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -38,6 +38,7 @@ int iprobe_next_msg(struct p2p_log_msg *p2p_msg);
 void set_next_msg(int count, MPI_Datatype datatype,
                   int source, int tag, MPI_Comm comm,
                   MPI_Status *status, MPI_Request *request);
+void save_request_info(MPI_Request *request, MPI_Status *status);
 
 #ifdef USE_READALL
 static
@@ -137,7 +138,7 @@ ssize_t writeall(int fd, void *buf, size_t count) {
   }
 
 // After MPI_Iprobe during original launch/log
-#define LOG_POST_Iprobe(source,tag,comm,status,request)
+#define LOG_POST_Iprobe(source,tag,comm,status)
   if (getenv("MANA_P2P_LOG")) {
     int bytesRecvd = -1;
     if (*flag == 0) {
@@ -217,10 +218,6 @@ ssize_t writeall(int fd, void *buf, size_t count) {
 // Before MPI_Wait, MPI_Test during log/launch
 // NOT USED:  MPI_Wait wrapper calls MPI_Test
 #define LOG_PRE_Wait(status)
-  MPI_Status local_status;
-  if (getenv("MANA_P2P_LOG") && status != MPI_STATUS_IGNORE) {
-    status = &local_status;
-  }
 
 #define LOG_PRE_Test(status) LOG_PRE_Wait(status)
 


### PR DESCRIPTION
This change fixes several issues in logging requests for deterministic p2p mode.
[1] Fix open request log
[2] Logging requests for MPI_Test and MPI_Wait
[3] Initialize MPI before using its function in mana_p2p_update_log
[4] Remove infinite loop in mana_p2p_update_log.c