### PR TITLE
Dynamically choose lh_proxy version for NIMROD

### DIFF
--- a/bin/mana_launch
+++ b/bin/mana_launch
@@ -107,6 +107,15 @@ if [ "$coordinator_found" == 0 ]; then
   exit 5
 fi
 
+# At higher ranks, restarting NIMROD causes a heap overflow (for a more detailed
+# write up, refer to Section 4 of mpi-proxy-split/doc/nimrod-build-tutorial.txt).
+# A temporary workaround is to swap the memory addresses of NIMROD and lh_proxy,
+# which requires a specially built version of lh_proxy.
+app_name="`echo $options | head -n1 | xargs basename`"
+if [ "$app_name" == "nimrod" ]; then
+  export USE_LH_PROXY_DEFADDR=1
+fi
+
 if [ "$verbose" == 0 ]; then
   options="-q -q $options"
 fi

--- a/mpi-proxy-split/Makefile
+++ b/mpi-proxy-split/Makefile
@@ -59,6 +59,7 @@ default: ${MANA_COORD_OBJS}
 	make -C ${WRAPPERS_SRCDIR} libmpiwrappers.a
 	@make libmana.so
 	@make -C ${LOWER_HALF_SRCDIR} lh_proxy
+	@make -C ${LOWER_HALF_SRCDIR} lh_proxy_default_address
 	@make -C ${WRAPPERS_SRCDIR} libmpistub.so
 
 # ${WRAPPERS_SRCDIR}/libmpiwrappers.a made in install/default before libmana.so

--- a/mpi-proxy-split/doc/nimrod-build-tutorial.txt
+++ b/mpi-proxy-split/doc/nimrod-build-tutorial.txt
@@ -245,26 +245,27 @@ of 0x80000000, in which the heap still overflows. A devised workaround is to
 swap the memory region for the lower half and NIMROD, such that the heap can
 grow freely.
 
-To implement this, we have to change how NIMROD and MANA are built.
+As of 14 June '22, building MANA now builds two copies of `lh_proxy` that
+are loaded into different addresses, 0x400000 and 0xe000000, with the
+former named `lh_proxy_default_address`. `mana_launch` will now check if
+the application being run is NIMROD, in which `lh_proxy_default_address`
+will be loaded instead.
 
-A future MANA version will remove this special requirement - June, '22.
+A version of NIMROD with the text segment specified to load at 0xe000000 has
+also been built and is available as a module on Cori. On other platforms, it is
+necessary to follow the steps below.
 
-NIMROD:
+  $ module use /global/cfs/cdirs/cr/mvm/modulefiles
+  $ module avail nimrod # you should see nimrod/r7643-mana
+  $ module load nimrod/r7643-mana
+
+OTHER PLATFORMS:
 When linking NIMROD, it's necessary to add a flag specifying where it should be
 loaded (by default, this is 0x400000). The command can be found in the output of
 the build script, prepended by "[ 90%] Linking Fortran executable ../bin/nimrod".
 
 Add a `-Wl,-Ttext-segment=E000000` flag to the build command, then run ONLY the
 command.
-
-MANA:
-Conversely, we should no longer specify where the lower half is loaded (so it
-will now be loaded to 0x400000 - where the upper half was). This can be done by
-making changes to `mpi-proxy-split/lower-half/Makefile`.
-
-Search for where the `PROXY_LD_FLAGS` variable is defined, and remove the
-`-Wl,-Ttext-segment -Wl,0xE000000` flag from it. Then run `make clean`, followed
-by `make mana`.
 
 ### ON CENTOS 7 AND CENTOS STREAM ###
 

--- a/mpi-proxy-split/lower-half/.gitignore
+++ b/mpi-proxy-split/lower-half/.gitignore
@@ -1,1 +1,2 @@
 lh_proxy
+lh_proxy_default_address

--- a/mpi-proxy-split/lower-half/.gitignore
+++ b/mpi-proxy-split/lower-half/.gitignore
@@ -1,2 +1,2 @@
 lh_proxy
-lh_proxy_default_address
+lh_proxy_da

--- a/mpi-proxy-split/lower-half/Makefile
+++ b/mpi-proxy-split/lower-half/Makefile
@@ -3,6 +3,7 @@ PLATFORM=${shell echo $$HOST}
 include ../Makefile_config
 
 PROXY_BIN = lh_proxy
+PROXY_BIN_DEFADDR = lh_proxy_default_address
 PROXY_OBJS = lh_proxy.o
 LIBPROXY = libproxy
 LIBPROXY_OBJS = libproxy.o procmapsutils.o sbrk.o mmap64.o munmap.o \
