### PR TITLE
Fix MANA-161: find nimrod as a substring

### DIFF
--- a/bin/mana_launch
+++ b/bin/mana_launch
@@ -112,7 +112,7 @@ fi
 # A temporary workaround is to swap the memory addresses of NIMROD and lh_proxy,
 # which requires a specially built version of lh_proxy.
 app_name="`echo $options | head -n1 | xargs basename`"
-if [ "$app_name" == "nimrod" ]; then
+if echo $app_name | grep -q nimrod ; then
   export USE_LH_PROXY_DEFADDR=1
 fi
 


### PR DESCRIPTION
Use `lh_proxy_da` when the executable has the keyword `nimrod` in its name. Earlier, the logic expects the executable's name to be exactly `nimrod`. It's causing nimrod's regression test to be failed as `mana_launch` would choose the wrong `lh_proxy`. The PR fixes that issue.