### PR TITLE
Refactored MPI_Type_vector to support MPI_Type_hvector

### DIFF
--- a/mpi-proxy-split/record-replay.cpp
+++ b/mpi-proxy-split/record-replay.cpp
@@ -52,7 +52,7 @@ static int restoreGroupIncl(MpiRecord& rec);
 
 static int restoreTypeContiguous(MpiRecord& rec);
 static int restoreTypeCommit(MpiRecord& rec);
-static int restoreTypeVector(MpiRecord& rec);
+static int restoreTypeHVector(MpiRecord& rec);
 static int restoreTypeIndexed(MpiRecord& rec);
 static int restoreTypeFree(MpiRecord& rec);
 static int restoreTypeCreateStruct(MpiRecord& rec);
@@ -189,9 +189,9 @@ dmtcp_mpi::restoreTypes(MpiRecord &rec)
       JTRACE("restoreTypeCommit");
       rc = restoreTypeCommit(rec);
       break;
-    case GENERATE_ENUM(Type_vector):
-      JTRACE("restoreTypeVector");
-      rc = restoreTypeVector(rec);
+    case GENERATE_ENUM(Type_hvector):
+      JTRACE("restoreTypeHVector");
+      rc = restoreTypeHVector(rec);
       break;
     case GENERATE_ENUM(Type_indexed):
       JTRACE("restoreTypeIndexed");
@@ -525,18 +525,18 @@ restoreTypeCommit(MpiRecord& rec)
 }
 
 static int
-restoreTypeVector(MpiRecord& rec)
+restoreTypeHVector(MpiRecord& rec)
 {
   int retval;
   int count = rec.args(0);
   int blocklength = rec.args(1);
-  int stride = rec.args(2);
+  MPI_Aint stride = rec.args(2);
   MPI_Datatype oldtype = rec.args(3);
   MPI_Datatype newtype = MPI_DATATYPE_NULL;
-  retval = FNC_CALL(Type_vector, rec)(count, blocklength,
+  retval = FNC_CALL(Type_hvector, rec)(count, blocklength,
                                       stride, oldtype, &newtype);
   JWARNING(retval == MPI_SUCCESS)(oldtype)
-          .Text("Could not restore MPI vector datatype");
+          .Text("Could not restore MPI hvector datatype");
   if (retval == MPI_SUCCESS) {
     MPI_Datatype virtType = rec.args(4);
     UPDATE_TYPE_MAP(virtType, newtype);

--- a/mpi-proxy-split/record-replay.h
+++ b/mpi-proxy-split/record-replay.h
@@ -96,6 +96,7 @@ namespace dmtcp_mpi
     TYPE_INT_ARRAY,
     TYPE_VOID_PTR,
     TYPE_VOID_CONST_PTR,
+    TYPE_LONG,
     TYPE_MPI_USER_FNC,
   };
 
@@ -201,6 +202,7 @@ namespace dmtcp_mpi
     void *c;
     void const *d;
     MPI_User_function *e;
+    long f;
 
     if (typeid(data) == typeid(a)) {
       return FncArg(&data, sizeof(data), TYPE_INT);
@@ -215,6 +217,9 @@ namespace dmtcp_mpi
       return FncArg(&data, sizeof(data), TYPE_VOID_CONST_PTR);
     }
     if (typeid(data) == typeid(e)) {
+      return FncArg(&data, sizeof(data), TYPE_MPI_USER_FNC);
+    }
+    if (typeid(data) == typeid(f)) {
       return FncArg(&data, sizeof(data), TYPE_MPI_USER_FNC);
     }
     JASSERT(false).Text("Unkown type for FncArg");

--- a/mpi-proxy-split/test/Makefile
+++ b/mpi-proxy-split/test/Makefile
@@ -35,7 +35,7 @@ FILES=mpi_hello_world \
       Abort_test Allreduce_test Alltoall_test Alltoallv_test \
       Allgather_test Group_size_rank Type_commit_contiguous \
       Irecv_test Alloc_mem sendrecv_replace_test \
-      f_ibarrier sendrecv_test Type_hvector_test \
+      f_ibarrier sendrecv_test Type_hvector_test Type_vector_test \
       wave_mpi day1_mpi quad_mpi poisson_nonblock_mpi \
       send_recv_loop large_async_p2p
 

--- a/mpi-proxy-split/test/Type_vector_test.c
+++ b/mpi-proxy-split/test/Type_vector_test.c
@@ -1,5 +1,5 @@
 /*
-  Test for the MPI_Type_hvector method
+  Test for the MPI_Type_vector method
 
   Run with 2 ranks
   Run with -i [iterations] for specific number of iterations, defaults to 10000
@@ -53,8 +53,8 @@ int main(int argc, char ** argv)
   assert(comm_size == 2);
 
   MPI_Datatype column_type;
-  MPI_Type_hvector(BUFFER_SIZE, 1,
-                   BUFFER_SIZE*sizeof(int), MPI_INT, &column_type);
+  MPI_Type_vector(BUFFER_SIZE, 1,
+                   BUFFER_SIZE, MPI_INT, &column_type);
   MPI_Type_commit(&column_type);
   int buffer[BUFFER_SIZE][BUFFER_SIZE];
   int recvbuf[BUFFER_SIZE];


### PR DESCRIPTION
- Removed previous FIXME and refactored MPI_Type_vector to use MPI_Type_hvector
- Required changing the record/replay to use MPI_Type_hvector instead
- Added support in record/replay for long datatype (to support MPI_Aint parameter)
- Added test for MPI_Type_vector