### PR TITLE
Add MPI_ANY_SOURCE test in drain_send_recv 

### DIFF
--- a/mpi-proxy-split/unit-test/Makefile
+++ b/mpi-proxy-split/unit-test/Makefile
@@ -35,8 +35,8 @@ override CXXFLAGS += -g3 -O0 -fPIC -I${DMTCP_INCLUDE} \
                      -I${DMTCP_ROOT}/src -std=c++11 \
                      -D'NEXT_FUNC(fnc)=MPI_\#\#fnc'
 
-TEST_LD_FLAGS=${DMTCP_ROOT}/src/libjalib.a \
-              ${DMTCP_ROOT}/src/libdmtcpinternal.a \
+TEST_LD_FLAGS=${DMTCP_ROOT}/src/libdmtcpinternal.a \
+              ${DMTCP_ROOT}/src/libjalib.a \
               ${DMTCP_ROOT}/src/libnohijack.a \
               -lgtest -lpthread
 

--- a/mpi-proxy-split/unit-test/drain-send-recv-test.cpp
+++ b/mpi-proxy-split/unit-test/drain-send-recv-test.cpp
@@ -176,7 +176,13 @@ TEST_F(DrainTests, testRecvDrain)
   EXPECT_EQ(MPI_Comm_dup(_comm, &newcomm), MPI_SUCCESS);
   EXPECT_EQ(MPI_Type_size(MPI_INT, &size), MPI_SUCCESS);
   for (int i = 0; i < TWO; i++) {
-    EXPECT_EQ(MPI_Irecv(&rbuf, 1, MPI_INT, 0, 0, newcomm, &reqs[i]),
+    int source = 0;
+    int tag = 0;
+    if (i == 0) {
+      source = MPI_ANY_SOURCE;
+      tag = MPI_ANY_TAG;
+    }
+    EXPECT_EQ(MPI_Irecv(&rbuf, 1, MPI_INT, source, tag, newcomm, &reqs[i]),
               MPI_SUCCESS);
     addPendingRequestToLog(IRECV_REQUEST, NULL, &rbuf, 1,
                            MPI_INT, 0, 0, newcomm, reqs[i]);

--- a/mpi-proxy-split/unit-test/drain-send-recv-test.cpp
+++ b/mpi-proxy-split/unit-test/drain-send-recv-test.cpp
@@ -212,6 +212,7 @@ TEST_F(DrainTests, testRecvDrain)
 int
 main(int argc, char **argv, char **envp)
 {
+  initializeJalib();
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/mpi-proxy-split/unit-test/record-replay-cart-test.cpp
+++ b/mpi-proxy-split/unit-test/record-replay-cart-test.cpp
@@ -111,6 +111,7 @@ TEST_F(CartTests, testCartSub)
 int
 main(int argc, char **argv)
 {
+  initializeJalib();
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/mpi-proxy-split/unit-test/record-replay-comm-test.cpp
+++ b/mpi-proxy-split/unit-test/record-replay-comm-test.cpp
@@ -102,6 +102,7 @@ TEST_F(CommTests, testCommCreate)
 int
 main(int argc, char **argv)
 {
+  initializeJalib();
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/mpi-proxy-split/unit-test/record-replay-group-test.cpp
+++ b/mpi-proxy-split/unit-test/record-replay-group-test.cpp
@@ -46,6 +46,7 @@ TEST_F(GroupTest, testGroupAPI)
 int
 main(int argc, char **argv)
 {
+  initializeJalib();
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/mpi-proxy-split/unit-test/record-replay-types-test.cpp
+++ b/mpi-proxy-split/unit-test/record-replay-types-test.cpp
@@ -97,6 +97,7 @@ TEST_F(TypesTests, testTypeCommit)
 int
 main(int argc, char **argv)
 {
+  initializeJalib();
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
First, this change adds test for MPI_ANY_SOURCE in drain_send_recv_test. 

Second, Libdmtcpinternal.a depends on Jbuffer() from libjalib.a and libjalib.a depends on initializeJalib() from libdmtcpinternal.a. This change fixes this inter-dependency. It calls initializeJalib in the test program so that we have the sequence
weak definition of initializeJalib in test program, real definition of initializeJalib in libdmtcpinternal.a followed by weak definition initialJalib in libjalib.a. This keeps the real definition of initializeJalib from being removed so that libjalib.a can access since initalizeJalib is used by the test program. 