### PR TITLE
Fix Makefiles to use MANA_ROOT, not DMTCP_ROOT

### DIFF
--- a/mpi-proxy-split/Makefile
+++ b/mpi-proxy-split/Makefile
@@ -37,9 +37,13 @@ LIBOBJS = mpi_plugin.o p2p_drain_send_recv.o p2p_log_replay.o \
 
 LIBPROXY = libproxy.a
 
+# Modify if your MANA_ROOT is located elsewhere.
+ifndef MANA_ROOT
+  MANA_ROOT=..
+endif
 # Modify if your DMTCP_ROOT is located elsewhere.
 ifndef DMTCP_ROOT
-  DMTCP_ROOT=../dmtcp
+  DMTCP_ROOT=${MANA_ROOT}/dmtcp
 endif
 DMTCP_INCLUDE=${DMTCP_ROOT}/include
 JALIB_INCLUDE=${DMTCP_ROOT}/jalib
@@ -93,28 +97,28 @@ check: libmana.so ${LOWER_HALF_SRCDIR}/lh_proxy ./autotest.py
 check-unit: libmana.so
 	@make -C unit-test/ check
 
-${DMTCP_ROOT}/lib/dmtcp/libmana.so: libmana.so
+${MANA_ROOT}/lib/dmtcp/libmana.so: libmana.so
 	cp -f $< $@
-${DMTCP_ROOT}/lib/dmtcp/libmpistub.so:
+${MANA_ROOT}/lib/dmtcp/libmpistub.so:
 	make -C ${WRAPPERS_SRCDIR} install
-${DMTCP_ROOT}/bin/lh_proxy:
+${MANA_ROOT}/bin/lh_proxy:
 	make -C ${LOWER_HALF_SRCDIR} install
-${DMTCP_ROOT}/bin/gethostbyname_proxy:
+${MANA_ROOT}/bin/gethostbyname_proxy:
 	make -C ${LOWER_HALF_SRCDIR}/gethostbyname-static install
-${DMTCP_ROOT}/bin/mana_p2p_update_logs: ${WRAPPERS_SRCDIR}/mana_p2p_update_logs.c
+${MANA_ROOT}/bin/mana_p2p_update_logs: ${WRAPPERS_SRCDIR}/mana_p2p_update_logs.c
 	make -C ${WRAPPERS_SRCDIR} install
 
 # ${WRAPPERS_SRCDIR}/libmpiwrappers.a ia a prerequisite for libmana.so,
-#   which is a prerequisite for ${DMTCP_ROOT}/lib/dmtcp/libmana.so
+#   which is a prerequisite for ${MANA_ROOT}/lib/dmtcp/libmana.so
 # Always do 'make default' or 'make install' -- not 'make libmana.so'
 # MANA_COORD_OBJS needed for 'make mana' at top level.
 install: ${MANA_COORD_OBJS}
 	make -C ${WRAPPERS_SRCDIR} libmpiwrappers.a
-	make ${DMTCP_ROOT}/lib/dmtcp/libmana.so
-	make ${DMTCP_ROOT}/lib/dmtcp/libmpistub.so
-	make ${DMTCP_ROOT}/bin/lh_proxy
-	make ${DMTCP_ROOT}/bin/gethostbyname_proxy
-	make ${DMTCP_ROOT}/bin/mana_p2p_update_logs
+	make ${MANA_ROOT}/lib/dmtcp/libmana.so
+	make ${MANA_ROOT}/lib/dmtcp/libmpistub.so
+	make ${MANA_ROOT}/bin/lh_proxy
+	make ${MANA_ROOT}/bin/gethostbyname_proxy
+	make ${MANA_ROOT}/bin/mana_p2p_update_logs
 
 tidy:
 	rm -f *~ .*.swp dmtcp_restart_script*.sh ckpt_*.dmtcp
@@ -123,7 +127,7 @@ tidy:
 clean: tidy
 	rm -f ${LIBOBJS} ${MANA_COORD_OBJS}
 	rm -f libmana.so
-	rm -f ${DMTCP_ROOT}/lib/dmtcp/libmana.so
+	rm -f ${MANA_ROOT}/lib/dmtcp/libmana.so
 	@cd ${LOWER_HALF_SRCDIR} && make clean
 	@cd ${WRAPPERS_SRCDIR} && make clean
 

