### PR TITLE
Remove MPI_Type_size in the MPI_Bcast wrapper

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -88,9 +88,9 @@ USER_DEFINED_WRAPPER(int, Bcast,
 {
   std::function<int()> realBarrierCb = [=]() {
     int retval;
+#if 0 // for debugging
     int size;
     MPI_Type_size(datatype, &size);
-#if 0 // for debugging
     printf("Rank %d: MPI_Bcast sending %d bytes\n", g_world_rank, count * size);
     fflush(stdout);
 #endif


### PR DESCRIPTION
The MPI_Type_size was added for debugging purposes.