### PR TITLE
First potential fix to ckpt pending issue: do not begin commit when replaying logged calls

### DIFF
--- a/mpi-proxy-split/seq_num.cpp
+++ b/mpi-proxy-split/seq_num.cpp
@@ -101,7 +101,7 @@ int twoPhaseCommit(MPI_Comm comm,
 }
 
 void commit_begin(MPI_Comm comm) {
-  if (comm == MPI_COMM_NULL) {
+  if (mana_state == RESTART_REPLAY || comm == MPI_COMM_NULL) {
     return;
   }
   pthread_mutex_lock(&seq_num_lock);


### PR DESCRIPTION
The issue this is solving is an error on restart, where replayed calls are getting stuck in the commit_begin method because ckpt_pending is not reset until after replaying logged calls. Therefore, these replayed calls get stuck in the replaying section. There are 2 possible changes: this approach seeks to undo the changes in the previous commit that caused these changes (by skipping commit_begin when replaying). An alternate approach is to simply reset sequence numbers before replaying logged calls. See https://github.com/mpickpt/mana/pull/235 for the alternate approach (only one is needed)