--- a/mpi-proxy-split/lower-half/Makefile
+++ b/mpi-proxy-split/lower-half/Makefile
@@ -8,9 +8,13 @@ LIBPROXY = libproxy
 LIBPROXY_OBJS = libproxy.o procmapsutils.o sbrk.o mmap64.o munmap.o \
 		shmat.o shmget.o
 
+# Modify if your MANA_ROOT is located elsewhere.
+ifndef MANA_ROOT
+  MANA_ROOT=../..
+endif
 # Modify if your DMTCP_ROOT is located elsewhere.
 ifndef DMTCP_ROOT
-  DMTCP_ROOT=../../dmtcp
+  DMTCP_ROOT=${MANA_ROOT}/dmtcp
 endif
 
 ifndef PLUGIN_ROOT
@@ -38,7 +42,7 @@ ${STATIC_GETHOSTBYNAME}: gethostbyname-static/gethostbyname_static.c \
                          gethostbyname-static/gethostbyname_proxy.c
 	cd gethostbyname-static && make gethostbyname_static.o
 	cd gethostbyname-static && make gethostbyname_proxy
-	cp gethostbyname-static/gethostbyname_proxy -f ${DMTCP_ROOT}/bin/
+	cp -f gethostbyname-static/gethostbyname_proxy ${MANA_ROOT}/bin/
 endif
 
 .c.o:
@@ -72,7 +76,7 @@ ${LIBPROXY}.a: ${LIBPROXY_OBJS}
 	ar cr $@ $^
 
 install: ${PROXY_BIN} ${STATIC_GETHOSTBYNAME}
-	cp -f $^ ${DMTCP_ROOT}/bin/
+	cp -f $^ ${MANA_ROOT}/bin/
 
 tidy:
 	rm -f *~ .*.swp dmtcp_restart_script*.sh ckpt_*.dmtcp

--- a/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
+++ b/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
@@ -26,5 +26,5 @@ dist: clean
 
 install:
 	make gethostbyname_proxy
-	cp gethostbyname_proxy -f ../../../../bin
+	cp -f gethostbyname_proxy ../../../bin/
 

--- a/mpi-proxy-split/mpi-wrappers/Makefile
+++ b/mpi-proxy-split/mpi-wrappers/Makefile
@@ -20,9 +20,14 @@ LIBWRAPPER_OBJS = mpi_p2p_wrappers.o mpi_collective_wrappers.o \
                   mpi_win_wrappers.o mpi_file_wrappers.o mpi_error_wrappers.o \
                   p2p-deterministic.o
 
+
+# Modify if your MANA_ROOT is located elsewhere.
+ifndef MANA_ROOT
+  MANA_ROOT=../..
+endif
 # Modify if your DMTCP_ROOT is located elsewhere.
 ifndef DMTCP_ROOT
-  DMTCP_ROOT=../../dmtcp
+  DMTCP_ROOT=${MANA_ROOT}/dmtcp
 endif
 DMTCP_INCLUDE=${DMTCP_ROOT}/include
 JALIB_INCLUDE=${DMTCP_ROOT}/jalib
@@ -78,14 +83,13 @@ mpi_collective_wrappers.o: mpi_collective_wrappers.cpp ../virtual-ids.h \
 	else \
 	  DEFINE_mpi_collective_p2p=""; \
 	fi && \
-	${MPICXX} ${CXXFLAGS} -Wall -DDEBUG \
-	  $$DEFINE_mpi_collective_p2p -fPIC -I../../../include \
-	  -I../../../jalib -I.. -I../../../src -I../lower-half -std=c++11 -c $<
+	${MPICXX} ${CXXFLAGS} -Wall -DDEBUG -fPIC $$DEFINE_mpi_collective_p2p \
+          -I.. -I../lower-half -std=c++11 -c $<
 
 # Some of these functions are also collective; e.g., MPI_Win_allocate_shared
 mpi_win_wrappers.o: mpi_win_wrappers.cpp ../virtual-ids.h
