### PR TITLE
[MANA-139] Skip replaying the completed request

### DIFF
--- a/mpi-proxy-split/record-replay.h
+++ b/mpi-proxy-split/record-replay.h
@@ -336,6 +336,8 @@ namespace dmtcp_mpi
           rec->addArgs(args...);
           _records.push_back(rec);
           MPI_Request req;
+	  // All collective calls are translated in MANA to the async calls Ibarrier/Ireduce/Ibcast.
+	  // If MANA uses other async calls, we need other cases.
 	  switch (type) {
             case GENERATE_ENUM(Ibarrier):
               req = rec->args(1);


### PR DESCRIPTION
This change use unsorted map to quickly find if the request in the record-replay has been completed. If it is completed, then we will skip replay this record in checkpoint restart. 