### PR TITLE
Correct mana.1 for use of MPI_COLLECTIVE_P2P

### DIFF
--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
@@ -20,8 +20,8 @@
  *        This version does not test for return values.
  ************************************************************************/
 
-// Add:  #define ADD_UNDEFINED
-//   if you want to define functions that are also in mpi_unimplemented_wrappers.txt
+// Add '#define ADD_UNDEFINED' if you want to define functions that are
+//   also in mpi_unimplemented_wrappers.txt
 
 #define PROLOG_Comm_rank_size \
   int rank; \
@@ -129,7 +129,7 @@ int MPI_Gather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
     }
     assert(sendextent*sendcount == recvextent*recvcount);
     if (!inplace) {
-      memcpy(recvbuf + rank*recvextent*recvcount, sendbuf, sendextent*sendcount);
+     memcpy(recvbuf + rank*recvextent*recvcount, sendbuf, sendextent*sendcount);
     } // NOTE: if inplace, MPI guarantees that the root data is already correct
     for (i = 0; i < size; i++) {
       if (i != root) {
@@ -211,7 +211,7 @@ int MPI_Scatter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
   } else { // else: rank != root
     for (i = 0; i < size; i++) {
       if (i != root) {
-        MPI_Recv(recvbuf, recvcount, recvtype, root, 0, comm, MPI_STATUS_IGNORE);
+       MPI_Recv(recvbuf, recvcount, recvtype, root, 0, comm, MPI_STATUS_IGNORE);
       }
     }
   }
@@ -230,7 +230,8 @@ int MPI_Scatterv(const void* sendbuf, const int sendcounts[],
     MPI_Aint sendextent;
     MPI_Type_get_extent(sendtype, &lower_bound, &sendextent);
     if (!inplace) {
-      memcpy(recvbuf, sendbuf + displs[root]*sendextent, sendextent*sendcounts[root]);
+      memcpy(recvbuf, sendbuf + displs[root]*sendextent,
+             sendextent*sendcounts[root]);
     } // NOTE: if inplace, MPI guarantees that the root data is already correct
     for (i = 0; i < size; i++) {
       if (i != root) {

--- a/manpages/mana.1
+++ b/manpages/mana.1
@@ -1,5 +1,5 @@
 '\" t
-.\" Manual page created with latex2man on Wed Mar 23 02:36:27 2022
+.\" Manual page created with latex2man on Thu Mar 31 02:23:15 2022
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +10,7 @@
 
 .fi
 ..
-.TH "MANA" "1" "23 March 2022" "MPI\-Agnostic Netw.\-Agnostic Ckpt " "MPI\-Agnostic Netw.\-Agnostic Ckpt "
+.TH "MANA" "1" "31 March 2022" "MPI\-Agnostic Netw.\-Agnostic Ckpt " "MPI\-Agnostic Netw.\-Agnostic Ckpt "
 .SH NAME
 
 \fBmana\fP
@@ -134,18 +134,29 @@ inside mtcp/mtcp_restart.c shortly before calling splitProcess()
 pause during restart, before resuming execution, to allow `gdb 
 attach\&' (GDB must be on same node.) 
 .TP
-\fBDEFINE_mpi_collective_p2p\fP
+\fBMPI_COLLECTIVE_P2P\fP
  For debugging only (high 
 runtime overhead): If this env. var. is set, and if re\-building 
 any files in contrib/mpi\-proxy\-split/mpi\-wrappers, then MPI 
 collective communication calls are translated to MPI_Send/Recv 
 at runtime. (Try \&'touch mpi_collective_p2p.c\&' if not re\-building.) 
+.br
+NOTE: You can select specific collective calls for translation
+to MPI_Send/Recv by copying MPI wrappers from
+mpi_collective_p2p.c
+to mpi_collective_wrappers.cpp
+in the mpi\-wrappers
+subdirectory; or block certain
+translations by adjusting \&'#ifdef/#ifndef MPI_COLLECTIVE_P2P\&'
+in those files.
 .TP
 \fBMANA_P2P_LOG"\fP
- For debugging: Set this before mana_launch
+ For debugging: Set this before 
+mana_launch
 in order to log the order of point\-to\-point 
 calls (MPI_Send and family) for later deterministic replay. See 
-details at top of contrib/mpi\-proxy\-split/mpi\-wrappers/p2p\-deterministic.c 
+details at top of 
+contrib/mpi\-proxy\-split/mpi\-wrappers/p2p\-deterministic.c 
 (IMPORTANT: If you checkpoint, continue running for a few minutes 
 after that, for final updating of the log files.) 
 .TP

--- a/manpages/mana.latex2man
+++ b/manpages/mana.latex2man
@@ -85,15 +85,22 @@ the last checkpoint.
     \item[\Opt{DMTCP_RESTART_PAUSE}] DMTCP/MANA will
 	pause during restart, before resuming execution, to allow `gdb
 	attach' (GDB must be on same node.)
-    \item[\Opt{DEFINE_mpi_collective_p2p}] For debugging only (high
+    \item[\Opt{MPI_COLLECTIVE_P2P}] For debugging only (high
 	runtime overhead): If this env. var. is set, and if re-building
 	any files in contrib/mpi-proxy-split/mpi-wrappers, then MPI
 	collective communication calls are translated to MPI_Send/Recv
-	at runtime. (Try 'touch mpi_collective_p2p.c' if not re-building.)
-    \item[\Opt{MANA_P2P_LOG"}] For debugging:  Set this before \texttt{mana_launch}
-	in order to log the order of point-to-point
+	at runtime. (Try 'touch mpi_collective_p2p.c' if not re-building.) \\
+	NOTE:  You can select specific collective calls for translation
+	to MPI_Send/Recv by copying MPI wrappers from
+	\texttt{mpi_collective_p2p.c} to \texttt{mpi_collective_wrappers.cpp}
+	in the \texttt{mpi-wrappers} subdirectory; or block certain
+	translations by adjusting '\#ifdef/\#ifndef MPI_COLLECTIVE_P2P'
+	in those files.
+    \item[\Opt{MANA_P2P_LOG"}] For debugging:  Set this before
+	\texttt{mana_launch} in order to log the order of point-to-point
 	calls (MPI_Send and family) for later deterministic replay.  See
-	details at top of contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
+	details at top of
+	contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
 	(IMPORTANT:  If you checkpoint, continue running for a few minutes
 	after that, for final updating of the log files.)
     \item[\Opt{MANA_P2P_REPLAY"}] For debugging:  If a checkpoint was created


### PR DESCRIPTION
Correct `manpages/mana.*`.  It previously said the environment variable was `DEFINE_mpi_collective_p2p`, when it should have been `MPI_COLLECTIVE_P2P`.

If you do `nroff -man mana.1` now in the `manpages` dir, you'll see the correct information for  `MPI_COLLECTIVE_P2P`.  I also fixed `mpi_collective_p2p.c`, where the formatting was going beyond column 80.