### PR TITLE
Fix RestoreInfo defines differently when --enable-timing

### DIFF
--- a/restart_plugin/mtcp_restart_plugin.h
+++ b/restart_plugin/mtcp_restart_plugin.h
@@ -2,6 +2,7 @@
 #define __MTCP_RESTART_PLUGIN_H__
 #include <sys/types.h>
 #include <stdint.h>
+#include "config.h"
 
 typedef void (*fnptr_t)();
 


### PR DESCRIPTION
Any idea how to make sure every source file includes the "config.h", so we won't have this problem again?