### PR TITLE
Update documentation for eventual feature/dmtcp-master merge

### DIFF
--- a/doc/mana-centos-tutorial.txt
+++ b/doc/mana-centos-tutorial.txt
@@ -268,6 +268,7 @@ In this tutorial, we'll install MANA in the home directory.
   $ cd $HOME
   $ git clone https://github.com/mpickpt/mana.git
   $ cd mana
+  $ git submodule update --init
   $ ./configure-mana
   $ make -j mana
 


### PR DESCRIPTION
This pull request updates documentation in `doc/mana-centos-tutorial.txt` and `mpi-proxy-split/README.md` for the eventual use of `feature/dmtcp-master` as `master`.