### PR TITLE
Init thread fix

### DIFF
--- a/mpi-proxy-split/lower-half/libproxy.c
+++ b/mpi-proxy-split/lower-half/libproxy.c
@@ -192,15 +192,24 @@ updateEnviron(const char **newenviron)
 }
 
 int
-getRank()
+getRank(int initFlag)
 {
   int flag;
   int world_rank = -1;
+  int provided;
   int retval = MPI_SUCCESS;
 
   MPI_Initialized(&flag);
   if (!flag) {
-    retval = MPI_Init(NULL, NULL);
+    if(initFlag == -1){
+      MPI_Init(NULL, NULL);
+    }
+    else{
+      retval = MPI_Init_thread(NULL, NULL, initFlag, &provided);
+    }
+  }
+  if(retval != MPI_SUCCESS){
+    MPI_ABORT();
   }
   if (retval == MPI_SUCCESS) {
     MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
@@ -214,16 +223,25 @@ getRank()
 MPI_Comm comm_cart_prime;
 
 int
-getCoordinates(CartesianProperties *cp, int *coords)
+getCoordinates(CartesianProperties *cp, int *coords, int initFlag)
 {
   int flag;
   int comm_old_rank = -1;
   int comm_cart_rank = -1;
   int retval = MPI_SUCCESS;
+  int provided;
 
   MPI_Initialized(&flag);
   if (!flag) {
-    retval = MPI_Init(NULL, NULL);
+    if(initFlag == -1){
+      MPI_Init(NULL, NULL);
+    }
+    else{
+      retval = MPI_Init_thread(NULL, NULL, initFlag, &provided);
+    }
+  }
+  if(retval != MPI_SUCCESS){
+    MPI_ABORT();
   }
   if (retval == MPI_SUCCESS) {
     MPI_Cart_create(MPI_COMM_WORLD, cp->ndims, cp->dimensions, cp->periods,

--- a/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
@@ -29,6 +29,7 @@
 #include "mpi_nextfunc.h"
 #include "virtual-ids.h"
 #include "p2p_drain_send_recv.h"
+#include "processinfo.h"
 
 #if 0
 DEFINE_FNC(int, Init, (int *) argc, (char ***) argv)
@@ -51,6 +52,7 @@ USER_DEFINED_WRAPPER(int, Init, (int *) argc, (char ***) argv) {
     fprintf(stderr, collective_p2p_string);
   }
   DMTCP_PLUGIN_DISABLE_CKPT();
+  dmtcp::ProcessInfo::instance().setInitThreadFlag(-1);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Init)(argc, argv);
   RETURN_TO_UPPER_HALF();
@@ -65,6 +67,7 @@ USER_DEFINED_WRAPPER(int, Init_thread, (int *) argc, (char ***) argv,
     fprintf(stderr, collective_p2p_string);
   }
   DMTCP_PLUGIN_DISABLE_CKPT();
+  dmtcp::ProcessInfo::instance().setInitThreadFlag(required);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Init_thread)(argc, argv, required, provided);
   RETURN_TO_UPPER_HALF();

--- a/restart_plugin/mtcp_restart_plugin.c
+++ b/restart_plugin/mtcp_restart_plugin.c
@@ -473,14 +473,16 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
 #if 0
     print(&CartesianProperties);
 #endif
-    typedef int (*getCoordinatesFptr_t)(CartesianProperties *, int *);
+    typedef int (*getCoordinatesFptr_t)(CartesianProperties *, int *, int);
     JUMP_TO_LOWER_HALF(rinfo->pluginInfo.fsaddr);
     // MPI_Init is called here. GNI memory areas will be loaded by MPI_Init.
     // Also, MPI_Cart_create will be called to restore cartesian topology.
     // Based on the coordinates, checkpoint image will be restored instead of
     // world rank.
     world_rank =
-      ((getCoordinatesFptr_t)rinfo->pluginInfo.getCoordinatesFptr)(&cp, coords);
+      ((getCoordinatesFptr_t)rinfo->pluginInfo.getCoordinatesFptr)(&cp, coords, rinfo->flag);
+    MTCP_PRINTF("[Rank: %d] Restoring with flag: %d\n", rank, rinfo->flag);
+
     RETURN_TO_UPPER_HALF();
 #if 0
     MTCP_PRINTF("\nWorld Rank: %d \n: ", world_rank);
@@ -492,11 +494,13 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
     ckpt_image_rank_to_be_restored =
     get_rank_corresponding_to_coordinates(cp.comm_old_size, cp.ndims, coords);
   } else {
-    typedef int (*getRankFptr_t)(void);
+    typedef int (*getRankFptr_t)(int);
     JUMP_TO_LOWER_HALF(rinfo->pluginInfo.fsaddr);
     // MPI_Init is called here. GNI memory areas will be loaded by MPI_Init.
-    world_rank = ((getRankFptr_t)rinfo->pluginInfo.getRankFptr)();
+    world_rank = ((getRankFptr_t)rinfo->pluginInfo.getRankFptr)(rinfo->flag);
     RETURN_TO_UPPER_HALF();
+    MTCP_PRINTF("[Rank: %d] Restoring with flag: %d\n", rank, rinfo->flag);
+
     ckpt_image_rank_to_be_restored = world_rank;
   }
 
@@ -577,14 +581,15 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
     end2 = start2;
   }
 
-  typedef int (*getRankFptr_t)(void);
+  typedef int (*getRankFptr_t)(int);
   int rank = -1;
   reserveUpperHalfMemoryRegionsForCkptImgs(start1, end1, start2, end2);
   JUMP_TO_LOWER_HALF(rinfo->pluginInfo.fsaddr);
 
   // MPI_Init is called here. GNI memory areas will be loaded by MPI_Init.
-  rank = ((getRankFptr_t)rinfo->pluginInfo.getRankFptr)();
+  rank = ((getRankFptr_t)rinfo->pluginInfo.getRankFptr)(rinfo->flag);
   RETURN_TO_UPPER_HALF();
+  MTCP_PRINTF("[Rank: %d] Restoring with flag: %d\n", rank, rinfo->flag);
   releaseUpperHalfMemoryRegionsForCkptImgs(start1, end1, start2, end2);
   unreserve_fds_upper_half(reserved_fds,total_reserved_fds);
 


### PR DESCRIPTION
This PR is to fix a bug where upon restart we are only calling MPI_Init, instead of MPI_Init_thread in cases where MPI_Init_thread is being called initially.

This PR does not work in its current form. Namely, the issue is that the flag used to initialize the process must be restored from the checkpoint header, but the process must first be initialized to get that header value.