### PR TITLE
Add lower-half Barrier to two-phase callbacks

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -213,6 +213,7 @@ USER_DEFINED_WRAPPER(int, Allreduce,
       retval = NEXT_FUNC(Allreduce)(sendbuf, recvbuf, count,
                                     realType, realOp, realComm);
     }
+    NEXT_FUNC(Barrier)(realComm);
     RETURN_TO_UPPER_HALF();
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
@@ -234,6 +235,7 @@ USER_DEFINED_WRAPPER(int, Reduce,
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Reduce)(sendbuf, recvbuf, count,
                                realType, realOp, root, realComm);
+    NEXT_FUNC(Barrier)(realComm);
     RETURN_TO_UPPER_HALF();
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
@@ -282,6 +284,7 @@ USER_DEFINED_WRAPPER(int, Reduce_scatter,
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Reduce_scatter)(sendbuf, recvbuf, recvcounts,
                                        realType, realOp, realComm);
+    NEXT_FUNC(Barrier)(realComm);
     RETURN_TO_UPPER_HALF();
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
@@ -310,6 +313,7 @@ MPI_Alltoall_internal(const void *sendbuf, int sendcount,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Alltoall)(sendbuf, sendcount, realSendType, recvbuf,
       recvcount, realRecvType, realComm);
+  NEXT_FUNC(Barrier)(realComm);
   RETURN_TO_UPPER_HALF();
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
@@ -345,6 +349,7 @@ USER_DEFINED_WRAPPER(int, Alltoallv,
     retval = NEXT_FUNC(Alltoallv)(sendbuf, sendcounts, sdispls, realSendType,
                                   recvbuf, recvcounts, rdispls, realRecvType,
                                   realComm);
+    NEXT_FUNC(Barrier)(realComm);
     RETURN_TO_UPPER_HALF();
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
@@ -366,6 +371,7 @@ USER_DEFINED_WRAPPER(int, Gather, (const void *) sendbuf, (int) sendcount,
     retval = NEXT_FUNC(Gather)(sendbuf, sendcount, realSendType,
                                recvbuf, recvcount, realRecvType,
                                root, realComm);
+    NEXT_FUNC(Barrier)(realComm);
     RETURN_TO_UPPER_HALF();
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
@@ -388,6 +394,7 @@ USER_DEFINED_WRAPPER(int, Gatherv, (const void *) sendbuf, (int) sendcount,
     retval = NEXT_FUNC(Gatherv)(sendbuf, sendcount, realSendType,
                                 recvbuf, recvcounts, displs, realRecvType,
                                 root, realComm);
+    NEXT_FUNC(Barrier)(realComm);
     RETURN_TO_UPPER_HALF();
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
@@ -409,6 +416,7 @@ USER_DEFINED_WRAPPER(int, Scatter, (const void *) sendbuf, (int) sendcount,
     retval = NEXT_FUNC(Scatter)(sendbuf, sendcount, realSendType,
                                 recvbuf, recvcount, realRecvType,
                                 root, realComm);
+    NEXT_FUNC(Barrier)(realComm);
     RETURN_TO_UPPER_HALF();
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
@@ -431,6 +439,7 @@ USER_DEFINED_WRAPPER(int, Scatterv, (const void *) sendbuf,
     retval = NEXT_FUNC(Scatterv)(sendbuf, sendcounts, displs, realSendType,
                                  recvbuf, recvcount, realRecvType,
                                  root, realComm);
+    NEXT_FUNC(Barrier)(realComm);
     RETURN_TO_UPPER_HALF();
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
@@ -452,6 +461,7 @@ USER_DEFINED_WRAPPER(int, Allgather, (const void *) sendbuf, (int) sendcount,
     retval = NEXT_FUNC(Allgather)(sendbuf, sendcount, realSendType,
                                   recvbuf, recvcount, realRecvType,
                                   realComm);
+    NEXT_FUNC(Barrier)(realComm);
     RETURN_TO_UPPER_HALF();
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
@@ -474,6 +484,7 @@ USER_DEFINED_WRAPPER(int, Allgatherv, (const void *) sendbuf, (int) sendcount,
     retval = NEXT_FUNC(Allgatherv)(sendbuf, sendcount, realSendType,
                                    recvbuf, recvcounts, displs, realRecvType,
                                    realComm);
+    NEXT_FUNC(Barrier)(realComm);
     RETURN_TO_UPPER_HALF();
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
@@ -494,6 +505,7 @@ USER_DEFINED_WRAPPER(int, Scan, (const void *) sendbuf, (void *) recvbuf,
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Scan)(sendbuf, recvbuf, count,
                              realType, realOp, realComm);
+    NEXT_FUNC(Barrier)(realComm);
     RETURN_TO_UPPER_HALF();
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;


### PR DESCRIPTION
This change add lower-half barrier to the two phase callback function of each collective MPI call that sends or receives buffer. This prevents checkpointing restart has some ranks proceeds to the next call while other ranks still are in the current collective call.

Tested and verified this change fixes the bit-for-bit discrepancy issue with VASP5 PdO4 128 ranks. 