### PR TITLE
Reverted to support for multiple cartesian coordinators

### DIFF
--- a/mpi-proxy-split/lower-half/libproxy.c
+++ b/mpi-proxy-split/lower-half/libproxy.c
@@ -36,7 +36,10 @@
 #include <fcntl.h>
 #include <errno.h>
 
+#ifdef SINGLE_CART_REORDER
 #include "../cartesian.h"
+#endif
+
 #include "libproxy.h"
 #include "mpi_copybits.h"
 #include "procmapsutils.h"
@@ -205,6 +208,7 @@ getRank()
   return world_rank;
 }
 
+#ifdef SINGLE_CART_REORDER
 // Prior to checkpoint we will use the normal variable names, and
 // after restart we will use the '_prime' suffix with variable names.
 MPI_Comm comm_cart_prime;
@@ -236,6 +240,7 @@ getCartesianCommunicator(MPI_Comm **comm_cart)
 {
   *comm_cart = &comm_cart_prime;
 }
+#endif
 
 void*
 mydlsym(enum MPI_Fncs fnc)
@@ -291,8 +296,12 @@ void first_constructor()
     lh_info.g_appContext = (void*)&g_appContext;
     lh_info.lh_dlsym = (void*)&mydlsym;
     lh_info.getRankFptr = (void*)&getRank;
+
+#ifdef SINGLE_CART_REORDER
     lh_info.getCoordinatesFptr = (void*)&getCoordinates;
     lh_info.getCartesianCommunicatorFptr = (void *)&getCartesianCommunicator;
+#endif
+
     lh_info.parentStackStart = (void*)pstackstart;
     lh_info.updateEnvironFptr = (void*)&updateEnviron;
     lh_info.getMmappedListFptr = (void*)&getMmappedList;

--- a/mpi-proxy-split/lower-half/lower_half_api.h
+++ b/mpi-proxy-split/lower-half/lower_half_api.h
@@ -92,8 +92,10 @@ typedef struct _LowerHalfInfo
   void *g_appContext; // Pointer to ucontext_t of upper half application (defined in the lower half)
   void *lh_dlsym;     // Pointer to mydlsym() function in the lower half
   void *getRankFptr;  // Pointer to getRank() function in the lower half
+#ifdef SINGLE_CART_REORDER
   void *getCoordinatesFptr; // Pointer to getCoordinates() function in the lower half
   void *getCartesianCommunicatorFptr; // Pointer to getCartesianCommunicator() function in the lower half
+#endif
   void *parentStackStart; // Address to the start of the stack of the parent process (FIXME: Not currently used anywhere)
   void *updateEnvironFptr; // Pointer to updateEnviron() function in the lower half
   void *getMmappedListFptr; // Pointer to getMmapedList() function in the lower half

--- a/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
@@ -30,19 +30,13 @@
 #include "mpi_nextfunc.h"
 #include "record-replay.h"
 #include "virtual-ids.h"
+#ifdef SINGLE_CART_REORDER
 #include "two-phase-algo.h"
+#include "../cartesian.h"
+#endif
 #include "p2p_drain_send_recv.h"
 
-#include "../cartesian.h"
-
 using namespace dmtcp_mpi;
-
-// This variable holds the cartesian properties and is only used at the time of
-// checkpoint (DMTCP_EVENT_PRECHECKPOINT event in mpi_plugin.cpp).
-CartesianProperties g_cartesian_properties = { .comm_old_size = -1,
-                                               .comm_cart_size = -1,
-                                               .comm_old_rank = -1,
-                                               .comm_cart_rank = -1 };
 
 USER_DEFINED_WRAPPER(int, Cart_coords, (MPI_Comm) comm, (int) rank,
                      (int) maxdims, (int*) coords)
