### PR TITLE
Polish collective p2p: MPI_Init prints if using MPI_COLLECTIVE_P2P

### DIFF
--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
@@ -663,37 +663,6 @@ int MPI_Iexscan(const void* sendbuf, void* recvbuf, int count,
 }
 #endif  // #ifdef ADD_UNDEFINED
 
-#if 0
-//FIXME:  Delete this, once we confirm it's not needed.  When MPI_COLLECTIVE_P2P is
-//        defined, the file p2p_drain_send_recv.cpp should call the C++ version
-//        of this, defined in mpi-wrappers/mpi_collective_wrappers.cpp.  (See the
-//        comment in the latter file.)  That is a call to the C++ version of
-//        MPI_Alltoall_internal.  So, this C version should never be used.
-// This routine is called from mpi-proxy-split/p2p_drain_send_recv.cpp.
-// The code in that file is invoked only at checkpoint time. It uses
-// MPI_Alltoall to drain any remaining Send/Recv messages.
-// So, it must not convert MPI_Alltoall_internal to use use point-to-point
-// communication. This is an exception that makes a collective call to the
-// lower half.
-int
-MPI_Alltoall_internal(const void *sendbuf, int sendcount,
-                      MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                      MPI_Datatype recvtype, MPI_Comm comm)
-{
-  int retval;
-  DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
-  MPI_Datatype realSendType = VIRTUAL_TO_REAL_TYPE(sendtype);
-  MPI_Datatype realRecvType = VIRTUAL_TO_REAL_TYPE(recvtype);
-  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
-  retval = NEXT_FUNC(Alltoall)(sendbuf, sendcount, realSendType, recvbuf,
-      recvcount, realRecvType, realComm);
-  RETURN_TO_UPPER_HALF();
-  DMTCP_PLUGIN_ENABLE_CKPT();
-  return retval;
-}
-#endif
-
 #ifdef __cplusplus
 } // end of: extern "C"
 #endif

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -38,6 +38,18 @@
 # include "mpi_collective_p2p.c"
 #endif
 
+// Returns true if the environment variable MPI_COLLECTIVE_P2P
+//   was set when the MANA plugin was compiled.
+//   MPI collective calls will be translated to use MPI_Send/Recv.
+bool
+isUsingCollectiveToP2p() {
+#ifdef MPI_COLLECTIVE_P2P
+  return true;
+#else
+  return false;
+#endif
+}
+
 // #define NO_BARRIER_BCAST
 using namespace dmtcp_mpi;
 

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
@@ -35,8 +35,21 @@ DEFINE_FNC(int, Init, (int *) argc, (char ***) argv)
 DEFINE_FNC(int, Init_thread, (int *) argc, (char ***) argv,
            (int) required, (int *) provided)
 #else
+static const char collective_p2p_string[] =
+   "\n"
+   "   ***************************************************************************\n"
+   "   *** The environment variable MPI_COLLECTIVE_P2P was set when this MANA was\n"
+   "   ***   compiled.  It's for debugging/testing.  MPI collective calls will be\n"
+   "   ***   translated to MPI_Send/Recv, and so the application will be _much_\n"
+   "   ***   slower. See mpi_wrappers.cpp and mpi_collective_p2p.c for selecting\n"
+   "   ***   individual MPI collective calls for translation to MPI_Send/Recv.\n"
+   "   ***************************************************************************\n"
+   "\n";
 USER_DEFINED_WRAPPER(int, Init, (int *) argc, (char ***) argv) {
   int retval;
+  if (isUsingCollectiveToP2p()) {
+    fprintf(stderr, collective_p2p_string);
+  }
   DMTCP_PLUGIN_DISABLE_CKPT();
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Init)(argc, argv);
@@ -48,6 +61,9 @@ USER_DEFINED_WRAPPER(int, Init, (int *) argc, (char ***) argv) {
 USER_DEFINED_WRAPPER(int, Init_thread, (int *) argc, (char ***) argv,
                      (int) required, (int *) provided) {
   int retval;
+  if (isUsingCollectiveToP2p()) {
+    fprintf(stderr, collective_p2p_string);
+  }
   DMTCP_PLUGIN_DISABLE_CKPT();
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Init_thread)(argc, argv, required, provided);

--- a/contrib/mpi-proxy-split/mpi_plugin.h
+++ b/contrib/mpi-proxy-split/mpi_plugin.h
@@ -51,4 +51,6 @@
 extern int g_numMmaps;
 extern MmapInfo_t *g_list;
 
+bool isUsingCollectiveToP2p();
+
 #endif // ifndef _MPI_PLUGIN_H


### PR DESCRIPTION
The title says it all.  I haven't tested this on Cori.  Please test on Cori by setting the environment variable `MPI_COLLECTIVE_P2P` and re-compiling.