### PR TITLE
fixup! Do not set status if (FORTRAN_)MPI_STATUS_IGNORE

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
@@ -241,7 +241,7 @@ USER_DEFINED_WRAPPER(int, Sendrecv, (const void *) sendbuf, (int) sendcount,
   retval = MPI_Waitall(2, reqs, sts);
   // Set status only when the status is neither MPI_STATUS_IGNORE nor
   // FORTRAN_MPI_STATUS_IGNORE
-  if (status != MPI_STATUS_IGNORE || status != FORTRAN_MPI_STATUS_IGNORE) {
+  if (status != MPI_STATUS_IGNORE && status != FORTRAN_MPI_STATUS_IGNORE) {
     *status = sts[1];
   }
   if (retval == MPI_SUCCESS) {


### PR DESCRIPTION
I had a typo in the last commit. It should have been an AND operation instead of an OR operation. This PR fixes the last commit.