### PR TITLE
[MANA-217] Convert freepass variable into semaphore, change commit_finish logic to match commit_begin

### DIFF
--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -326,7 +326,7 @@ mpi_plugin_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
           string commId = "MANA-PRESUSPEND-COMM-" + jalib::XToString(round);
           string targetId = "MANA-PRESUSPEND-TARGET-" + jalib::XToString(round);
           int64_t commKey = (int64_t) data_to_coord.comm;
-          
+
           int target_reached = check_seq_nums();
           if (!target_reached) {
             dmtcp_kvdb64(DMTCP_KVDB_OR, targetId.c_str(), 0, 1);


### PR DESCRIPTION
Converts freepass variable into a semaphore to avoid weird thread scheduling bug

Also changes commit_finish to run normally during presuspend phase