### PR TITLE
Use p2p wrapper for Bcast to avoid hang on restart

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -38,7 +38,7 @@
 # include "mpi_collective_p2p.c"
 #endif
 
-// #define NO_BARRIER_BCAST
+#define NO_BARRIER_BCAST
 using namespace dmtcp_mpi;
 
 #ifndef MPI_COLLECTIVE_P2P


### PR DESCRIPTION
```
Rank 0 (root)    Rank 1
     |              |
-----+--------------X----- Trivial barrier
     |              |
-----+--------------+----- Phase_1
     |              |
-----+--------------+----- Critical section (MPI_Bcast())
     |              |
-----X--------------+----- Outside of the wrapper
     |              |
     v              v
```
Both ranks entered and trivial barrier. Rank 0 leave the trivial barrier first.
Then it finishes the critical section fast and leave the wrapper. Rank 1 is
still in the trivial barrier, waiting a new round of MPI_Test_internal is
called so that it can leave the trivial barrier. At this moment, a checkpoint
is requested. Since no rank is in the critical section, the coordinator decide
to do the checkpoint. On restart, rank 1 replayed the trivial barrier because
it was in the trivial barrier at the checkpoint time, but rank 0 does not
replay the trivial barrier because it was out of the wrapper. In this case,
rank 1 will hang in the MPI_Wait, waiting the trivial barrier can finishes,
which will never happen.

This can be fixed with the hybrid two-phase-commit algorithm because no trivial
barrier will be replayed on restart. For now, a simple temporary fix is to
define the NO_BARRIER_BCAST macro in mpi_collective_wrapper.cpp. It will use a
point-to-point implementation of MPI_Bcast instead of the collective version.
Therefore, the trivial barrier problem is avoided. The drawback is a small
degrade of performance. Another fix we can have is adding a point-to-point
communication at the end of MPI_Bcast's wrapper to force it to be truely
blocking.