### PR TITLE
[MANA-196] Fixed issue when calling init thread by adding mana header

### DIFF
--- a/mpi-proxy-split/mana_header.h
+++ b/mpi-proxy-split/mana_header.h
@@ -1,0 +1,10 @@
+#ifndef MANA_HEADER_H
+#define MANA_HEADER_H
+
+#define MPI_INIT_NO_THREAD -1
+
+typedef struct ManaHeader {
+    int init_flag;
+} ManaHeader;
+
+#endif // MANA_HEADER

--- a/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
@@ -29,6 +29,7 @@
 #include "mpi_nextfunc.h"
 #include "virtual-ids.h"
 #include "p2p_drain_send_recv.h"
+#include "mana_header.h"
 
 #if 0
 DEFINE_FNC(int, Init, (int *) argc, (char ***) argv)
@@ -45,12 +46,16 @@ static const char collective_p2p_string[] =
    "   ***   individual MPI collective calls for translation to MPI_Send/Recv.\n"
    "   ***************************************************************************\n"
    "\n";
+
+ManaHeader g_mana_header = { .init_flag = MPI_INIT_NO_THREAD };
+
 USER_DEFINED_WRAPPER(int, Init, (int *) argc, (char ***) argv) {
   int retval;
   if (isUsingCollectiveToP2p()) {
     fprintf(stderr, collective_p2p_string);
   }
   DMTCP_PLUGIN_DISABLE_CKPT();
+  g_mana_header.init_flag = MPI_INIT_NO_THREAD;
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Init)(argc, argv);
   RETURN_TO_UPPER_HALF();
@@ -65,6 +70,7 @@ USER_DEFINED_WRAPPER(int, Init_thread, (int *) argc, (char ***) argv,
     fprintf(stderr, collective_p2p_string);
   }
   DMTCP_PLUGIN_DISABLE_CKPT();
+  g_mana_header.init_flag = required;
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Init_thread)(argc, argv, required, provided);
   RETURN_TO_UPPER_HALF();

--- a/restart_plugin/mtcp_restart_plugin.c
+++ b/restart_plugin/mtcp_restart_plugin.c
@@ -6,6 +6,7 @@
 #include "mtcp_restart.h"
 #include "mtcp_sys.h"
 #include "mtcp_util.h"
+#include "../mpi-proxy-split/mana_header.h"
 #include "mtcp_split_process.h"
 #ifdef SINGLE_CART_REORDER
 #include "../mpi-proxy-split/cartesian.h"
@@ -326,6 +327,17 @@ mysetauxval(char **evp, unsigned long int type, unsigned long int val)
   return -1;
 }
 
+int
+load_mana_header (char *filename, ManaHeader *mh)
+{
+  int fd = mtcp_sys_open2(filename, O_RDONLY);
+  if (fd == -1) {
+    return -1;
+  }
+  mtcp_sys_read(fd, &mh->init_flag, sizeof(int));
+  return 0;
+}
+
 #ifdef SINGLE_CART_REORDER
 int
 load_cartesian_properties(char *filename, CartesianProperties *cp)
@@ -466,6 +478,12 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
   int ckpt_image_rank_to_be_restored = -1;
   char *filename = "./ckpt_rank_0/cartesian.info";
 
+  char *header_filname = "./ckpt_rank_0/header.mana";
+  ManaHeader m_header;
+  MTCP_ASSERT(load_mana_header(header_filename, &m_header) == 0);
+
+  MTCP_PRINTF("Initializing with flag: %d\n", m_header.init_flag);
+
   if (mtcp_sys_access(filename, F_OK) == 0) {
     int coords[MAX_CART_PROP_SIZE];
     CartesianProperties cp;
@@ -473,14 +491,15 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
 #if 0
     print(&CartesianProperties);
 #endif
-    typedef int (*getCoordinatesFptr_t)(CartesianProperties *, int *);
+    typedef int (*getCoordinatesFptr_t)(CartesianProperties *, int *, int);
     JUMP_TO_LOWER_HALF(rinfo->pluginInfo.fsaddr);
     // MPI_Init is called here. GNI memory areas will be loaded by MPI_Init.
     // Also, MPI_Cart_create will be called to restore cartesian topology.
     // Based on the coordinates, checkpoint image will be restored instead of
     // world rank.
     world_rank =
-      ((getCoordinatesFptr_t)rinfo->pluginInfo.getCoordinatesFptr)(&cp, coords);
+      ((getCoordinatesFptr_t)
+      rinfo->pluginInfo.getCoordinatesFptr)(&cp, coords, m_header.init_flag);
     RETURN_TO_UPPER_HALF();
 #if 0
     MTCP_PRINTF("\nWorld Rank: %d \n: ", world_rank);
@@ -490,12 +509,13 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
       MTCP_PRINTF("%d, ", coords[i]);
 #endif
     ckpt_image_rank_to_be_restored =
-    get_rank_corresponding_to_coordinates(cp.comm_old_size, cp.ndims, coords);
+    get_rank_corresponding_to_coordinates(cp.comm_old_size, cp.ndims, coords, m_header.init_flag);
   } else {
     typedef int (*getRankFptr_t)(void);
     JUMP_TO_LOWER_HALF(rinfo->pluginInfo.fsaddr);
     // MPI_Init is called here. GNI memory areas will be loaded by MPI_Init.
-    world_rank = ((getRankFptr_t)rinfo->pluginInfo.getRankFptr)();
+    world_rank =
+      ((getRankFptr_t)rinfo->pluginInfo.getRankFptr)(m_header.init_flag);
     RETURN_TO_UPPER_HALF();
     ckpt_image_rank_to_be_restored = world_rank;
   }
@@ -577,13 +597,17 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
     end2 = start2;
   }
 
-  typedef int (*getRankFptr_t)(void);
+  char *header_filename = "./ckpt_rank_0/header.mana";
+  ManaHeader m_header;
+  MTCP_ASSERT(load_mana_header(header_filename, &m_header) == 0);
+
+  typedef int (*getRankFptr_t)(int);
   int rank = -1;
   reserveUpperHalfMemoryRegionsForCkptImgs(start1, end1, start2, end2);
   JUMP_TO_LOWER_HALF(rinfo->pluginInfo.fsaddr);
 
   // MPI_Init is called here. GNI memory areas will be loaded by MPI_Init.
-  rank = ((getRankFptr_t)rinfo->pluginInfo.getRankFptr)();
+  rank = ((getRankFptr_t)rinfo->pluginInfo.getRankFptr)(m_header.init_flag);
   RETURN_TO_UPPER_HALF();
   releaseUpperHalfMemoryRegionsForCkptImgs(start1, end1, start2, end2);
   unreserve_fds_upper_half(reserved_fds,total_reserved_fds);


### PR DESCRIPTION
Adds a MANA Header to be saved in each checkpoint file. Currently, this header only saves the level of thread support used to initialize the thread. This header is saved to a file in each checkpoint directory, and is loaded on restart before initialization of the MPI process of each rank. 

This fix assumes that the same flag is being used to initialize all ranks. I couldn't find anything in the MPI standard to explicitly support this assumption see [here](https://www.mpi-forum.org/docs/mpi-4.0/mpi40-report.pdf) pg. 491. However, it seems like that in almost all cases this would be the case. We could try to verify this by saving each process thread support level in the DMTCP header also, and verifying on restart that the loaded level of thread support is equivalent to the saved value. This would allow us to abort if we restart with incorrect level of thread support. 

