### PR TITLE
Update DMTCP submodule (PRs 1007, 1010-1013)

### DIFF
--- a/mpi-proxy-split/unit-test/Makefile
+++ b/mpi-proxy-split/unit-test/Makefile
@@ -43,7 +43,7 @@ override CXXFLAGS += -g3 -O0 -fPIC -I${DMTCP_INCLUDE} \
 TEST_LD_FLAGS=${DMTCP_ROOT}/src/libdmtcpinternal.a \
               ${DMTCP_ROOT}/src/libjalib.a \
               ${DMTCP_ROOT}/src/libnohijack.a \
-              -lgtest -lpthread
+              -lgtest -lpthread -ldl
 
 DRAIN_TEST_OBJS = drain-send-recv-test.o ../p2p_drain_send_recv.cpp \
                   ../p2p_log_replay.cpp ${DMTCP_ROOT}/src/lookup_service.o


### PR DESCRIPTION
1. configure.ac/configure: check FSGSBASE in kernel
2. Fixed pthread_create bug when called from a constructor.
3. Various logging improvements.
4. Util to test for FSGSBASE patch; info on use
5. Polish configure.ac/configure
----
6. Added link flag to the unit tests for the new DMTCP logging mechanism