### PR TITLE
Add temporary fix for Fortran-to-C array bug

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/generate-mpi-fortran-wrappers.py
+++ b/mpi-proxy-split/mpi-wrappers/generate-mpi-fortran-wrappers.py
@@ -90,13 +90,17 @@ def emit_wrapper(decl, ret_type, fnc, args, arg_vars):
   if fnc in ['MPI_Wtime', 'MPI_Wtick']:
     print("  return " + fnc + "(" + cargs + ");")
   else:
+      if "int* index" in fargs:
+        # This is a temporary fix for the Fortran-to-C interface bug -
+        # more details can be found in MPI_Testany in mpi_request_wrappers.cpp
+        print("  int *local_index = index;");
       print("  *ierr = " + fnc + "(" + cargs + ");")
       if "int* index" in fargs:
         if not (fnc in ['MPI_Waitany', 'MPI_Testany']):
           warnings.warn("'int* index' found in {fnc} - likely to cause erroneous behavior".format(fnc=fnc))
         # We need this line because Fortran arrays start from 1, and *index
         # refers to the index of the first request that completes in an array.
-        print("  *index = *index + 1;")
+        print("  *local_index = *local_index + 1;")
       print("  return *ierr;")
   print("}")
   # print(ret_type + " " + fnc.lower() + "_ (" + args + ") __attribute__ ((weak, alias (\"" + fnc + "\")));")

--- a/mpi-proxy-split/mpi-wrappers/mpi_fortran_wrappers.txt
+++ b/mpi-proxy-split/mpi-wrappers/mpi_fortran_wrappers.txt
@@ -59,7 +59,7 @@ int MPI_Iprobe(int source, int tag, MPI_Comm comm, int* flag, MPI_Status* status
 int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status* status);
 int MPI_Waitall(int count, MPI_Request* array_of_requests, MPI_Status* array_of_statuses);
 int MPI_Waitany(int count, MPI_Request* array_of_requests, int* index, MPI_Status* status);
-int MPI_Testall(int count, MPI_Request* requests, int* flag, MPI_Status* statuses);
+int MPI_Testall(int count, MPI_Request* array_of_requests, int* flag, MPI_Status* array_of_statuses);
 int MPI_Testany(int count, MPI_Request* array_of_requests, int* index, int* flag, MPI_Status* status);
 
 int MPI_Comm_group(MPI_Comm comm, MPI_Group* group);


### PR DESCRIPTION
This pull request adds a temporary fix for the Fortran-to-C array bug. This is a bug where, when passing an array as an argument in a function from Fortran to MANA's C wrapper, the arguments are passed by registers instead of on the stack. As a result, when another function returns inside the C wrapper, the arguments are corrupted. We don't yet know the cause of this bug, but creating a local copy of all the arguments before any internal function calls return fixes the issue.