### PR TITLE
Fix: src and dest of mremap_move may overlap in mtcp_restart.c

### DIFF
--- a/src/mtcp/Makefile.in
+++ b/src/mtcp/Makefile.in
@@ -95,8 +95,13 @@ default: build
 libs: build
 build: $(targetdir)/bin/$(MTCP_RESTART) libmtcp.a
 
+# TODO(kapil): Check if -Ttext-segment value is appropriate for x86.
+# The other sections (bss, rodata, etc.) will follow immediately after text.
+# A 2MB hugepage is 0x200000.  Addresses must be a multiple of 0x200000.
+LINKER_FLAGS= -Wl,-Ttext-segment=11200000 #-Wl,-Trodata-segment=445000000
+
 $(targetdir)/bin/$(MTCP_RESTART): mtcp_restart.o mtcp_split_process.o getcontext.o
-	${ARM_BINARIES} ${LINK} -fPIC -g -O0 -nodefaultlibs $^
+	${ARM_BINARIES} ${LINK} -fPIC -g -O0 -nodefaultlibs ${LINKER_FLAGS} $^
 
 # We need to compile mtcp_restart.c with "-fno-stack-protector" to avoid
 # runtime stack smashing detection.


### PR DESCRIPTION
This is a port of `Fix: src and dest of mremap_move may overlap in mtcp_restart.c #975` from DMTCP:
&nbsp;&nbsp;  https://github.com/dmtcp/dmtcp/pull/975
See the description in the DMTCP PR for details.