### PR TITLE
[MANA-95] P2p bugfix

### DIFF
--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
@@ -170,7 +170,8 @@ USER_DEFINED_WRAPPER(int, Irecv,
   DMTCP_PLUGIN_DISABLE_CKPT();
   LOG_PRE_Irecv(&status);
   REPLAY_PRE_Irecv(count,datatype,source,tag,comm);
-  if (isBufferedPacket(source, tag, comm, &flag, &status)) {
+  if (mana_state == RUNNING &&
+      isBufferedPacket(source, tag, comm, &flag, &status)) {
     consumeBufferedPacket(buf, count, datatype, source, tag, comm,
                           &status, size);
     *request = MPI_REQUEST_NULL;

--- a/contrib/mpi-proxy-split/mpi_plugin.h
+++ b/contrib/mpi-proxy-split/mpi_plugin.h
@@ -51,4 +51,15 @@
 extern int g_numMmaps;
 extern MmapInfo_t *g_list;
 
+enum mana_state_t {
+  UNKNOWN_STATE,
+  RUNNING,
+  CKPT_COLLECTIVE,
+  CKPT_P2P,
+  RESTART_RETORE,
+  RESTART_REPLAY
+};
+
+extern mana_state_t mana_state;
+
 #endif // ifndef _MPI_PLUGIN_H


### PR DESCRIPTION
Currently, the MPI_Irecv wrapper, which will be called when draining p2p messages, will check the internal buffer used for draining during checkpoint time. As a result, if two messages need to be drained during checkpoint time and they have the same destination, tag, and size, MANA will try to "consume" the first message in the internal buffer and put it back into the internal buffer as the second message. The real second message will never be properly received. MPI_Iprobe will always remind MANA there's a pending message in the network, and the draining process for the second message will be repeated infinitely. Therefore, the p2p draining becomes an infinite loop.

The bug can be reproduced with the test case added in PR #97.

This fix adds a global variable `mana_state`, which shows the current state of MANA. Previously, a macro `MPI_LOGGING` has similar functionality, but can only distinguish the replay state during a restart. `mana_state` enables MANA to distinguish more states during its lifetime. Now, the `MPI_Irecv` wrapper will only check the internal draining buffer if `mana_state == RUNNING`.