### PR TITLE
Fix bug in libproxy.c where PID may be longer than expected

### DIFF
--- a/contrib/mpi-proxy-split/lower-half/libproxy.c
+++ b/contrib/mpi-proxy-split/lower-half/libproxy.c
@@ -110,7 +110,9 @@ getTextSegmentRange(pid_t proc,                 // IN
   if (proc == -1) {
     f = fopen("/proc/self/stat", "r");
   } else {
-    char pids[] = "/proc/XXXXXX/stat";
+    // On 64-bit systems, pid_max can be set to any value up to 2^22
+    // (PID_MAX_LIMIT, approximately 4 million).
+    char pids[PATH_MAX];
     snprintf(pids, sizeof pids, "/proc/%u/stat", proc);
     f = fopen(pids, "r");
   }


### PR DESCRIPTION
This pull request fixes a bug where a `lh_proxy` process may have a PID longer than 6 digits, which would cause the end of the `pids` string to be cut off. This is an issue on CentOS Stream, where the max PID is 4194304.