### PR TITLE
Clean lh_proxy and gethostbyname_proxy on make clean

### DIFF
--- a/mpi-proxy-split/lower-half/Makefile
+++ b/mpi-proxy-split/lower-half/Makefile
@@ -86,6 +86,7 @@ tidy:
 
 clean: tidy
 	rm -f ${PROXY_BIN} ${LIBPROXY}.a ${PROXY_OBJS} ${LIBPROXY_OBJS}
+	rm -f ${MANA_ROOT}/bin/${PROXY_BIN}
 	if test -d gethostbyname-static; then \
 	  cd gethostbyname-static && make clean; \
 	fi

--- a/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
+++ b/mpi-proxy-split/lower-half/gethostbyname-static/Makefile
@@ -19,6 +19,7 @@ gethostbyname_proxy: gethostbyname_proxy.c
 
 clean:
 	rm -f a.out *.o gethostbyname_proxy
+	rm -f ${MANA_ROOT}/bin/gethostbyname_proxy
 
 dist: clean
 	dir=`basename $$PWD` && cd .. && tar zcvf ./$$dir.tar.gz ./$$dir


### PR DESCRIPTION
This PR will enable `make clean` in the `MANA_ROOT` to remove both`lh_proxy` and `gethostbyname_proxy` (if exist).