@@ -55,61 +49,6 @@ USER_DEFINED_WRAPPER(int, Cart_coords, (MPI_Comm) comm, (int) rank,
   RETURN_TO_UPPER_HALF();
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
-}
-
-USER_DEFINED_WRAPPER(int, Cart_create, (MPI_Comm)old_comm, (int)ndims,
-                     (const int *)dims, (const int *)periods, (int)reorder,
-                     (MPI_Comm *)comm_cart)
-{
-  /* FIXME: The comm size should be checked at checkpoint. We can checkpoint
-   * even if the application creates multiple cartesian communicators but only
-   * have one active cartesian communicator at checkpoint.
-   *
-   * This will be removed after we add support for multiple cartesian
-   * communicators.
-   */
-  JWARNING(g_cartesian_properties.comm_old_size == -1)
-    .Text("MPI_Cart_create() called more than once! The checkpoint-restart "
-          "might fail as the current implementation only supports one "
-          "cartesian communicator.");
-
-  std::function<int()> realBarrierCb = [=]() {
-    int retval;
-    DMTCP_PLUGIN_DISABLE_CKPT();
-    MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(old_comm);
-    JUMP_TO_LOWER_HALF(lh_info.fsaddr);
-    retval = NEXT_FUNC(Cart_create)(realComm, ndims, dims, periods, reorder,
-                                    comm_cart);
-    RETURN_TO_UPPER_HALF();
-    g_cartesian_properties.ndims = ndims;
-    g_cartesian_properties.reorder = reorder;
-    for (int i = 0; i < ndims; i++) {
-      g_cartesian_properties.dimensions[i] = dims[i];
-      g_cartesian_properties.periods[i] = periods[i];
-    }
-    MPI_Comm_size(old_comm, &g_cartesian_properties.comm_old_size);
-    MPI_Comm_size(*comm_cart, &g_cartesian_properties.comm_cart_size);
-    MPI_Comm_rank(old_comm, &g_cartesian_properties.comm_old_rank);
-    MPI_Comm_rank(*comm_cart, &g_cartesian_properties.comm_cart_rank);
-    MPI_Cart_coords(*comm_cart, g_cartesian_properties.comm_cart_rank,
-                    g_cartesian_properties.ndims,
-                    g_cartesian_properties.coordinates);
-
-    if (retval == MPI_SUCCESS && MPI_LOGGING()) {
-      MPI_Comm virtComm = ADD_NEW_COMM(*comm_cart);
-      VirtualGlobalCommId::instance().createGlobalId(virtComm);
-      *comm_cart = virtComm;
-      active_comms.insert(virtComm);
-
-      FncArg ds = CREATE_LOG_BUF(dims, ndims * sizeof(int));
-      FncArg ps = CREATE_LOG_BUF(periods, ndims * sizeof(int));
-      LOG_CALL(restoreCarts, Cart_create, old_comm, ndims, ds, ps, reorder,
-               virtComm);
-    }
-    DMTCP_PLUGIN_ENABLE_CKPT();
-    return retval;
-  };
-  return twoPhaseCommit(old_comm, realBarrierCb);
 }
 
 USER_DEFINED_WRAPPER(int, Cart_get, (MPI_Comm) comm, (int) maxdims,
@@ -222,6 +161,108 @@ USER_DEFINED_WRAPPER(int, Dims_create, (int)nnodes, (int)ndims, (int *)dims)
   return retval;
 }
 
