### PR TITLE
Deterministic p2p - log and replay MPI_[Irecv,Iprobe,Wait,Test]

### DIFF
--- a/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
@@ -74,7 +74,8 @@ void fill_in_log(struct p2p_log_msg *p2p_log) {
     req_start_offset = 0;
   }
   while (1) {
-    readall(fd2, &p2p_request, sizeof(p2p_request));
+    int rc = readall(fd2, &p2p_request, sizeof(p2p_request));
+    if (rc == 0) return;
     if (p2p_request.request == p2p_log->request) {
       p2p_log->source = p2p_request.source;
       p2p_log->tag = p2p_request.tag;

--- a/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
@@ -74,18 +74,17 @@ void fill_in_log(struct p2p_log_msg *p2p_log) {
     if (p2p_request.request == p2p_log->request) {
       p2p_log->source = p2p_request.source;
       p2p_log->tag = p2p_request.tag;
-      p2p_log->request = MPI_REQUEST_NULL;
       break;
     }
   }
   close(fd2);
 }
 
-int show_log(char *name)
+int show_msg_file(char *name)
 {
   int fd_log = open(name, O_RDWR);
   if (fd_log == -1) {
-    fprintf(stderr, "show_log open: fle %s, error: %s\n", name, strerror(errno)); 
+    fprintf(stderr, "show_log_file open: fle %s, error: %s\n", name, strerror(errno));
     return 1; 
   }
 
@@ -101,4 +100,40 @@ int show_log(char *name)
   }
   return 0;
 }
+
+int show_request_file(char *name)
+{
+  int fd_log = open(name, O_RDWR);
+  if (fd_log == -1) {
+    fprintf(stderr, "show_request_file open: fle %s, error: %s\n", name, strerror(errno));
+    return 1;
+  }
+
+  while (1) {
+    struct p2p_log_request p2p_request;
+    int rc = readall(fd_log, &p2p_request, sizeof(p2p_request));
+    if (rc == 0) {
+      break;
+    }
+
+    printf("MSG(request,source,tag): %d,%d,%d\n",
+	   p2p_request.request, p2p_request.source, p2p_request.tag);
+  }
+  return 0;
+}
  
+int show_log(char *name)
+{
+  int rank;
+
+  if (sscanf(name, P2P_LOG_MSG, &rank) == 1) {
+    show_msg_file(name);
+  } else if (sscanf(name, P2P_LOG_REQUEST, &rank) == 1) {
+    show_request_file(name);
+  } else {
+    fprintf(stderr, "Not a p2p log fle %s, error: %s\n", name, strerror(errno));
+    return 1;
+  }
+
+  return 0;
+}

--- a/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
@@ -81,7 +81,9 @@ void fill_in_log(struct p2p_log_msg *p2p_log) {
       p2p_log->tag = p2p_request.tag;
       break;
     }
