### PR TITLE
Call lower-half Barrier from Bcast callback

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -100,11 +100,12 @@ USER_DEFINED_WRAPPER(int, Bcast,
     MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Bcast)(buffer, count, realType, root, realComm);
+    NEXT_FUNC(Barrier)(realComm);
     RETURN_TO_UPPER_HALF();
     DMTCP_PLUGIN_ENABLE_CKPT();
     // Call MPI_Barrier in the critical section to wait until all rank in the
     // communictor finished.
-    MPI_Barrier(comm);
+    // MPI_Barrier(comm);
     return retval;
   };
   return twoPhaseCommit(comm, realBarrierCb);

--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -100,12 +100,11 @@ USER_DEFINED_WRAPPER(int, Bcast,
     MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Bcast)(buffer, count, realType, root, realComm);
+    // Call lower-half Barrier in the critical section to wait until all rank in the
+    // communictor finished.
     NEXT_FUNC(Barrier)(realComm);
     RETURN_TO_UPPER_HALF();
     DMTCP_PLUGIN_ENABLE_CKPT();
-    // Call MPI_Barrier in the critical section to wait until all rank in the
-    // communictor finished.
-    // MPI_Barrier(comm);
     return retval;
   };
   return twoPhaseCommit(comm, realBarrierCb);


### PR DESCRIPTION
    We should call lower-half Barrier directly from Bcast callback
    instead of using MANA wrapper Barrier. The reason is that
    MANA wrapper changes process state from IN_CS to IN_TRIVIAL_BARRIER
    while it is in IN_CS. This will mislead checkpoint to think all ranks
    are in trivial barrier while some ranks are still in lower-half.

    This change fixes the following scenario that some ranks move to the
    next Bcast while some ranks are still in current rank in checkpoint
    restart.
    T0 Both rank 0 and 1 are in state IN_CS.
    T1 Rank 0 calls the lower-half Bcast from MANA Bcast wrapper
       two-phase callback function
    T2 Rank 0 calls MPI_Barrier from MANA Bcast wrapper two-phase
       callback function
    T3 Rank 0 state is changed to IN_TRIVIAL_BARRIER by MPI_Barrier
    T4 Checkpoint request is received. Since all ranks are
       IN_TRAVIAL_BARRIER state. Checkpoint is taken.
    T5 Checkpoint restart.
    T6 Rank 0 replays the trivial barrier.
    T7 Rank 1 replays the trivial barrier.
    T8 Rank 1 calls lower-half Bcast from MANA Bcast wrapper
       two-phase callback function
    T9 Rank 0 call _next_ Bcast
    Now Rank 1 will get wrong Bcast data as Rank 0 sends the data
    from the next Bast whiel Rank 1 is still at current Bcast.