### PR TITLE
Async p2p bugfix

### DIFF
--- a/mpi-proxy-split/test/Makefile
+++ b/mpi-proxy-split/test/Makefile
@@ -37,7 +37,7 @@ FILES=mpi_hello_world \
       Irecv_test Alloc_mem \
       f_ibarrier \
       wave_mpi day1_mpi quad_mpi poisson_nonblock_mpi \
-      send_recv_loop
+      send_recv_loop large_async_p2p
 
 OBJS=$(addsuffix .o, ${FILES})
 

--- a/mpi-proxy-split/test/large_async_p2p.c
+++ b/mpi-proxy-split/test/large_async_p2p.c
@@ -1,0 +1,50 @@
+// For testing, checkpoint this during the 5-second sleep between
+// MPI_Isend (rank 1) and MPI_Irecv (rank 0).
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <unistd.h>
+
+#define MSG_SIZE 256*1024 // large message
+// #define MSG_SIZE 64 // small message
+
+int main(int argc, char** argv) {
+  void *data = malloc(MSG_SIZE);
+  int counter = 0;
+  void *recv_buf = malloc(MSG_SIZE);
+  // Initialize the MPI environment
+  MPI_Init(NULL, NULL);
+  // Find out rank, size
+  int world_rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  int world_size;
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+  MPI_Request req;
+
+  // We are assuming 3 processes for this task
+  if (world_size != 2) {
+    fprintf(stderr, "World size must be 2 for %s\n", argv[0]);
+    MPI_Abort(MPI_COMM_WORLD, 1);
+  }
+
+  if (world_rank == 0) {
+    printf("Rank 0 sleeping\n");
+    fflush(stdout);
+    sleep(5);
+    printf("Rank 0 draining from rank 1\n");
+    fflush(stdout);
+    MPI_Irecv(recv_buf, MSG_SIZE, MPI_BYTE, 1, 0, MPI_COMM_WORLD, &req);
+    MPI_Wait(&req, MPI_STATUSES_IGNORE);
+    printf("Rank 0 drained the message\n");
+    fflush(stdout);
+  }
+
+  if (world_rank == 1) {
+    printf("Rank 1 sending to rank 0\n");
+    fflush(stdout);
+    MPI_Isend(data, MSG_SIZE, MPI_BYTE, 0, 0, MPI_COMM_WORLD, &req);
+    MPI_Wait(&req, MPI_STATUSES_IGNORE);
+  }
+  MPI_Finalize();
+}


### PR DESCRIPTION
This is a fix of issue #161. When sharing large data with asynchronous point-to-point communication, MPICH requires a handshake between the sender and receiver. If MPI_Irecv has not been called before checkpoint time, only the metadata of the message is shared among MPI processes and the data is still in the sender's local buffer. As a result, MPI_Iprobe in the p2p draining algorithm can detect the incoming message, but MPI_Irecv can't receive the message. In this PR, I also call MPI_Test on pending MPI_Isend requests to complete potential pending handshakes.