### PR TITLE
Mark platform as Cori for a compute node

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -45,7 +45,7 @@ default: display-build-env add-git-hooks mana_prereqs
 
 all: default
 
-mana: dmtcp
+mana: mana_prereqs dmtcp
 	cd mpi-proxy-split && $(MAKE) install && $(MAKE) -j tests
 
 dmtcp:
@@ -109,6 +109,11 @@ mana_prereqs:
 	    echo '** DMTCP is incompatible with the altd module.'; \
 	    echo '** Please do "module unload altd" before building DMTCP.';\
 	    exit 1; \
+	fi
+	@ # If one is building MANA on a compute node.
+	@ if test -n "$$SLURM_NODEID"; then \
+	    echo '** Warning: Building MANA can take longer on a compute node.'; \
+	    echo '** Please build MANA on a login node.'; \
 	fi
 
 display-build-env: display-config display-release

--- a/mpi-proxy-split/Makefile_config.in
+++ b/mpi-proxy-split/Makefile_config.in
@@ -8,6 +8,10 @@ CXXFLAGS = @CXXFLAGS@
 ifeq ($(findstring cori,$(PLATFORM)),cori)
 IS_CORI = 1
 endif
+# Mark the platform as Cori for a compute node.
+ifeq ($(findstring nid0,$(PLATFORM)),nid0)
+IS_CORI = 1
+endif
 ifeq ($(findstring gert,$(PLATFORM)),gert)
 IS_GERTY = 1
 endif


### PR DESCRIPTION
Issue: On Cori, the `HOST` env. var. points to the login node (`coriXXX`) when one logs into the compute node via the `salloc` command. However, if you ssh explicitly to your allocated compute node via the `JOB_ID`, the `HOST` points to the compute node. At this point, MANA's build fails as the Makefile considers it as a non-cori platform.
The PR handles the case when one builds MANA on a compute node and the `HOST` points to the compute node.