### PR TITLE
Add run_mana_mpi_regression_test script

### DIFF
--- a/mpi-proxy-split/test/run_all.py
+++ b/mpi-proxy-split/test/run_all.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import subprocess
+import argparse
+import sys
+import os
+
+tests = {
+    'Allgather_test': {'itr': 1000000, 'ranks': 4},
+    'Alloc_mem': {'itr': 20, 'ranks': 2},
+    'Allreduce_test': {'itr': 1000000000, 'ranks': 4},
+    'Alltoall_test': {'itr': 1000000000, 'ranks': 4},
+    'Alltoallv_test': {'itr': 1000000000, 'ranks': 4},
+    'Barrier_test': {'itr': 12, 'ranks': 4},
+    'Bcast_test': {'itr': 800000, 'ranks': 4},
+    'Cart_map_test': {'itr': 100000000, 'ranks': 4},
+    'Cart_sub_test': {'itr': 100000000, 'ranks': 6},
+    'Cartdim_get_test': {'itr': 100000000, 'ranks': 12},
+    'Comm_dup_test': {'itr': 60, 'ranks': 4},
+    'Comm_get_attr_test': {'itr': 60, 'ranks': 2},
+    'Comm_split_test': {'itr': 60, 'ranks': 4},
+    'Gather_test': {'itr': 100000000, 'ranks': 3},
+    'Gatherv_test': {'itr': 100000000, 'ranks': 4},
+    'Group_size_rank': {'itr': 100000000, 'ranks': 4},
+    'Ibarrier_test': {'itr': 10, 'ranks': 4},
+    'Ibcast_test': {'itr': 100000000, 'ranks': 4},
+    'Ibcast_test1': {'itr': 100000000, 'ranks': 4, 'args': -1},
+    'Ibcast_test2': {'itr': 100000000, 'ranks': 4, 'args': -2},
+    'Initialized_test': {'itr': 100000000, 'ranks': 4},
+    'Irecv_test': {'itr': 12, 'ranks': 2},
+    'Isend_test': {'itr': 12, 'ranks': 2},
+    'Reduce_test': {'itr': 100000000, 'ranks': 4},
+    'Scan_test': {'itr': 100000000, 'ranks': 4},
+    'Scatter_test': {'itr': 100000000, 'ranks': 3},
+    'Scatter_test': {'itr': 100000000, 'ranks': 4},
+    'Sendrecv_test': {'itr': 100000000, 'ranks': 3},
+    'Testany_test': {'itr': 10, 'ranks': 3},
+    'Type_commit_contiguous': {'itr': 10, 'ranks': 4},
+    'Type_hvector_test': {'itr': 100000000, 'ranks': 2},
+    'Type_vector_test': {'itr': 100000000, 'ranks': 2},
+    'Waitall_test': {'itr': 10, 'ranks': 4},
+    'Waitany_test': {'itr': 10, 'ranks': 4},
+    'file_test': {'itr': 100000000, 'ranks': 2},
+    'keyval_test': {'itr': 12, 'ranks': 4},
+    'large_async_p2p': {'itr': 12, 'ranks': 2},
+    'send_recv_loop': {'itr': 12, 'ranks': 3},
+    'sendrecv_replace_test': {'itr': 100000000, 'ranks': 3},
+    'two-phase-commit-1': {'itr': 60, 'ranks': 4},
+    'two-phase-commit-2': {'itr': 60, 'ranks': 4}
+}
+
+# Custom argparser to eprint error message
+class CustomParser(argparse.ArgumentParser):
+    def error(self, message):
+        sys.stderr.write('error: %s\n' % message)
+        self.print_help()
+        os._exit(2)
+'''
+Example usage:
+
+python3 run_all.py -r -m ~/mana
+
+'''
+def main():
+    parser = CustomParser(description='Run all MANA Tests')
+    parser.add_argument('-m','--mana_root', metavar='M', help='Absolute \
+                         path to mana folder', default='', required=False)
+    parser.add_argument('-r','--mpirun', help='Use mpirun instead \
+                         of srun', action="store_true")
+
+    args = parser.parse_args()
+    mana = args.mana_root
+    if mana == '':
+        mana = os.path.abspath(__file__).replace('/mpi-proxy-split/'
+                                                 'test/run_all.py', '')
+    mpirun = ''
+    if args.mpirun:
+        mpirun = '-r'
+    num_tests = 0
+    num_passed = 0
+    failed = []
+
+    for test in tests:
+        print(f'Running test {test}')
+        i = tests[test]['itr']
+        n = tests[test]['ranks']
+        if 'args' in tests[test]:
+            a = tests[test]['args']
+            test_child=subprocess.run(['python3', f'{mana}/mpi-proxy-split'
+                                      '/test/run_mana_mpi_regression_test.py',
+                                      f'{mpirun}', '-m', f'{mana}', '-t', '120',
+                                      '-i', f'{i}', '-n', f'{n}', f'-a={a}',
+                                      f'{test}'],
+                                      stdout=subprocess.DEVNULL,
+                                      stderr=subprocess.DEVNULL)
+        else:
+            test_child=subprocess.run(['python3', f'{mana}/mpi-proxy-split'
+                                     '/test/run_mana_mpi_regression_test.py',
+                                     f'{mpirun}', '-m', f'{mana}', '-t', '120',
+                                     '-i', f'{i}', '-n', f'{n}', f'{test}'],
+                                      stdout=subprocess.DEVNULL,
+                                      stderr=subprocess.DEVNULL)
+        try:
+            r = test_child.check_returncode()
+            print(f'TEST CASE PASSED: {test}')
+            num_passed += 1
+        except:
+            print(f'TEST CASE FAILED: {test}')
+            failed.append(test)
+        num_tests += 1
+    print("TESTS COMPLETED")
+    print(f'Passed {num_passed} of {num_tests}')
+    print('Failed tests: ')
+    print(failed)
+
+if __name__ == '__main__':
+    main()