+#ifdef SINGLE_CART_REORDER
+// This variable holds the cartesian properties and is only used at the time of
+// checkpoint (DMTCP_EVENT_PRECHECKPOINT event in mpi_plugin.cpp).
+CartesianProperties g_cartesian_properties = { .comm_old_size = -1,
+                                               .comm_cart_size = -1,
+                                               .comm_old_rank = -1,
+                                               .comm_cart_rank = -1 };
+
+USER_DEFINED_WRAPPER(int, Cart_create, (MPI_Comm)old_comm, (int)ndims,
+                     (const int *)dims, (const int *)periods, (int)reorder,
+                     (MPI_Comm *)comm_cart)
+{
+  JWARNING(g_cartesian_properties.comm_old_size == -1)
+    .Text("MPI_Cart_create() called more than once. Current implementation "
+          "only supports one cartesian communicator.");
+
+  std::function<int()> realBarrierCb = [=]() {
+    int retval;
+    DMTCP_PLUGIN_DISABLE_CKPT();
+    MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(old_comm);
+    JUMP_TO_LOWER_HALF(lh_info.fsaddr);
+    retval = NEXT_FUNC(Cart_create)(realComm, ndims, dims, periods, reorder,
+                                    comm_cart);
+    RETURN_TO_UPPER_HALF();
+    g_cartesian_properties.ndims = ndims;
+    g_cartesian_properties.reorder = reorder;
+    for (int i = 0; i < ndims; i++) {
+      g_cartesian_properties.dimensions[i] = dims[i];
+      g_cartesian_properties.periods[i] = periods[i];
+    }
+    MPI_Comm_size(old_comm, &g_cartesian_properties.comm_old_size);
+    MPI_Comm_size(*comm_cart, &g_cartesian_properties.comm_cart_size);
+    MPI_Comm_rank(old_comm, &g_cartesian_properties.comm_old_rank);
+    MPI_Comm_rank(*comm_cart, &g_cartesian_properties.comm_cart_rank);
+    MPI_Cart_coords(*comm_cart, g_cartesian_properties.comm_cart_rank,
+                    g_cartesian_properties.ndims,
+                    g_cartesian_properties.coordinates);
+
+    if (retval == MPI_SUCCESS && MPI_LOGGING()) {
+      MPI_Comm virtComm = ADD_NEW_COMM(*comm_cart);
+      VirtualGlobalCommId::instance().createGlobalId(virtComm);
+      *comm_cart = virtComm;
+      active_comms.insert(virtComm);
+
+      FncArg ds = CREATE_LOG_BUF(dims, ndims * sizeof(int));
+      FncArg ps = CREATE_LOG_BUF(periods, ndims * sizeof(int));
+      LOG_CALL(restoreCarts, Cart_create, old_comm, ndims, ds, ps, reorder,
+               virtComm);
+    }
+    DMTCP_PLUGIN_ENABLE_CKPT();
+    return retval;
+  };
+  return twoPhaseCommit(old_comm, realBarrierCb);
+}
+#else
+
+USER_DEFINED_WRAPPER(int, Cart_create, (MPI_Comm) old_comm, (int) ndims,
+                     (const int*) dims, (const int*) periods, (int) reorder,
+                     (MPI_Comm *) comm_cart)
+{
+  int retval;
+  // The MPI library assigns the cartesian coordinates naively
+  // (in the increasing rank order) with no reordering as opposed to optimal
+  // reordering based on the physical topology. For example, if there are
+  // 6 ranks (0-5) exist, then without reordering, the two-dimensional
+  // coordinates will be following:
+  // (0, 0) -> rank 0
+  // (0, 1) -> rank 1
+  // .
+  // .
+  // (2, 2) -> rank 5
+  // While no reordering ensures the same rank to coordinates mapping
+  // on the restart,  it can incur some overhead as MPI can no longer
+  // optimize the ranks' ordering. For now, we focus on the correctness across
+  // checkpoint-restart. Therefore, we enforce the reorder variable
+  // to be false.
+  //FIXME: Handle the case when reorder variable is true.
+  JWARNING (reorder == false) .Text ("We are enforcing reorder to false as "
+                                     "the current implementation does not "
+                                     "support reordered ranks.");
+  reorder = 0;
+  DMTCP_PLUGIN_DISABLE_CKPT();
+  MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(old_comm);
+  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
+  retval = NEXT_FUNC(Cart_create)(realComm, ndims, dims,
+                                  periods, reorder, comm_cart);
+  RETURN_TO_UPPER_HALF();
+  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
+    MPI_Comm virtComm = ADD_NEW_COMM(*comm_cart);
+    VirtualGlobalCommId::instance().createGlobalId(virtComm);
+    *comm_cart = virtComm;
+    active_comms.insert(virtComm);
+    FncArg ds = CREATE_LOG_BUF(dims, ndims * sizeof(int));
+    FncArg ps = CREATE_LOG_BUF(periods, ndims * sizeof(int));
+    LOG_CALL(restoreCarts, Cart_create, old_comm, ndims,
+             ds, ps, reorder, virtComm);
+  }
+  DMTCP_PLUGIN_ENABLE_CKPT();
+  return retval;
+}
+
+#endif
 
 PMPI_IMPL(int, MPI_Cart_coords, MPI_Comm comm, int rank,
           int maxdims, int coords[])