@@ -29,9 +30,11 @@ override CFLAGS += -fPIC -I${DMTCP_INCLUDE} -std=gnu11
 override CXXFLAGS += -fPIC -I${DMTCP_INCLUDE} -I${JALIB_INCLUDE} \
                      -I${DMTCP_ROOT}/src -std=c++11
 
-PROXY_LD_FLAGS=-static -Wl,-Ttext-segment -Wl,0xE000000 -Wl,--wrap -Wl,__munmap -Wl,--wrap -Wl,shmat -Wl,--wrap -Wl,shmget
+PROXY_LD_FLAGS=-static -Wl,--wrap -Wl,__munmap -Wl,--wrap -Wl,shmat -Wl,--wrap -Wl,shmget
 
-default: ${PROXY_BIN} ${STATIC_GETHOSTBYNAME}
+TEXTSEG_ADDR_FLAG=-Wl,-Ttext-segment=E000000
+
+default: ${PROXY_BIN} ${PROXY_BIN_DEFADDR} ${STATIC_GETHOSTBYNAME}
 
 # We should remove the special case for Cori, once we know this works on Cori.
 ifeq ($(findstring cori,$(PLATFORM)),cori)
@@ -64,6 +67,19 @@ endif
 ${PROXY_BIN}: ${PROXY_OBJS} ${LIBPROXY}.a ${STATIC_GETHOSTBYNAME}
 	if ${MPICC} -v 2>&1 | grep -q 'MPICH version'; then \
 	  rm -f tmp.sh; \
+	  ${MPICC} -show ${PROXY_LD_FLAGS} ${TEXTSEG_ADDR_FLAG} -o $@ -Wl,-start-group \
+	    $^ ${MPI_LD_FLAG} -lrt -lpthread -lc -Wl,-end-group | \
+	    sed -e 's^-lunwind ^ ^'> tmp.sh; \
+	  sh tmp.sh; \
+	  rm -f tmp.sh; \
+	else \
+	  ${MPICC} ${PROXY_LD_FLAGS} ${TEXTSEG_ADDR_FLAG} -o $@ -Wl,-start-group \
+            $^ ${MPI_LD_FLAG} -lrt -lpthread -lc -Wl,-end-group; \
+	fi
+
+${PROXY_BIN_DEFADDR}: ${PROXY_OBJS} ${LIBPROXY}.a ${STATIC_GETHOSTBYNAME}
+	if ${MPICC} -v 2>&1 | grep -q 'MPICH version'; then \
+	  rm -f tmp.sh; \
 	  ${MPICC} -show ${PROXY_LD_FLAGS} -o $@ -Wl,-start-group \
 	    $^ ${MPI_LD_FLAG} -lrt -lpthread -lc -Wl,-end-group | \
 	    sed -e 's^-lunwind ^ ^'> tmp.sh; \
@@ -77,7 +93,7 @@ ${PROXY_BIN}: ${PROXY_OBJS} ${LIBPROXY}.a ${STATIC_GETHOSTBYNAME}
 ${LIBPROXY}.a: ${LIBPROXY_OBJS}
 	ar cr $@ $^
 
-install: ${PROXY_BIN} ${STATIC_GETHOSTBYNAME}
+install: ${PROXY_BIN} ${PROXY_BIN_DEFADDR} ${STATIC_GETHOSTBYNAME}
 	cp -f $^ ${MANA_ROOT}/bin/
 
 tidy:
@@ -85,8 +101,9 @@ tidy:
 	rm -rf ckpt_rank_*
 
 clean: tidy
-	rm -f ${PROXY_BIN} ${LIBPROXY}.a ${PROXY_OBJS} ${LIBPROXY_OBJS}
+	rm -f ${PROXY_BIN} ${PROXY_BIN_DEFADDR} ${LIBPROXY}.a ${PROXY_OBJS} ${LIBPROXY_OBJS}
 	rm -f ${MANA_ROOT}/bin/${PROXY_BIN}
+	rm -f ${MANA_ROOT}/bin/${PROXY_BIN_DEFADDR}
 	if test -d gethostbyname-static; then \
 	  cd gethostbyname-static && make clean; \
 	fi

--- a/mpi-proxy-split/lower-half/Makefile
+++ b/mpi-proxy-split/lower-half/Makefile
@@ -3,7 +3,7 @@ PLATFORM=${shell echo $$HOST}
 include ../Makefile_config
 
 PROXY_BIN = lh_proxy