--- a/mpi-proxy-split/test/run_mana_mpi_regression_test.py
+++ b/mpi-proxy-split/test/run_mana_mpi_regression_test.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import subprocess
+import time
+import argparse
+from threading import Thread
+from subprocess import PIPE
+
+verbose = False
+
+# Wrapper to eprint to stderr
+def eprint(*args):
+    if verbose:
+        print(*args, file=sys.stderr)
+
+# Custom argparser to eprint error message
+class CustomParser(argparse.ArgumentParser):
+    def error(self, message):
+        sys.stderr.write('error: %s\n' % message)
+        self.print_help()
+        os._exit(2)
+
+# Error handling thread for timeouts
+def timeout_exit(timeout):
+    time.sleep(int(timeout))
+    sys.stderr.write('ERROR: TEST FAILED BY TIMEOUT\n')
+    sys.stderr.flush()
+    os._exit(11)
+
+# Remove unnecessary files (old checkpoint files)
+def clean():
+    subprocess.run('rm -rf ckpt_rank_*', shell=True)
+    subprocess.run('rm -rf dmtcp_restart_*', shell=True)
+
+# Helper function to get the number of currently running ranks
+def get_running_ranks(mana_dir, state=None):
+    status = subprocess.run([f"{mana_dir}/bin/mana_status"], stdout=PIPE,
+                             stderr=subprocess.DEVNULL)
+    if state is None:
+        return status.stdout.decode('utf-8').count(".mana.exe")
+    else:
+        return status.stdout.decode('utf-8').count(state)
+
+'''
+Example usage:
+
+python3 run_mana_mpi_regression_test.py send_recv_loop -i 12 -n 3 -m ~/mana
+
+'''
+def main():
+    # Parse arguments
+    parser = CustomParser(description='Run a MANA Test')
+    parser.add_argument('-i', '--iterations', metavar='I',
+                         help='Number of iterations for the test case',
+                         required=True)
+    parser.add_argument('test', metavar='T', help='Path to test case to run')
+    parser.add_argument('-n','--num_ranks', metavar='N', help='Number of ranks \
+                              for test', required=True)
+    parser.add_argument('-m','--mana_root', metavar='M', help='Absolute \
+                         path to mana folder', default='', required=False)
+    parser.add_argument('-r','--mpirun', help='Use mpirun instead \
+                         of srun', action="store_true")
+    parser.add_argument('-v','--verbose', help='Print status logs to console',
+                        action="store_true")
+    parser.add_argument('-a', '--args', help='Arguments to pass to test',
+                        default='')
+    parser.add_argument('-t', '--timeout', help='Testcase time (seconds)')
+    args = parser.parse_args()
+    name = args.test
+    itr = args.iterations
+    ranks = args.num_ranks
+    mana_dir = args.mana_root
+    if mana_dir == '':
+        mana_dir = os.path.abspath(__file__).replace('/mpi-proxy-split/'
+                                                     'test/run_all.py', '')
+    verbose = args.verbose
+    srun = ''
+    restart='srun'
+    if args.mpirun:
+        srun='-r'
+        restart='mpirun'
+    add_args = args.args
+    mana_bin = f'{mana_dir}/bin'
+
+    # Set timeout as thread
+    if not args.timeout == None:
+        eprint("Setting timeout...")
+        t = Thread(target=timeout_exit, args=(args.timeout, ))
+        t.start()
+        eprint("Timeout set...")
+
+    eprint(f"Running {name} for {itr} iterations with {ranks} ranks")
+
+    # Start test by running mana_coordinator and executable
+    clean()
+    kill_child = subprocess.Popen(['pkill', '-9', 'dmtcp_coord'])
+    kill_child.wait()
+    eprint("Starting test...")
+    cmd=''
+    if add_args == '':
+        cmd = (f'python3 {mana_dir}/mpi-proxy-split/test/mana_test.py '
+               f'{mana_dir}/mpi-proxy-split/test/{name} -m {mana_bin} '
+               f'{srun} -n {ranks} -i {itr}')
+
+    else:
+        cmd = (f'python3 {mana_dir}/mpi-proxy-split/test/mana_test.py '
+               f'{mana_dir}/mpi-proxy-split/test/{name} -m {mana_bin} '
+               f'{srun} -n {ranks} -i {itr} -a {add_args}')
+    eprint(verbose, cmd)
+    run_child = subprocess.Popen([cmd], shell=True)
+
+    # Wait for ranks to start
+    while get_running_ranks(mana_dir, "WorkerState::RUNNING") != int(ranks):
+        sleep(0.5)
+
+    print("Running")
+
+    # Test executable starting, checkpoint 3 times
+    eprint("Test started...")
+    for i in range(3):
+        time.sleep(3)
+        if run_child.poll() is None:
+            # Send checkpoint command and wait on it to succeed
+            eprint("Sending checkpoint command...")
+            ckpt_child = subprocess.run([f'{mana_dir}/bin/mana_status',
+                                         '--checkpoint'])
+            if ckpt_child.check_returncode() is not None:
+                eprint("Test case failed: checkpointing failed")
+                return 1
+            eprint("Checkpoint command successful")
+
+            # Wait for checkpoint to complete, make sure no ranks die
+            while get_running_ranks(mana_dir, "WorkerState::RUNNING") \
+                    != int(ranks):
+                if get_running_ranks(mana_dir) != int(ranks):
+                    eprint("Test case failed: not enough \
+                        ranks running while checkpointing")
+                    return 6
+
+            # Kill DMTCP Coord
+            kill_child = subprocess.Popen(['pkill', '-9', 'dmtcp_coord'])
+            kill_child.wait()
+
+            # Wait for DMTCP Coord to die, then restart it
+            status = subprocess.run([f'{mana_dir}/bin/mana_status'],
+                                     stdout=PIPE, stderr=subprocess.DEVNULL)
+            while "Checking for coordinator" \
+                    not in status.stdout.decode('utf-8'):
+                status = \
+                    subprocess.run([f'{mana_dir}/bin/mana_status'],
+                                    stdout=PIPE, stderr=PIPE)
+            eprint("Checkpointed, restarting...")
+            subprocess.run([f"{mana_dir}/bin/mana_coordinator"],
+                           stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+
+            # Wait for coord to restart, then restart ranks
+            time.sleep(1)
+            run_child = subprocess.Popen([f'{restart}', '-n', f'{ranks}',
+                                         f'{mana_dir}/bin/mana_restart'],
+                                         stdout=subprocess.DEVNULL,
+                                         stderr=subprocess.DEVNULL)
+
+            # Wait for ranks to restart without dying
+            while get_running_ranks(mana_dir, "WorkerState::RUNNING") \
+                    != int(ranks):
+                if get_running_ranks(mana_dir) \
+                        != int(ranks) and \
+                        get_running_ranks(mana_dir, "WorkerState::RESTARTING") \
+                        == 0:
+
+                    eprint("Test case failed: not enough \
+                        ranks running after restart")
+                    return 2
+
+            time.sleep(3) # Sleep between checkpoints to allow for progression
+
+            clean() # Remove ckpt images and restart scripts
+        else: # Child died earlier, check retval to see if successful
+            if run_child.poll() != 0:
+                eprint("Test case failed: child exited early")
+                return 3
+            else:
+                eprint("Child exited early: increase iterations")
+                return 0
+
+    # Check enough ranks running at exit, then return
+    # Kills mana_coordinator + spawned MPI children
+    if get_running_ranks(mana_dir) != int(ranks):
+        eprint("Test case failed: not enough ranks running when exiting")
+        run_child.kill()
+        return 4
+    else:
+        eprint("Test case passed")
+        run_child.kill()
+        return 0
+
+if __name__ == "__main__":
+    ecode = main()
+    if ecode == 0:
+        sys.stderr.write('TESTCASE PASSED\n')
+    else:
+        sys.stderr.write('TESTCASE FAILED with code %d\n' % ecode)
+    sys.stderr.flush()
+    os._exit(ecode)


### PR DESCRIPTION
Sample success output:
> Running Allgather_test for 1000000 iterations with 4 ranks
Starting test...
python3 /root/mana/mpi-proxy-split/test/mana_test.py /root/mana/mpi-proxy-split/test/Allgather_test -m='/root/mana/bin' -r -n 4 -i 1000000 -a 
Test started...
/root/mana/bin/mana_coordinator
*** Coordinator/job information written to /root/.mana
mpirun -n 4 /root/mana/bin/mana_launch /root/mana/mpi-proxy-split/test/Allgather_test.mana.exe 1000000 
Sending checkpoint command...
Checkpoint command successful
Checkpointed, restarting...
*** Coordinator/job information written to /root/.mana
[7691] /root/mana/restart_plugin/mtcp_restart_plugin.c:595 mtcp_plugin_hook:
  [Rank: 0] Choosing ckpt image: ./ckpt_rank_0/ckpt_Allgather_test.mana.exe_1d0070a644edf9b-40000-b9dd30735d0ce.dmtcp
[7692] /root/mana/restart_plugin/mtcp_restart_plugin.c:595 mtcp_plugin_hook:
  [Rank: 1] Choosing ckpt image: ./ckpt_rank_1/ckpt_Allgather_test.mana.exe_1d0070a644edf9b-41000-b9dd30734f1b6.dmtcp
[7690] /root/mana/restart_plugin/mtcp_restart_plugin.c:595 mtcp_plugin_hook:
  [Rank: 2] Choosing ckpt image: ./ckpt_rank_2/ckpt_Allgather_test.mana.exe_1d0070a644edf9b-42000-b9dd3073503d9.dmtcp
[7695] /root/mana/restart_plugin/mtcp_restart_plugin.c:595 mtcp_plugin_hook:
  [Rank: 3] Choosing ckpt image: ./ckpt_rank_3/ckpt_Allgather_test.mana.exe_1d0070a644edf9b-43000-b9dd30734b690.dmtcp
Sending checkpoint command...
Checkpoint command successful
Checkpointed, restarting...
*** Coordinator/job information written to /root/.mana
[8991] /root/mana/restart_plugin/mtcp_restart_plugin.c:595 mtcp_plugin_hook:
  [Rank: 0] Choosing ckpt image: ./ckpt_rank_0/ckpt_Allgather_test.mana.exe_1d0070a644edf9b-40000-b9dd30735d0ce.dmtcp
[8995] /root/mana/restart_plugin/mtcp_restart_plugin.c:595 mtcp_plugin_hook:
  [Rank: 1] Choosing ckpt image: ./ckpt_rank_1/ckpt_Allgather_test.mana.exe_1d0070a644edf9b-41000-b9dd30734f1b6.dmtcp
[8992] /root/mana/restart_plugin/mtcp_restart_plugin.c:595 mtcp_plugin_hook:
  [Rank: 2] Choosing ckpt image: ./ckpt_rank_2/ckpt_Allgather_test.mana.exe_1d0070a644edf9b-42000-b9dd3073503d9.dmtcp
[8994] /root/mana/restart_plugin/mtcp_restart_plugin.c:595 mtcp_plugin_hook:
  [Rank: 3] Choosing ckpt image: ./ckpt_rank_3/ckpt_Allgather_test.mana.exe_1d0070a644edf9b-43000-b9dd30734b690.dmtcp
Sending checkpoint command...
Checkpoint command successful
Checkpointed, restarting...
*** Coordinator/job information written to /root/.mana
[10399] /root/mana/restart_plugin/mtcp_restart_plugin.c:595 mtcp_plugin_hook:
  [Rank: 0] Choosing ckpt image: ./ckpt_rank_0/ckpt_Allgather_test.mana.exe_1d0070a644edf9b-40000-b9dd30735d0ce.dmtcp
[10400] /root/mana/restart_plugin/mtcp_restart_plugin.c:595 mtcp_plugin_hook:
  [Rank: 1] Choosing ckpt image: ./ckpt_rank_1/ckpt_Allgather_test.mana.exe_1d0070a644edf9b-41000-b9dd30734f1b6.dmtcp
[10396] /root/mana/restart_plugin/mtcp_restart_plugin.c:595 mtcp_plugin_hook:
  [Rank: 2] Choosing ckpt image: ./ckpt_rank_2/ckpt_Allgather_test.mana.exe_1d0070a644edf9b-42000-b9dd3073503d9.dmtcp
[10398] /root/mana/restart_plugin/mtcp_restart_plugin.c:595 mtcp_plugin_hook:
  [Rank: 3] Choosing ckpt image: ./ckpt_rank_3/ckpt_Allgather_test.mana.exe_1d0070a644edf9b-43000-b9dd30734b690.dmtcp
Test case passed


Sample failure output:
> Setting timeout...
Timeout set...
Running Allgather_test for 1000000 iterations with 4 ranks
Starting test...
python3 /root/mana/mpi-proxy-split/test/mana_test.py /root/mana/mpi-proxy-split/test/Allgather_test -m='/root/mana/bin' -r -n 4 -i 1000000 -a 
Test started...
/root/mana/bin/mana_coordinator
*** Coordinator/job information written to /root/.mana
mpirun -n 4 /root/mana/bin/mana_launch /root/mana/mpi-proxy-split/test/Allgather_test.mana.exe 1000000 
Sending checkpoint command...
Checkpoint command successful
TIMEOUT

Note that the exit code is also unique by the error that occurs during the test, allowing us to determine the error without reading error logs. 