### PR TITLE
[MANA-95] Add test case to reproduce the infinite loop issue

### DIFF
--- a/contrib/mpi-proxy-split/mpi-wrappers/Makefile
+++ b/contrib/mpi-proxy-split/mpi-wrappers/Makefile
@@ -141,6 +141,7 @@ clean: tidy
 	rm -f ${LIBNAME}.a libmpistub.so
 	rm -f ${DMTCP_ROOT}/lib/dmtcp/libmpistub.so
 	rm -f mpi_stub_wrappers.c
+	rm -f p2p-deterministic.h
 	rm -f mpi_unimplemented_wrappers.cpp
 	rm -f mpi_fortran_wrappers.cpp
 	rm -f libmpich_intel.so.3.0.1 libmpich_intel.so.3

--- a/contrib/mpi-proxy-split/test/Makefile
+++ b/contrib/mpi-proxy-split/test/Makefile
@@ -34,7 +34,8 @@ FILES=mpi_hello_world \
       Allgather_test Group_size_rank Type_commit_contiguous \
       Irecv_test Alloc_mem \
       f_ibarrier \
-      wave_mpi day1_mpi quad_mpi poisson_nonblock_mpi
+      wave_mpi day1_mpi quad_mpi poisson_nonblock_mpi \
+      send_recv_loop
 
 OBJS=$(addsuffix .o, ${FILES})
 

--- a/contrib/mpi-proxy-split/test/send_recv_loop.c
+++ b/contrib/mpi-proxy-split/test/send_recv_loop.c
@@ -1,0 +1,77 @@
+// Author: Wes Kendall
+// Copyright 2011 www.mpitutorial.com
+// This code is provided freely with the tutorials on mpitutorial.com. Feel
+// free to modify it for your own use. Any distribution of the code must
+// either provide a link to www.mpitutorial.com or keep this header in tact.
+//
+// MPI_Send, MPI_Recv example. Communicates the number -1 from process 0
+// to processe 1.
+//
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <unistd.h>
+#include <limits.h>
+#include <time.h>
+
+int main(int argc, char** argv) {
+  int iteration = 10;
+  if (argc > 1) {
+    iteration = atoi(argv[1]);
+  }
+
+  // Initialize the MPI environment
+  MPI_Init(NULL, NULL);
+  // Find out rank, size
+  int world_rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  int world_size;
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+
+  // We are assuming at least 2 processes for this task
+  if (world_size < 3) {
+    fprintf(stderr, "World size must be greater than or equal to 3 for %s\n", argv[0]);
+    MPI_Abort(MPI_COMM_WORLD, 1);
+  }
+
+  // rank 0 wait a while then send messages to rank 1
+  if (world_rank == 0) {
+    int number = 0;
+    for (int i = 0; i < iteration; i++) {
+      sleep(10);
+      MPI_Send(&number, 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
+      number++;
+      MPI_Barrier(MPI_COMM_WORLD);
+      printf("Rank 0 have successfully sent %d messages to rank 1\n", i + 1);
+      fflush(stdout);
+    }
+  } else if (world_rank == 1) {
+    // rank 1 receive message from 0 first and then 2
+    int number = 0;
+    for (int i = 0; i < iteration; i++) {
+      int recv_number = -1;
+      MPI_Recv(&recv_number, 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+      assert(number == recv_number);
+      MPI_Recv(&recv_number, 1, MPI_INT, 2, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+      assert(number == recv_number);
+      number++;
+      MPI_Barrier(MPI_COMM_WORLD);
+      printf("Rank 1 have successfully received %d messages\n", (i + 1) * 2);
+      fflush(stdout);
+    }
+  } else {
+    // rank 2 send messages to rank 1 right away
+    int number = 0;
+    for (int i = 0; i < iteration; i++) {
+      MPI_Send(&number, 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
+      number++;
+      MPI_Barrier(MPI_COMM_WORLD);
+      printf("Rank 2 have successfully sent %d messages to rank 1\n", i + 1);
+      fflush(stdout);
+    }
+
+  }
+  MPI_Finalize();
+  return 0;
+}


### PR DESCRIPTION
There're 2 bugs in [MANA-95](https://memverge.atlassian.net/browse/MANA-95), one is fixed by PR #98 (PR #97 is the one to reproduce that issue).

This PR adds a test case to reproduce the issue that there might have another infinite loop in `completePendingIrecvs`

The root cause is when checkpoints, rank 1 is trying to receive a message from rank 0, but rank 0 hasn't sent it yet. So the send/receive bytes matched between rank 1 and rank 0, but there is one pending RECV request in rank 1's `g_async_calls`
Also at this moment, rank 2 has sent a message to rank 1, but rank 1 hasn't got a chance to receive it yet. that's why the send/receive bytes between rank 1 and rank 2 don't match, and we're hoping, the `recvFromAllComms` can recover this case.
But the rank 1 is stuck at `completePendingIrecvs`, and didn't get a chance to recover.

```
Rank 0:
int data = 0;
loop {
  sleep(10);
  MPI_Send(i++, 1);
  MPI_Barrier();
}

Rank 1:
loop {
  MPI_Recv(0);
  MPI_Recv(2);
  MPI_Barrier();
}

Rank 2:
int data = 0;
loop {
  MPI_Send(i++, 1);
  MPI_Barrier();
}
```