-    // The request sequence is out of order
+    // The request sequence is out of order. This could happen when MPI_Wait
+    // for a high request number is called first followed by MPI_Wait for a
+    // lower request number.
     if (req_start_offset == 0 && p2p_request.request > p2p_log->request) {
       req_start_offset = lseek(fd2, 0, SEEK_CUR) - sizeof(p2p_request);
     }

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
@@ -168,8 +168,6 @@ USER_DEFINED_WRAPPER(int, Irecv,
   size = size * count;
 
   DMTCP_PLUGIN_DISABLE_CKPT();
-  LOG_PRE_Irecv(&status);
-  REPLAY_PRE_Irecv(count,datatype,source,tag,comm);
 
   if (mana_state == RUNNING &&
       isBufferedPacket(source, tag, comm, &flag, &status)) {
@@ -180,6 +178,9 @@ USER_DEFINED_WRAPPER(int, Irecv,
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   }
+  LOG_PRE_Irecv(&status);
+  REPLAY_PRE_Irecv(count,datatype,source,tag,comm);
+
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
@@ -35,6 +35,8 @@
 // To support MANA_P2P_LOG and MANA_P2P_REPLAY:
 #include "p2p-deterministic.h"
 
+extern int p2p_deterministic_skip_save_request;
+
 USER_DEFINED_WRAPPER(int, Send,
                      (const void *) buf, (int) count, (MPI_Datatype) datatype,
                      (int) dest, (int) tag, (MPI_Comm) comm)
@@ -56,7 +58,9 @@ USER_DEFINED_WRAPPER(int, Send,
   if (retval != MPI_SUCCESS) {
     return retval;
   }
+  p2p_deterministic_skip_save_request = 1;
   retval = MPI_Wait(&req, &st);
+  p2p_deterministic_skip_save_request = 0;
 #endif
   return retval;
 }
@@ -145,6 +149,7 @@ USER_DEFINED_WRAPPER(int, Recv,
   if (retval != MPI_SUCCESS) {
     return retval;
   }
+  p2p_deterministic_skip_save_request = 0;
   retval = MPI_Wait(&req, status);
 #endif
   // updateLocalRecvs();

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
@@ -170,6 +170,7 @@ USER_DEFINED_WRAPPER(int, Irecv,
   DMTCP_PLUGIN_DISABLE_CKPT();
   LOG_PRE_Irecv(&status);
   REPLAY_PRE_Irecv(count,datatype,source,tag,comm);
+
   if (mana_state == RUNNING &&
       isBufferedPacket(source, tag, comm, &flag, &status)) {
     consumeBufferedPacket(buf, count, datatype, source, tag, comm,

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -210,6 +210,7 @@ USER_DEFINED_WRAPPER(int, Wait, (MPI_Request*) request, (MPI_Status*) status)
       fflush(stdout);
 #endif
     }
+    if (flag) LOG_POST_Wait(request, statusPtr);
     if (flag && MPI_LOGGING()) {
       clearPendingRequestFromLog(*request);
       REMOVE_OLD_REQUEST(*request);

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -238,14 +238,14 @@ USER_DEFINED_WRAPPER(int, Iprobe,
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  LOG_PRE_Iprobe(status);
+  // LOG_PRE_Iprobe(status);
 
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Iprobe)(source, tag, realComm, flag, status);
   RETURN_TO_UPPER_HALF();
-  LOG_POST_Iprobe(source,tag,comm,status);
-  REPLAY_POST_Iprobe(source,tag,comm,status,flag);
+  // LOG_POST_Iprobe(source,tag,comm,status);
+  // REPLAY_POST_Iprobe(source,tag,comm,status,flag);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -35,6 +35,8 @@
 // To support MANA_P2P_LOG and MANA_P2P_REPLAY:
 #include "p2p-deterministic.h"
 
+extern int p2p_deterministic_skip_save_request;
+
 int MPI_Test_internal(MPI_Request *request, int *flag, MPI_Status *status,
                       bool isRealRequest)
 {
@@ -210,7 +212,9 @@ USER_DEFINED_WRAPPER(int, Wait, (MPI_Request*) request, (MPI_Status*) status)
       fflush(stdout);
 #endif
     }
-    if (flag) LOG_POST_Wait(request, statusPtr);
+    if (p2p_deterministic_skip_save_request == 0) {
+      if (flag) LOG_POST_Wait(request, statusPtr);
+    }
     if (flag && MPI_LOGGING()) {
       clearPendingRequestFromLog(*request);
       REMOVE_OLD_REQUEST(*request);

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -245,7 +245,7 @@ USER_DEFINED_WRAPPER(int, Iprobe,
   retval = NEXT_FUNC(Iprobe)(source, tag, realComm, flag, status);
   RETURN_TO_UPPER_HALF();
   LOG_POST_Iprobe(source,tag,comm,status);
-  REPLAY_POST_Iprobe(count,datatype,source,tag,comm,status);
+  REPLAY_POST_Iprobe(source,tag,comm,status,flag);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
@@ -169,7 +169,6 @@ void p2p_replay_pre_irecv(int count, MPI_Datatype datatype, int *source,
   int rc = 0;
   rc = get_next_msg_irecv(&p2p_msg);
   if (rc == 1) return; // no next msg
-  iprobe_next_msg(&p2p_msg);
   assert(*source == MPI_ANY_SOURCE || *source == p2p_msg.source);
   assert(*tag == MPI_ANY_TAG || *tag == p2p_msg.tag);
   *source = p2p_msg.source;

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
@@ -104,15 +104,21 @@ int get_next_msg_irecv(struct p2p_log_msg *p2p_msg) {
 }
 
 int get_next_msg_iprobe(struct p2p_log_msg *p2p_msg) {
-  static int fd = -1;
+#define UNINITIALIZED -2
+  static int fd = UNINITIALIZED;
   int rc = 1;
-  if (fd == -1) {
+  if (fd == UNINITIALIZED) {
     char buf[100];
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     snprintf(buf, sizeof(buf)-1, P2P_LOG_MSG, rank);
     fd = open(buf, O_RDONLY);
     if (fd == -1) {
+      fd = UNINITIALIZED;
+      // The log file is created by set_next_msg() which
+      // is called later. It is expected that first open
+      // fails. Return 1 here to indicate that there is
+      // not any next message yet.
       return 1;
     }
   }

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
@@ -12,6 +12,7 @@
 #define USE_WRITEALL
 #include "p2p-deterministic.h"
 
+int p2p_deterministic_skip_save_request = 0;
 /**********************************************************************************
  * USAGE (workflow):
  *   MANA_P2P_LOG=1 mana_launch -i SECONDS ... mpi_executable
@@ -35,6 +36,7 @@
 
 static struct p2p_log_msg next_msg_entry = {0, MPI_CHAR, 0, 0, 0, MPI_COMM_NULL, MPI_REQUEST_NULL};
 static struct p2p_log_msg *next_msg = NULL;
+static int logging_start = 0;
 
 void p2p_log(int count, MPI_Datatype datatype, int source, int tag,
              MPI_Comm comm, MPI_Status *status, MPI_Request *request) {
@@ -146,6 +148,7 @@ void set_next_msg(int count, MPI_Datatype datatype,
       exit(1);
     }
   }
+  logging_start = 1;
   p2p_msg.count = count;
   p2p_msg.datatype = datatype;
   p2p_msg.source = source;
@@ -233,6 +236,7 @@ void  p2p_replay(int count, MPI_Datatype datatype, int *source, int *tag,
 void save_request_info(MPI_Request *request, MPI_Status *status) {
   struct p2p_log_request p2p_request;
   static int fd = -2;
+  if (!logging_start) return;
   if (fd == -2) {
     char buf[100];
     int rank;

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
@@ -167,14 +167,8 @@ void p2p_replay_pre_irecv(int count, MPI_Datatype datatype, int *source,
                           int *tag, MPI_Comm comm) {
   struct p2p_log_msg p2p_msg;
   int rc = 0;
-  rc = iprobe_next_msg(NULL);
-  if (rc == -1) return; // no next msg
-  while (iprobe_next_msg(NULL) == 0) {
-    // consume messages where log says MPI_Iprobe: flag==0
-    rc = get_next_msg_irecv(&p2p_msg);
-    if (rc == 1) return; // no next msg
-  }
-  // Now log says MPI_Iprobe returned with flag==1
+  rc = get_next_msg_irecv(&p2p_msg);
+  if (rc == 1) return; // no next msg
   iprobe_next_msg(&p2p_msg);
   assert(*source == MPI_ANY_SOURCE || *source == p2p_msg.source);
   assert(*tag == MPI_ANY_TAG || *tag == p2p_msg.tag);

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -39,7 +39,8 @@ void  p2p_replay_pre_irecv(int count, MPI_Datatype datatype, int *source,
                            int *tag, MPI_Comm comm);
 void p2p_replay_post_iprobe(int *source, int *tag,
 		            MPI_Comm comm, MPI_Status *status, int *flag);
-int get_next_msg(struct p2p_log_msg *p2p_msg);
+int get_next_msg_irecv(struct p2p_log_msg *p2p_msg);
+int get_next_msg_iprobe(struct p2p_log_msg *p2p_msg);
 int iprobe_next_msg(struct p2p_log_msg *p2p_msg);
 void set_next_msg(int count, MPI_Datatype datatype,
                   int source, int tag, MPI_Comm comm,

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -221,7 +221,6 @@ ssize_t writeall(int fd, void *buf, size_t count) {
 #define LOG_PRE_Test(status) LOG_PRE_Wait(status)
 
 // After MPI_Wait, MPI_Test during log/launch
-// NOT USED:  MPI_Wait wrapper calls MPI_Test
 #define LOG_POST_Wait(request,status)
   if (getenv("MANA_P2P_LOG")) {
     if (flag) {

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -33,7 +33,11 @@ struct p2p_log_request {
 
 void p2p_log(int count, MPI_Datatype datatype, int source, int tag,
              MPI_Comm comm, MPI_Status *status, MPI_Request *request);
-void get_next_msg(struct p2p_log_msg *p2p_msg);
+void  p2p_replay(int count, MPI_Datatype datatype, int *source, int *tag,
+                 MPI_Comm comm);
+void  p2p_replay_irecv(int count, MPI_Datatype datatype, int source, int tag,
+                       MPI_Comm comm);
+int get_next_msg(struct p2p_log_msg *p2p_msg);
 int iprobe_next_msg(struct p2p_log_msg *p2p_msg);
 void set_next_msg(int count, MPI_Datatype datatype,
                   int source, int tag, MPI_Comm comm,
@@ -171,16 +175,7 @@ ssize_t writeall(int fd, void *buf, size_t count) {
 // FIXME:  Need to add MPI_Recv_init when MANA supports it
 #define REPLAY_PRE_Irecv(count,datatype,source,tag,comm)
   if (getenv("MANA_P2P_REPLAY")) {
-    struct p2p_log_msg p2p_msg;
-    while (!iprobe_next_msg(NULL)) {
-      // consume messages where log says MPI_Iprobe: flag==0
-      get_next_msg(&p2p_msg);
-    } // Now log says MPI_Iprobe returned with flag==1
-    iprobe_next_msg(&p2p_msg);
-    assert(source == MPI_ANY_SOURCE || source == p2p_msg.source);
-    assert(tag == MPI_ANY_TAG || tag == p2p_msg.tag);
-    source = p2p_msg.source;
-    tag = p2p_msg.tag;
+    p2p_replay_irecv(count,datatype,source,tag,comm);
   }
 
 // Before MPI_Probe during replay
@@ -197,8 +192,8 @@ ssize_t writeall(int fd, void *buf, size_t count) {
   int MPI_Iprobe_recurse = 0;
   if (getenv("MANA_P2P_REPLAY") && !MPI_Iprobe_recurse) {
     struct p2p_log_msg p2p_msg;
-    if (*flag != 0 || iprobe_next_msg(NULL)) { // There is a message.
-      while (!iprobe_next_msg(NULL)) {
+    if (*flag != 0 || iprobe_next_msg(NULL) == 1) { // There is a message.
+      while (iprobe_next_msg(NULL) == 0) {
         // consume messages where log says MPI_Iprobe: flag==0
         get_next_msg(&p2p_msg);
       } // Now log says MPI_Iprobe returned with flag==1

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -35,8 +35,10 @@ void p2p_log(int count, MPI_Datatype datatype, int source, int tag,
              MPI_Comm comm, MPI_Status *status, MPI_Request *request);
 void  p2p_replay(int count, MPI_Datatype datatype, int *source, int *tag,
                  MPI_Comm comm);
-void  p2p_replay_irecv(int count, MPI_Datatype datatype, int source, int tag,
-                       MPI_Comm comm);
+void  p2p_replay_pre_irecv(int count, MPI_Datatype datatype, int *source,
+                           int *tag, MPI_Comm comm);
+void p2p_replay_post_iprobe(int *source, int *tag,
+		            MPI_Comm comm, MPI_Status *status, int *flag);
 int get_next_msg(struct p2p_log_msg *p2p_msg);
 int iprobe_next_msg(struct p2p_log_msg *p2p_msg);
 void set_next_msg(int count, MPI_Datatype datatype,
@@ -175,7 +177,7 @@ ssize_t writeall(int fd, void *buf, size_t count) {
 // FIXME:  Need to add MPI_Recv_init when MANA supports it
 #define REPLAY_PRE_Irecv(count,datatype,source,tag,comm)
   if (getenv("MANA_P2P_REPLAY")) {
-    p2p_replay_irecv(count,datatype,source,tag,comm);
+    p2p_replay_pre_irecv(count,datatype,&source,&tag,comm);
   }
 
 // Before MPI_Probe during replay
@@ -188,26 +190,9 @@ ssize_t writeall(int fd, void *buf, size_t count) {
 // After call to MPI_Iprobe() in lower half during replay
 //   Make sure log is in sync with MPI_Iprobe again.
 // FIXME:  Need to add MPI_Improbe when MANA supports it
-#define REPLAY_POST_Iprobe(count,datatype,source,tag,comm,status)
-  int MPI_Iprobe_recurse = 0;
-  if (getenv("MANA_P2P_REPLAY") && !MPI_Iprobe_recurse) {
-    struct p2p_log_msg p2p_msg;
-    if (*flag != 0 || iprobe_next_msg(NULL) == 1) { // There is a message.
-      while (iprobe_next_msg(NULL) == 0) {
-        // consume messages where log says MPI_Iprobe: flag==0
-        get_next_msg(&p2p_msg);
-      } // Now log says MPI_Iprobe returned with flag==1
-      // Call blocking probe until implicit *flag and log agree
-      assert(source == MPI_ANY_SOURCE || source == p2p_msg.source);
-      assert(tag == MPI_ANY_TAG || tag == p2p_msg.tag);
-      MPI_Iprobe_recurse = 1;
-      MPI_Probe(p2p_msg.source, p2p_msg.tag, p2p_msg.comm, status);
-      MPI_Iprobe_recurse = 0;
-      *flag = 1;
-    } else { // else: *flag == 0; log says MPI_Iprobe returned with flag==0
-      get_next_msg(&p2p_msg); // flag and log agree: consume this message
-      *flag = 0;
-    }
+#define REPLAY_POST_Iprobe(source,tag,comm,status,flag)
+  if (getenv("MANA_P2P_REPLAY")) {
+    p2p_replay_post_iprobe(&source,&tag,comm,status,flag);
   }
 
 /************************************************

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -142,7 +142,7 @@ ssize_t writeall(int fd, void *buf, size_t count) {
 // FIXME:  Need to add MPI_Improbe when MANA supports it
 #define LOG_PRE_Iprobe(status)
   MPI_Status local_status;
-  if (getenv("MANA_P2P_LOG") && status != MPI_STATUS_IGNORE) {
+  if (getenv("MANA_P2P_LOG") && status == MPI_STATUS_IGNORE) {
     status = &local_status;
   }
 

--- a/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/contrib/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -120,7 +120,7 @@ ssize_t writeall(int fd, void *buf, size_t count) {
   if (getenv("MANA_P2P_LOG")) {
     // source and tag will be filled in later, based on request
     // (count, datatype) will be replaced by (bytesRecvd, MPI_CHAR)
-    p2p_log(count, datatype, source, tag, comm, status, request);
+    p2p_log(count, datatype, source, tag, comm, NULL, request);
   }
 
 // Before MPI_Probe during original launch/log

--- a/contrib/mpi-proxy-split/two-phase-algo.cpp
+++ b/contrib/mpi-proxy-split/two-phase-algo.cpp
@@ -28,6 +28,7 @@
 #include "virtual-ids.h"
 #include "siginfo.h"
 
+extern int p2p_deterministic_skip_save_request;
 using namespace dmtcp_mpi;
 
 struct twoPhaseHistory {
@@ -152,7 +153,9 @@ TwoPhaseAlgo::commit_begin(MPI_Comm comm)
     nanosleep(&test_interval, NULL);
   }
 #else
+  p2p_deterministic_skip_save_request = 1;
   MPI_Wait(&_request, MPI_STATUS_IGNORE);
+  p2p_deterministic_skip_save_request = 0;
 #endif
 
   if (isCkptPending()) {

--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -356,7 +356,7 @@ FileConnection::refill(bool isRestart)
             ((_fcntlFlags & O_WRONLY) || (_fcntlFlags & O_RDWR))) {
           errno = 0;
           JWARNING(false) (_path) (_st_size) (statbuf.st_size)
-          .Text("Set saved size to the current file size");
+          .Text("Setting saved size to the current file size");
 	  _st_size = statbuf.st_size;
           // JASSERT(truncate(_path.c_str(), _st_size) == 0)
           //  (_path.c_str()) (_st_size) (JASSERT_ERRNO);

--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -355,8 +355,11 @@ FileConnection::refill(bool isRestart)
         if (statbuf.st_size > _st_size &&
             ((_fcntlFlags & O_WRONLY) || (_fcntlFlags & O_RDWR))) {
           errno = 0;
-          JASSERT(truncate(_path.c_str(), _st_size) == 0)
-            (_path.c_str()) (_st_size) (JASSERT_ERRNO);
+          JWARNING(false) (_path) (_st_size) (statbuf.st_size)
+          .Text("Set saved size to the current file size");
+	  _st_size = statbuf.st_size;
+          // JASSERT(truncate(_path.c_str(), _st_size) == 0)
+          //  (_path.c_str()) (_st_size) (JASSERT_ERRNO);
         } else if (statbuf.st_size < _st_size) {
           JWARNING(false).Text("Size of file smaller than what we expected");
         }


### PR DESCRIPTION
This change adds several enhancements and bug fixes in deterministic p2p log and replay. 

The main changes are,
- Log in MPI_Irecv, MPI_Iprobe, MPI_Wait and MPI_Test
- Don't truncate file to the saved file size saved in checkpoint image. The message log file continues saving messages post checkpoint while the program runs. So its size is larger.
- Change get_next_message to support when both MANA_P2P_LOG and MANA_P2P_REPLAY are enabled at the same time.
- Enhance mana_p2p_update_logs to handle the request number out of order.