@@ -239,3 +280,4 @@ PMPI_IMPL(int, MPI_Cart_sub, MPI_Comm comm,
           const int remain_dims[], MPI_Comm *new_comm)
 PMPI_IMPL(int, MPI_Cartdim_get, MPI_Comm comm, int *ndims)
 PMPI_IMPL(int, MPI_Dims_create, int nnodes, int ndims, int *dims)
+

--- a/mpi-proxy-split/mtcp_split_process.h
+++ b/mpi-proxy-split/mtcp_split_process.h
@@ -54,8 +54,10 @@ typedef struct LowerHalfInfo
   void *g_appContext;
   void *lh_dlsym;
   void *getRankFptr;
+#ifdef SINGLE_CART_REORDER
   void *getCoordinatesFptr;
   void *getCartesianCommunicatorFptr;
+#endif
   void *parentStackStart;
   void *updateEnvironFptr;
   void *getMmappedListFptr;

--- a/mpi-proxy-split/record-replay.h
+++ b/mpi-proxy-split/record-replay.h
@@ -309,7 +309,7 @@ namespace dmtcp_mpi
       bool getComplete()
       {
         return _complete;
-      }	
+      }
 
       // Returns a pointer to the wrapper function corresponding to this MPI
       // record object
@@ -718,5 +718,7 @@ namespace dmtcp_mpi
 // Restores the MPI state by recreating the communicator, groups, types, etc.
 // post restart
 extern void restoreMpiLogState();
+#ifdef SINGLE_CART_REORDER
 extern void setCartesianCommunicator(void *getCartesianCommunicatorFptr);
+#endif
 #endif // ifndef MPI_RECORD_REPLAY_H

--- a/mpi-proxy-split/unit-test/Makefile
+++ b/mpi-proxy-split/unit-test/Makefile
@@ -53,7 +53,11 @@ default: ${TEST_BINS}
 ../record-replay.o ../drain_send_recv_packets.o:
 	@make -C ..
 
-%.exe: %.o ../record-replay.o ../split_process.o ../lower-half/procmapsutils.o
+# NOTE:  The objects files split_process.o and procmapsutils.o
+# below are required only when MANA is configured with SINGLE_CART_REORDER
+# C/C++ flag. One should remove these two obj files when we decide to remove
+# the SINGLE_CART_REORDER macro implementation entirely from MANA.
+%.exe: %.o ../record-replay.o  ../split_process.o ../lower-half/procmapsutils.o
 	${MPICXX} -fPIC -g3 -O0 -o $@ $^ ${TEST_LD_FLAGS}
 
 drain-send-recv-test.exe: ${DRAIN_TEST_OBJS}

--- a/restart_plugin/mtcp_restart_plugin.h
+++ b/restart_plugin/mtcp_restart_plugin.h
@@ -48,8 +48,10 @@ typedef struct LowerHalfInfo
   void *g_appContext;
   void *lh_dlsym;
   void *getRankFptr;
+#ifdef SINGLE_CART_REORDER
   void *getCoordinatesFptr;
   void *getCartesianCommunicatorFptr;
+#endif
   void *parentStackStart;
   void *updateEnvironFptr;
   void *getMmappedListFptr;


### PR DESCRIPTION
- Reverted changes to cartesian support that reordered ranks in cartesian-supporting communicators with new macro to enable these changes
- Changed Cart_create to always set reorder=false to ensure that restarted ranks have the same cartesian coordinates in all communicators