### PR TITLE
Fix 65cee67:  REPLAY_PRE_Irecv() needs to be used

### DIFF
--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
@@ -169,6 +169,7 @@ USER_DEFINED_WRAPPER(int, Irecv,
 
   DMTCP_PLUGIN_DISABLE_CKPT();
   LOG_PRE_Irecv(&status);
+  REPLAY_PRE_Irecv(count,datatype,source,tag,comm);
   if (isBufferedPacket(source, tag, comm, &flag, &status)) {
     consumeBufferedPacket(buf, count, datatype, source, tag, comm,
                           &status, size);

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -107,6 +107,7 @@ ssize_t writeall(int fd, void *buf, size_t count) {
 #define LOG_PRE_Irecv(status)
 
 // After MPI_Irecv during original launch/log
+// FIXME:  Need to add MPI_Recv_init when MANA supports it
 #define LOG_POST_Irecv(source,tag,comm,status,request)
   if (getenv("MANA_P2P_LOG")) {
     // source and tag will be filled in later, based on request
@@ -130,6 +131,7 @@ ssize_t writeall(int fd, void *buf, size_t count) {
   }
 
 // Before MPI_Iprobe during original launch/log
+// FIXME:  Need to add MPI_Improbe when MANA supports it
 #define LOG_PRE_Iprobe(status)
   MPI_Status local_status;
   if (getenv("MANA_P2P_LOG") && status != MPI_STATUS_IGNORE) {
@@ -137,6 +139,7 @@ ssize_t writeall(int fd, void *buf, size_t count) {
   }
 
 // After MPI_Iprobe during original launch/log
+// FIXME:  Need to add MPI_Improbe when MANA supports it
 #define LOG_POST_Iprobe(source,tag,comm,status,request)
   if (getenv("MANA_P2P_LOG")) {
     int bytesRecvd = -1;
@@ -164,9 +167,9 @@ ssize_t writeall(int fd, void *buf, size_t count) {
   }
 
 // Before call to MPI_Irecv() in lower half during replay
-// NOT USED:  MPI_Recv wrapper calls MPI_Irecv
+// FIXME:  Need to add MPI_Recv_init when MANA supports it
 #define REPLAY_PRE_Irecv(count,datatype,source,tag,comm)
-  if (getenv("MANA_P2P_REPLAY") && !MPI_Iprobe_recurse) {
+  if (getenv("MANA_P2P_REPLAY")) {
     struct p2p_log_msg p2p_msg;
     while (!iprobe_next_msg(NULL)) {
       // consume messages where log says MPI_Iprobe: flag==0
@@ -188,6 +191,7 @@ ssize_t writeall(int fd, void *buf, size_t count) {
 
 // After call to MPI_Iprobe() in lower half during replay
 //   Make sure log is in sync with MPI_Iprobe again.
+// FIXME:  Need to add MPI_Improbe when MANA supports it
 #define REPLAY_POST_Iprobe(count,datatype,source,tag,comm,status)
   int MPI_Iprobe_recurse = 0;
   if (getenv("MANA_P2P_REPLAY") && !MPI_Iprobe_recurse) {


### PR DESCRIPTION
Fixing problem with PR #78.  I had created the `REPLAY_PRE_Irecv()` macro, but I forgot to add it into the wrapper for `MPI_Irecv`.  Thanks for catching this, @dahongli.