### PR TITLE
Fix the race between two phase commit and checkpointing

### DIFF
--- a/contrib/mpi-proxy-split/mana_coordinator.cpp
+++ b/contrib/mpi-proxy-split/mana_coordinator.cpp
@@ -298,6 +298,20 @@ unblockRanks(const ClientToStateMap& clientStates, long int size)
   query_t *queries = (query_t*) malloc(size * sizeof(query_t));
   memset(queries, NONE, size * sizeof(query_t));
 
+  // If all members are in PHASE_1, give one free pass
+  // so one member can proceed to IN_CS and unblock
+  // other ranks eventually.
+  int found = 0;
+  for (RankKVPair c : clientStates) {
+    if (c.second.st != PHASE_1) {
+      found = 1;
+      break;
+    }
+  }
+  if (found == 0) {
+    queries[clientStates.begin()->second.rank] = FREE_PASS;
+  }
+
   // if some member of a communicator is in the critical section,
   // give free passes to members in phase 1 or the trivial barrier.
   for (RankKVPair c : clientStates) {

--- a/contrib/mpi-proxy-split/two-phase-algo.cpp
+++ b/contrib/mpi-proxy-split/two-phase-algo.cpp
@@ -230,7 +230,7 @@ TwoPhaseAlgo::preSuspendBarrier(const void *data)
     case INTENT:
       setCkptPending();
       if (getCurrState() == PHASE_1) {
-	st = waitForNewStateAfter(PHASE_1, 10 /* timeout ms*/);
+	st = waitForNewStateAfter(PHASE_1, 100 /* timeout ms*/);
 	if (st == PHASE_1) break;
         // Wait for us to finish doing IN_CS
         if (st != IN_CS) {
@@ -316,6 +316,8 @@ TwoPhaseAlgo::waitForNewStateAfter(phase_t oldState, int timeout_ms)
   lock_t lock(_phaseMutex);
 
   if (timeout_ms) {
+    // Since _phaseCv is a condition var., it should be prepared for spurious wakeups.
+    // So, waking it up on a timeout is harmless.
     _phaseCv.wait_for(lock, std::chrono::milliseconds(timeout_ms),
                       [this, oldState]
                       { return _currState != oldState &&

--- a/contrib/mpi-proxy-split/two-phase-algo.h
+++ b/contrib/mpi-proxy-split/two-phase-algo.h
@@ -162,7 +162,7 @@ namespace dmtcp_mpi
       void stop(MPI_Comm);
 
       // Wait until the state is changed to a new state
-      phase_t waitForNewStateAfter(phase_t oldState);
+      phase_t waitForNewStateAfter(phase_t oldState, int timeout_ms=0);
 
       // Sends the given message 'msg' (along with the given 'extraData') to
       // the coordinator


### PR DESCRIPTION
There is race between two phase algorithm preSuspendBarrier() and two
phase commit commit_begin().
T1 thread #1: setCkptPending()
T2               thread #2: checks isCkptPending() then stop(comm)
T3              thread #2: stop(comm) sets state to PHASE_1
T4              thread #2: while isCkptPending() loop
T5 thread #1 calls waitForNewStateAfter(PHASE_1)

This change adds a timeout when waiting state change. When timeout
expires, the barrier sends a response message to the coordinator.
The coordinator gives a free phase1 pass to one member if all members
are in phase1 so this member can move to IN_CS state and contine
two phase commit. Once this member is in IN_CS, the coordinator would
unblock other members.