-PROXY_BIN_DEFADDR = lh_proxy_default_address
+PROXY_BIN_DEFADDR = lh_proxy_da
 PROXY_OBJS = lh_proxy.o
 LIBPROXY = libproxy
 LIBPROXY_OBJS = libproxy.o procmapsutils.o sbrk.o mmap64.o munmap.o \

--- a/mpi-proxy-split/split_process.cpp
+++ b/mpi-proxy-split/split_process.cpp
@@ -300,6 +300,9 @@ startProxy()
 
       dmtcp::string nockpt = dmtcp::Util::getPath("dmtcp_nocheckpoint");
       dmtcp::string progname = dmtcp::Util::getPath("lh_proxy");
+      if (getenv("USE_LH_PROXY_DEFADDR")) {
+        progname = progname + "_default_address";
+      }
       char* const args[] = {const_cast<char*>(nockpt.c_str()),
                             const_cast<char*>(progname.c_str()),
                             NULL};

--- a/mpi-proxy-split/split_process.cpp
+++ b/mpi-proxy-split/split_process.cpp
@@ -301,7 +301,7 @@ startProxy()
       dmtcp::string nockpt = dmtcp::Util::getPath("dmtcp_nocheckpoint");
       dmtcp::string progname = dmtcp::Util::getPath("lh_proxy");
       if (getenv("USE_LH_PROXY_DEFADDR")) {
-        progname = progname + "_default_address";
+        progname = progname + "_da";
       }
       char* const args[] = {const_cast<char*>(nockpt.c_str()),
                             const_cast<char*>(progname.c_str()),

--- a/restart_plugin/mtcp_restart_plugin.h
+++ b/restart_plugin/mtcp_restart_plugin.h
@@ -62,6 +62,12 @@ typedef LowerHalfInfo_t PluginInfo;
 typedef struct RestoreInfo RestoreInfo;
 union ProcMapsArea;
 void mtcp_plugin_hook(RestoreInfo *rinfo);
-int mtcp_plugin_skip_memory_region_munmap(ProcMapsArea *area, RestoreInfo *rinfo);
+int mtcp_plugin_skip_memory_region_munmap(ProcMapsArea *area,
+                                          RestoreInfo *rinfo);
+int getCkptImageByDir(RestoreInfo *rinfo,
+                      char *buffer,
+                      size_t buflen,
+                      int rank);
+char* getCkptImageByRank(int rank, char **argv);
 
 #endif // #ifndef __MTCP_RESTART_PLUGIN_H__

--- a/restart_plugin/mtcp_split_process.c
+++ b/restart_plugin/mtcp_split_process.c
@@ -194,8 +194,20 @@ startProxy(RestoreInfo *rinfo)
       // Replace ".../mtcp_restart" by ".../lh_proxy" in argv0/args[0]
       args[0] = rinfo->argv[0];
       char *last_component = mtcp_strrchr(args[0], '/');
-      MTCP_ASSERT(mtcp_strlen("lh_proxy") <= mtcp_strlen(last_component+1));
-      mtcp_strcpy(last_component+1, "lh_proxy");
+      // Set the ckptImage to rank 0 temporarily; later, it will be replaced
+      // with its respective image.
+      if (getCkptImageByDir(rinfo, rinfo->ckptImage, 512, 0) == -1) {
+        mtcp_strncpy(rinfo->ckptImage, getCkptImageByRank(0, rinfo->argv),
+                     PATH_MAX);
+      }
+      // checking space for lh_proxy_da's length is enough for lh_proxy
+      MTCP_ASSERT(mtcp_strlen("lh_proxy_da") <= mtcp_strlen(last_component+1));
+      // FIXME: it's a special case for nimrod application; make it general
+      if (mtcp_strstr(rinfo->ckptImage, "nimrod")) {
+        mtcp_strcpy(last_component+1, "lh_proxy_da");
+      } else {
+        mtcp_strcpy(last_component+1, "lh_proxy");
+      }
 
       // Move reading end of pipe to stadin of lh_proxy.
       // Can then write pipefd_out[1] to lh_proxy.


### PR DESCRIPTION
This pull request adds two things:

1. building MANA now builds two copies of `lh_proxy`
    * `lh_proxy`, which will be loaded into `0xe000000`
    * `lh_proxy_default_address`, which will be loaded into `0x400000`
1. `mana_launch` now checks if the application is NIMROD, and if so will use `lh_proxy_default_address` instead

And the documentation has also been updated to reflect these changes, since manually building `lh_proxy` is no longer necessary.