### PR TITLE
[MANA-8] Remove the request from record-replay log when it finishes

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -103,10 +103,14 @@ USER_DEFINED_WRAPPER(int, Test, (MPI_Request*) request,
 #endif
   }
   LOG_POST_Test(request, statusPtr);
-  if (retval == MPI_SUCCESS && *flag && MPI_LOGGING()) {
-    clearPendingRequestFromLog(*request);
-    REMOVE_OLD_REQUEST(*request);
-    *request = MPI_REQUEST_NULL;
+  if (retval == MPI_SUCCESS && *flag) {
+    if (MPI_LOGGING()) {
+      clearPendingRequestFromLog(*request);
+      REMOVE_OLD_REQUEST(*request);
+      *request = MPI_REQUEST_NULL;
+    } else {
+      LOG_REMOVE_REQUEST(*request);
+    }
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
@@ -284,10 +288,14 @@ USER_DEFINED_WRAPPER(int, Wait, (MPI_Request*) request, (MPI_Status*) status)
       fflush(stdout);
 #endif
     }
-    if (flag && MPI_LOGGING()) {
-      clearPendingRequestFromLog(*request);
-      REMOVE_OLD_REQUEST(*request);
-      *request = MPI_REQUEST_NULL;
+    if (flag) {
+      if (MPI_LOGGING()) {
+        clearPendingRequestFromLog(*request);
+        REMOVE_OLD_REQUEST(*request);
+        *request = MPI_REQUEST_NULL;
+      } else {
+	LOG_REMOVE_REQUEST(*request);
+      }
     }
     DMTCP_PLUGIN_ENABLE_CKPT();
   }

--- a/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -103,14 +103,11 @@ USER_DEFINED_WRAPPER(int, Test, (MPI_Request*) request,
 #endif
   }
   LOG_POST_Test(request, statusPtr);
-  if (retval == MPI_SUCCESS && *flag) {
-    if (MPI_LOGGING()) {
-      clearPendingRequestFromLog(*request);
-      REMOVE_OLD_REQUEST(*request);
-      *request = MPI_REQUEST_NULL;
-    } else {
-      LOG_REMOVE_REQUEST(*request);
-    }
+  if (retval == MPI_SUCCESS && *flag && MPI_LOGGING()) {
+    clearPendingRequestFromLog(*request);
+    REMOVE_OLD_REQUEST(*request);
+    LOG_REMOVE_REQUEST(*request); // remove from record-replay log
+    *request = MPI_REQUEST_NULL;
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
@@ -288,14 +285,11 @@ USER_DEFINED_WRAPPER(int, Wait, (MPI_Request*) request, (MPI_Status*) status)
       fflush(stdout);
 #endif
     }
-    if (flag) {
-      if (MPI_LOGGING()) {
-        clearPendingRequestFromLog(*request);
-        REMOVE_OLD_REQUEST(*request);
-        *request = MPI_REQUEST_NULL;
-      } else {
-	LOG_REMOVE_REQUEST(*request);
-      }
+    if (flag && MPI_LOGGING()) {
+      clearPendingRequestFromLog(*request); // Remove from g_async_calls
+      REMOVE_OLD_REQUEST(*request); // Remove from virtual id
+      LOG_REMOVE_REQUEST(*request); // Remove from record-replay log
+      *request = MPI_REQUEST_NULL;
     }
     DMTCP_PLUGIN_ENABLE_CKPT();
   }

--- a/mpi-proxy-split/record-replay.h
+++ b/mpi-proxy-split/record-replay.h
@@ -562,7 +562,9 @@ namespace dmtcp_mpi
 	        return false;
             }
 	  };
-        remove_if(_records.begin(), _records.end(), isStaleRequest);
+        mpi_record_vector_iterator_t it =
+          remove_if(_records.begin(), _records.end(), isStaleRequest);
+	_records.erase(it, _records.end());
       }
 
       // Returns true if we are currently replaying the MPI calls


### PR DESCRIPTION
Record-replay records Ibarrier/Ireduce/Ibcast in the log. This change removes the request from the log once it finishes at MPI_Wait/MPI_Test so the request wouldn't be relayed at the time of
checkpoint restart.

Now that VASP checkpoint restart is bit-for-bit MATCH with vasp native. I tested restart with the VASP5 PdO2 64 ranks and PdO4 128 ranks. Checkpoint restart results matches the reference results from Zhengji as well.