-	${MPICXX} ${CXXFLAGS} -Wall -DDEBUG -fPIC -I../../../include \
-	-I../../../jalib -I.. -I../../../src -I../lower-half -std=c++11 -c $<
+	${MPICXX} ${CXXFLAGS} -Wall -DDEBUG -fPIC \
+          -I.. -I../lower-half -std=c++11 -c $<
 
 # We need to write to mpi_stub_wrappers.c.tmp.$$ first, in case of 'make -j'.
 # The parallel make would generate mpi_stub_wrappers.c 3 times, and overwrite.
@@ -133,21 +137,21 @@ tidy:
 	rm -rf ckpt_rank_*
 
 install: libmpistub.so mana_p2p_update_logs
-	cp -f libmpistub.so ${DMTCP_ROOT}/lib/dmtcp/
-	cd ${DMTCP_ROOT}/lib/dmtcp && \
+	cp -f libmpistub.so ${MANA_ROOT}/lib/dmtcp/
+	cd ${MANA_ROOT}/lib/dmtcp && \
 		ln -sf libmpistub.so libmpich_intel.so.3.0.1 && \
 		ln -sf libmpich_intel.so.3.0.1 libmpich_intel.so.3 && \
 		ln -sf libmpistub.so libmpich_gnu_82.so.3.0.1 && \
 		ln -sf libmpich_gnu_82.so.3.0.1 libmpich_gnu_82.so.3
-	cd ${DMTCP_ROOT}/lib/dmtcp && \
+	cd ${MANA_ROOT}/lib/dmtcp && \
 		ln -sf libmpistub.so libpmi.so.0.5.0 && \
 		ln -sf libpmi.so.0.5.0 libpmi.so.0
-	cp -f mana_p2p_update_logs ${DMTCP_ROOT}/bin/
+	cp -f mana_p2p_update_logs ${MANA_ROOT}/bin/
 
 clean: tidy
 	rm -f ${LIBWRAPPER_OBJS}
 	rm -f ${LIBNAME}.a libmpistub.so
-	rm -f ${DMTCP_ROOT}/lib/dmtcp/libmpistub.so
+	rm -f ${MANA_ROOT}/lib/dmtcp/libmpistub.so
 	rm -f mpi_stub_wrappers.c
 	rm -f p2p-deterministic.h
 	rm -f mpi_unimplemented_wrappers.cpp
@@ -155,7 +159,7 @@ clean: tidy
 	rm -f libmpich_intel.so.3.0.1 libmpich_intel.so.3
 	rm -f libmpich_gnu_82.so.3.0.1 libmpich_gnu_82.so.3
 	rm -f libpmi.so.3.0.1 libpmi.so.0
-	cd ${DMTCP_ROOT}/lib/dmtcp && rm -f libmpich_gnu_82.so.* \
+	cd ${MANA_ROOT}/lib/dmtcp && rm -f libmpich_gnu_82.so.* \
 		libmpich_intel.so.* libpmi.so.*
 
 distclean: clean


### PR DESCRIPTION
Prior to this, after a fresh 'git clone', one had to do `make -j mana` twice in order to install the MANA files in the top-level bin and lib/dmtcp directories.  It was because they were installing to dmtcp/{bin,lib} on the first round instead of to {bin,lib} where they belonged.  The details follow below.

  [ A second bug was discovered in doing this, and will be addressed in a future PR.  The MANA README.md says to define `MANA_ROOT`.  The MANA Makefiles use a make variable, `MANA_ROOT`.  The make variables then get accidentally initialized to the environment variable value.  If `MANA_ROOT` refers to a previous MANA build (not the current one), then a bug happens in which MANA tries to install to the previous MANA build. We should fix the Makefiles to avoid using such an environment variable. ]

 * In commit 7389f9, contrib/mpi-proxy-split was changed to
    mpi-proxy-split, as part of reorganizing to set DMTCP as a submodule.
    But unfortunately, parts of MANA were then set to install to
    MANA_ROOT/dmtcp/{bin,lib} instead of MANA_ROOT/{bin,lib}.

 * Without the current fix, MANA is installing into
    MANA_ROOT/dmtcp/{bin,lib} and that is later copied to
    MANA_ROOT/{bin,lib}.  As a result, it was necessary to 'make mana'
    twice (once to install in MANA_ROOT/dmtcp/{bin,lib},
    and once to copy to MANA_ROOT/{bin,lib}.

 * With this fix, MANA now installs directly to MANA_ROOT/{bin,lib}
    without disturbing MANA_ROOT/dmtcp.