### PR TITLE
[MANA-133] Fix MPI_REQUEST_NULL not being skipped in Testany

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -173,7 +173,6 @@ USER_DEFINED_WRAPPER(int, Testany, (int) count,
     if (local_array_of_requests[i] == MPI_REQUEST_NULL) {
       continue;
     }
-    *local_flag = 0;
     retval = MPI_Test(&local_array_of_requests[i], local_flag, local_status);
     if (retval != MPI_SUCCESS) {
       break;

--- a/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -167,14 +167,13 @@ USER_DEFINED_WRAPPER(int, Testany, (int) count,
   MPI_Status *local_status = status;
 
   int retval;
-  bool all_requests_null = true;
-  *local_flag = 0;
+  *local_flag = 1;
   *local_index = MPI_UNDEFINED;
   for (int i = 0; i < local_count; i++) {
     if (local_array_of_requests[i] == MPI_REQUEST_NULL) {
       continue;
     }
-    all_requests_null = false;
+    *local_flag = 0;
     retval = MPI_Test(&local_array_of_requests[i], local_flag, local_status);
     if (retval != MPI_SUCCESS) {
       break;
@@ -183,9 +182,6 @@ USER_DEFINED_WRAPPER(int, Testany, (int) count,
       *local_index = i;
       break;
     }
-  }
-  if (all_requests_null) {
-    *local_flag = 1;
   }
   return retval;
 }

--- a/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -167,9 +167,14 @@ USER_DEFINED_WRAPPER(int, Testany, (int) count,
   MPI_Status *local_status = status;
 
   int retval;
+  bool all_requests_null = true;
   *local_flag = 0;
   *local_index = MPI_UNDEFINED;
   for (int i = 0; i < local_count; i++) {
+    if (local_array_of_requests[i] == MPI_REQUEST_NULL) {
+      continue;
+    }
+    all_requests_null = false;
     retval = MPI_Test(&local_array_of_requests[i], local_flag, local_status);
     if (retval != MPI_SUCCESS) {
       break;
@@ -178,6 +183,9 @@ USER_DEFINED_WRAPPER(int, Testany, (int) count,
       *local_index = i;
       break;
     }
+  }
+  if (all_requests_null) {
+    *local_flag = 1;
   }
   return retval;
 }


### PR DESCRIPTION
This pull requests fixes a bug where `MPI_REQUEST_NULL` handles were not being skipped properly in `MPI_Testany`.