### PR TITLE
Fix race between two phase commit preSuspendBarrier and commit_begin

### DIFF
--- a/mpi-proxy-split/two-phase-algo.h
+++ b/mpi-proxy-split/two-phase-algo.h
@@ -162,7 +162,7 @@ namespace dmtcp_mpi
       void stop(MPI_Comm);
 
       // Wait until the state is changed to a new state
-      phase_t waitForNewStateAfter(phase_t oldState);
+      phase_t waitForNewStateAfter(phase_t oldState, int timeout_ms=0);
 
       // Sends the given message 'msg' (along with the given 'extraData') to
       // the coordinator


### PR DESCRIPTION
There is race between two phase algorithm preSuspendBarrier() and two
phase commit commit_begin().

T1 thread #1: setCkptPending()
T2               thread #2: checks isCkptPending() then stop(comm)
T3              thread #2: stop(comm) sets state to PHASE_1
T4              thread #2: while isCkptPending() loop
T5 thread #1 calls waitForNewStateAfter(PHASE_1)

This change adds a timeout when waiting state change. When the
preSuspend wait for PHASE_1 state change times out, it would
set response to FREE_PASS.