### PR TITLE
Polish README.md of feature/dmtcp-master

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ applications, including multi-threaded and distributed applications. It
 operates directly on the user binary executable, without any Linux kernel
 modules or other kernel modifications.
 
-** [If you are looking for MANA (suppot for MPI), please read below.] **
+<hr>
+
+**If you are looking for MANA (support for MPI), please read:**<br>
+ &nbsp;&nbsp;&nbsp;&nbsp; *[the section on MANA](README.md#mana-mpi-agnostic-network-agnostic-mpi)*, **below.**
+<hr>
 
 Among the applications supported by DMTCP are MPI (various implementations),
 OpenMP, MATLAB, Python, Perl, R, and many programming languages and shell
@@ -49,8 +53,6 @@ of accuracy on restart.  This is still under development.  Please test
 your application on MANA first, before using MANA.
 
 For details of installing and using MANA, please see:
-- [the MANA README file](https://github.com/mpickpt/mana/blob/master/mpi-proxy-split/README)
-or (older version):
-- [the MANA README file](https://github.com/mpickpt/mana/blob/master/contrib/mpi-proxy-split/README) and
-- [the MANA INSTALL file](https://github.com/mpickpt/mana/blob/master/contrib/mpi-proxy-split/INSTALL)
-- [the MANA 'man' page](https://github.com/mpickpt/mana/blob/master/manpages/mana.1) (or 'nroff -man mana.1')
+- [the newer MANA README file](https://github.com/mpickpt/mana/blob/feature/dmtcp-master/mpi-proxy-split/README)
+- which will eventually replace the older (obsolete) version at: [the older MANA README file](https://github.com/mpickpt/mana/blob/master/contrib/mpi-proxy-split/README)
+- [the MANA 'man' page](https://github.com/mpickpt/mana/blob/master/manpages/mana.1) (or 'nroff -man mana.1' on a local copy)


### PR DESCRIPTION
Fix links on top-level README.md to point to the right things, and remove a pointer to the obsolete INSTALL file.