### PR TITLE
Define NO_BARRIER_BCAST

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -50,10 +50,10 @@ isUsingCollectiveToP2p() {
 #endif
 }
 
-// #define NO_BARRIER_BCAST
 using namespace dmtcp_mpi;
 
 #ifndef MPI_COLLECTIVE_P2P
+#define NO_BARRIER_BCAST
 #ifdef NO_BARRIER_BCAST
 USER_DEFINED_WRAPPER(int, Bcast,
                      (void *) buffer, (int) count, (MPI_Datatype) datatype,


### PR DESCRIPTION
When NO_BARRIER_BCAST is defined, p2p is used to do broadcast. Currently this is a workaround to get the bit-for-bit match with native run for VASP checkpoint restart. 