### PR TITLE
[MANA-95] Add test case to reproduce p2p infinite loop at ckpt

### DIFF
--- a/contrib/mpi-proxy-split/test/Makefile
+++ b/contrib/mpi-proxy-split/test/Makefile
@@ -26,6 +26,7 @@ FILES=mpi_hello_world \
       hello_mpi_init_thread \
       keyval_test \
       send_recv send_recv_many ping_pong Comm_dup_test Sendrecv_test \
+      multi_send_recv \
       Barrier_test Bcast_test Comm_split_test Reduce_test \
       Waitall_test \
       two-phase-commit-1 two-phase-commit-2 \

--- a/contrib/mpi-proxy-split/test/multi_send_recv.c
+++ b/contrib/mpi-proxy-split/test/multi_send_recv.c
@@ -1,0 +1,60 @@
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <unistd.h>
+
+int main(int argc, char** argv) {
+  int data = 0;
+  int recv_buf = 0;
+  // Initialize the MPI environment
+  MPI_Init(NULL, NULL);
+  // Find out rank, size
+  int world_rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  int world_size;
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+
+  // We are assuming 2 processes for this task
+  if (world_size != 2) {
+    fprintf(stderr, "World size must be 2 for %s\n", argv[0]);
+    MPI_Abort(MPI_COMM_WORLD, 1);
+  }
+
+  while (1) {
+    MPI_Barrier(MPI_COMM_WORLD);
+    // For rank 0, send data 3 time. After each send, increment the data by 1.
+    if (world_rank == 0) {
+      printf("Rank %d sending integer %d to %d\n", world_rank, data, data + 2);
+      fflush(stdout);
+      MPI_Send(&data, 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
+      data++;
+      MPI_Send(&data, 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
+      data++;
+      MPI_Send(&data, 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
+      data++;
+    }
+
+    printf("Rank %d sleeping\n", world_rank);
+    fflush(stdout);
+    sleep(5);
+
+    // For rank 1, recv data 3 time. After each recv, increment the data by 1.
+    // Also chech the data received.
+    if (world_rank == 1) {
+      printf("Rank %d recving integer %d to %d\n", world_rank, data, data + 2);
+      fflush(stdout);
+      MPI_Recv(&recv_buf, 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+      assert(recv_buf == data);
+      data++;
+      MPI_Recv(&recv_buf, 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+      assert(recv_buf == data);
+      data++;
+      MPI_Recv(&recv_buf, 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+      assert(recv_buf == data);
+      data++;
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+  }
+  MPI_Finalize();
+}


### PR DESCRIPTION
This test case is what I described in the email. The sender will send messages with the same length and same destination multiple times before the checkpoint. The receiver will receive these messages after the checkpoint. This is related to PR #96.