### PR TITLE
Add two more Ibcast test cases

### DIFF
--- a/mpi-proxy-split/test/Ibcast_test.c
+++ b/mpi-proxy-split/test/Ibcast_test.c
@@ -155,6 +155,8 @@ void test_case_2(void) {
     // Checkpoint likely happens here - sender (root) advances to
     // the next Ibcast while receivers is waiting.
     if (myid != root) {
+        printf("[Rank = %d] sleep 100 seconds\n", myid);
+        fflush(stdout);
         sleep(100);
     }
     MPI_Ibcast(buffer,count,MPI_INT,root,MPI_COMM_WORLD, &request);
@@ -175,6 +177,11 @@ void test_case_2(void) {
     }
     printf("\n");
     fflush(stdout);
+    if (myid == root) {
+        printf("[Rank = %d] sleep 100 seconds\n", myid);
+        fflush(stdout);
+        sleep(100);
+    }
 
     MPI_Finalize();
 }

--- a/mpi-proxy-split/test/Ibcast_test.c
+++ b/mpi-proxy-split/test/Ibcast_test.c
@@ -78,8 +78,8 @@ void test_case_0(void) {
     MPI_Finalize();
 }
 
-// Case 1 - the sender likely advances to the next Ibcast while
-// the receivers are the current or previous Ibcast at the
+// Case 1 - In a regression bug, the sender could advance to the next Ibcast
+// while the receivers are the current or previous Ibcast at the
 // checkpoint time.
 void test_case_1(void) {
     int i,iter,myid;
@@ -130,8 +130,8 @@ void test_case_1(void) {
     MPI_Finalize();
 }
 
-// Case 2 - Sender completes the last call while receivers are still at
-// the current or previous calls while checkpointing
+// Case 2 - In a regression bug, the sender could complete the last call while
+// receivers are still at the current or previous calls while checkpointing.
 void test_case_2(void) {
     int i,count,myid,root;
     int buffer[4];

--- a/mpi-proxy-split/test/Ibcast_test.c
+++ b/mpi-proxy-split/test/Ibcast_test.c
@@ -186,9 +186,7 @@ void test_case_2(void) {
     MPI_Finalize();
 }
 
-int main(argc,argv)
-int argc;
-char *argv[];
+int main(int argc, char *argv[])
 {
     int opt;
 

--- a/mpi-proxy-split/test/Ibcast_test.c
+++ b/mpi-proxy-split/test/Ibcast_test.c
@@ -31,7 +31,7 @@ char *argv[];
     MPI_Status status;
     MPI_Request request = MPI_REQUEST_NULL; 
 
-    MPI_Init(&argc,&argv);
+    MPI_Init(NULL,NULL);
     MPI_Comm_size(MPI_COMM_WORLD,&numprocs);
     MPI_Comm_rank(MPI_COMM_WORLD,&myid);
     root = 0;

--- a/mpi-proxy-split/test/Ibcast_test.c
+++ b/mpi-proxy-split/test/Ibcast_test.c
@@ -10,6 +10,7 @@
 #include <mpi.h>
 #include <math.h>
 #include <assert.h>
+#include <getopt.h>
 /************************************************************
 This is a simple Ibcast program in MPI
 OPTIONS:   iterations, MPI_TEST, MPI_WAIT, Move the 'sleep(1)'
@@ -20,19 +21,75 @@ OPTIONS:   iterations, MPI_TEST, MPI_WAIT, Move the 'sleep(1)'
 # define MPI_WAIT
 #endif
 
-int main(argc,argv)
-int argc;
-char *argv[];
+void usage(int argc, char *argv[])
 {
-    int i,iter,myid, numprocs;
+  printf("Usage: %s [-12]\n"
+         "Options:\n"
+	 "  -1:	senders advances to the next call while receivers are at previous\n"
+	 "  -2: senders finishes the last call while receivers are at previous calls\n",
+	 argv[0]);
+  return;
+}
+
+void test_case_0(void) {
+    int i,iter,myid;
     int root,count,iterations;
     int buffer[4];
     int expected_output[4];
     MPI_Status status;
-    MPI_Request request = MPI_REQUEST_NULL; 
+    MPI_Request request = MPI_REQUEST_NULL;
 
     MPI_Init(NULL,NULL);
-    MPI_Comm_size(MPI_COMM_WORLD,&numprocs);
+    MPI_Comm_rank(MPI_COMM_WORLD,&myid);
+    root = 0;
+    count = 4;
+    iterations = 100;
+    // Case 0 - all ranks likely reaches the current
+    // iteration broadcast at the checkpoint
+    for (iter = 0; iter < iterations; iter++) {
+        for (i=0; i<count; i++) {
+            expected_output[i] = i + iter;
+            if (myid == root) {
+              buffer[i] = expected_output[i];
+            } else {
+              buffer[i] = 0; // MPI_Ibcast should populate this.
+            }
+        }
+        MPI_Ibcast(buffer,count,MPI_INT,root,MPI_COMM_WORLD, &request);
+        printf("[Rank = %d]", myid);
+        sleep(1); // The checkpoint is likely to occur here.
+#ifdef MPI_TEST
+        while (1) {
+            int flag = 0;
+            MPI_Test(&request, &flag, &status);
+            if (flag) { break; }
+        }
+#endif
+#ifdef MPI_WAIT
+        MPI_Wait(&request, &status);
+#endif
+        for (i=0;i<count;i++) {
+            printf(" %d %d", buffer[i], expected_output[i]);
+            assert(buffer[i] == expected_output[i]);
+        }
+        printf("\n");
+        fflush(stdout);
+    }
+    MPI_Finalize();
+}
+
+// Case 1 - the sender likely advances to the next Ibcast while
+// the receivers are the current or previous Ibcast at the
+// checkpoint time.
+void test_case_1(void) {
+    int i,iter,myid;
+    int root,count,iterations;
+    int buffer[4];
+    int expected_output[4];
+    MPI_Status status;
+    MPI_Request request = MPI_REQUEST_NULL;
+
+    MPI_Init(NULL,NULL);
     MPI_Comm_rank(MPI_COMM_WORLD,&myid);
     root = 0;
     count = 4;
@@ -46,9 +103,13 @@ char *argv[];
             buffer[i] = 0; // MPI_Ibcast should populate this.
           }
         }
+	// Sender (root) advances to the next Ibcast while receivers
+	// wait a second.
+	if (myid != root) {
+	  sleep(1);
+	}
         MPI_Ibcast(buffer,count,MPI_INT,root,MPI_COMM_WORLD, &request);
         printf("[Rank = %d]", myid);
-        sleep(1); // The checkpoint is likely to occur here.
 #ifdef MPI_TEST
         while (1) {
           int flag = 0;
@@ -67,4 +128,81 @@ char *argv[];
         fflush(stdout);
     }
     MPI_Finalize();
+}
+
+// Case 2 - Sender completes the last call while receivers are still at
+// the current or previous calls while checkpointing
+void test_case_2(void) {
+    int i,count,myid,root;
+    int buffer[4];
+    int expected_output[4];
+    MPI_Status status;
+    MPI_Request request = MPI_REQUEST_NULL;
+
+    MPI_Init(NULL,NULL);
+    MPI_Comm_rank(MPI_COMM_WORLD,&myid);
+    root = 0;
+    count = 4;
+    for (i=0; i<count; i++) {
+        expected_output[i] = i;
+        if (myid == root) {
+          buffer[i] = expected_output[i];
+        } else {
+          buffer[i] = 0; // MPI_Ibcast should populate this.
+        }
+    }
+
+    // Checkpoint likely happens here - sender (root) advances to
+    // the next Ibcast while receivers is waiting.
+    if (myid != root) {
+        sleep(100);
+    }
+    MPI_Ibcast(buffer,count,MPI_INT,root,MPI_COMM_WORLD, &request);
+    printf("[Rank = %d]", myid);
+#ifdef MPI_TEST
+    while (1) {
+        int flag = 0;
+        MPI_Test(&request, &flag, &status);
+        if (flag) { break; }
+    }
+#endif
+#ifdef MPI_WAIT
+    MPI_Wait(&request, &status);
+#endif
+    for (i=0;i<count;i++) {
+        printf(" %d %d", buffer[i], expected_output[i]);
+        assert(buffer[i] == expected_output[i]);
+    }
+    printf("\n");
+    fflush(stdout);
+
+    MPI_Finalize();
+}
+
+int main(argc,argv)
+int argc;
+char *argv[];
+{
+    int opt;
+
+    while ((opt = getopt(argc, argv, "12")) != -1) {
+        switch(opt) {
+	case '1':
+          test_case_1();
+          break;
+        case '2':
+          test_case_2();
+	  break;
+        case '?':
+	default:
+          usage(argc, argv);
+          return 1;
+	}
+    }
+    // Default: test case 0. No argument.
+    if (opt == -1 && argc == 1) {
+      test_case_0();
+    }
+
+    return 0;
 }


### PR DESCRIPTION
This change adds two more test cases for Ibcast. 
1] At checkpoint time, sender (rank 0) calls Ibcast for sending message-A then wait. However, the receiver (rank 1) hasn’t call Ibcast for message-A yet. At checkpoint-restart, the receiver calls the current MPI Ibcast. The sender advances to the next MPI Ibcast to send message-B. 
2] At checkpoint time, sender has already completed the last Ibcast call while the receivers does not call Ibcast yet. At restart, there is no more Ibcast message from the sender. 