### PR TITLE
[MANA-213] Fixed previous typo in seqnum logic

### DIFF
--- a/mpi-proxy-split/seq_num.cpp
+++ b/mpi-proxy-split/seq_num.cpp
@@ -211,7 +211,7 @@ void commit_begin(MPI_Comm comm) {
 }
 
 void commit_finish() {
-  if (mana_state != RESTART_REPLAY) {
+  if (mana_state == RESTART_REPLAY) {
     return;
   }
   pthread_mutex_lock(&seq_num_lock);


### PR DESCRIPTION
This may be related to the issue we are seeing with the extremely slow checkpointing. 

This bug would cause the ranks to get stuck in the IN_CS state, and would never be set to IS_READY, which would make it impossible to checkpoint