### PR TITLE
Set collective version bcast as default

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -53,7 +53,6 @@ isUsingCollectiveToP2p() {
 using namespace dmtcp_mpi;
 
 #ifndef MPI_COLLECTIVE_P2P
-#define NO_BARRIER_BCAST
 #ifdef NO_BARRIER_BCAST
 USER_DEFINED_WRAPPER(int, Bcast,
                      (void *) buffer, (int) count, (MPI_Datatype) datatype,


### PR DESCRIPTION
P2p version bcast was a workaround for correctness. Since the
collective version bcast correctness issue is resolved, this
change sets the collective version bcast as the default.

This changes solves the performance regression introduced by p2p bcast.