### PR TITLE
Log p2p message data

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
+++ b/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
@@ -19,12 +19,12 @@ int main(int argc, char *argv[]) {
   int rank;
   int rc;
 
+  MPI_Init(NULL, NULL);
   if (argc == 2) {
     rc = show_log(argv[1]);
     return rc;
   }
 
-  MPI_Init(NULL, NULL);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   snprintf(buf, sizeof(buf)-1, P2P_LOG_MSG, rank);
   int fd_log = open(buf, O_RDWR);

--- a/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
@@ -201,7 +201,7 @@ USER_DEFINED_WRAPPER(int, Irecv,
     logRequestInfo(*request, IRECV_REQUEST);
 #endif
   }
-  LOG_POST_Irecv(source,tag,comm,&status,request);
+  LOG_POST_Irecv(source,tag,comm,&status,request,buf);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }

--- a/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
+++ b/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
@@ -11,7 +11,6 @@
 //   Define USE_READALL/WRITEALL if using readall/writeall.
 #define USE_READALL
 #define USE_WRITEALL
-#define USE_CHECKSUM_LRC
 #include "p2p-deterministic.h"
 
 int p2p_deterministic_skip_save_request = 0;
@@ -176,6 +175,7 @@ void set_next_msg(int count, MPI_Datatype datatype,
     p2p_msg->tag = status->MPI_TAG;
     if (status->MPI_ERROR) {
       fprintf(stderr, "Recv with error:  %d\n", status->MPI_ERROR);
+      free(p2p_msg);
       exit(1);
     }
   }

--- a/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
+++ b/mpi-proxy-split/mpi-wrappers/p2p-deterministic.c
@@ -11,6 +11,7 @@
 //   Define USE_READALL/WRITEALL if using readall/writeall.
 #define USE_READALL
 #define USE_WRITEALL
+#define USE_CHECKSUM_LRC
 #include "p2p-deterministic.h"
 
 int p2p_deterministic_skip_save_request = 0;

--- a/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -91,6 +91,7 @@ int readp2pmsg(int fd, struct p2p_log_msg **p2p_log_out, int *size_out)
   int size;
   MPI_Type_size(p2p_log_head.datatype, &size);
   p2p_log = malloc(sizeof(struct p2p_log_msg) + size * p2p_log_head.count);
+  *p2p_log = p2p_log_head;
   rc = readall(fd, p2p_log->data, size * p2p_log->count);
   if (rc <= 0) {
     free(p2p_log);

--- a/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -33,7 +33,8 @@ struct p2p_log_request {
 };
 
 void p2p_log(int count, MPI_Datatype datatype, int source, int tag,
-             MPI_Comm comm, MPI_Status *status, MPI_Request *request,             void *data);
+             MPI_Comm comm, MPI_Status *status, MPI_Request *request,
+             void *data);
 void  p2p_replay(int count, MPI_Datatype datatype, int *source, int *tag,
                  MPI_Comm comm);
 void  p2p_replay_pre_irecv(int count, MPI_Datatype datatype, int *source,
@@ -48,7 +49,7 @@ void set_next_msg(int count, MPI_Datatype datatype,
                   MPI_Status *status, MPI_Request *request, void *buf);
 void save_request_info(MPI_Request *request, MPI_Status *status);
 
-#ifdef USE_CHECKSUM_LRC
+#ifdef USE_READALL
 /* 8 bits lrc checksum */
 char checksum_lrc(char *buf, int size)
 {
@@ -59,9 +60,7 @@ char checksum_lrc(char *buf, int size)
    }
    return lrc;
 }
-#endif
 
-#ifdef USE_READALL
 static
 ssize_t readall(int fd, void *buf, size_t count) {
   ssize_t rc;
@@ -80,6 +79,26 @@ ssize_t readall(int fd, void *buf, size_t count) {
     }
   }
   return num_read;
+}
+
+int readp2pmsg(int fd, struct p2p_log_msg **p2p_log_out, int *size_out)
+{
+  struct p2p_log_msg p2p_log_head;
+  int rc;
+  struct p2p_log_msg *p2p_log;
+  rc = readall(fd, &p2p_log_head, sizeof(struct p2p_log_msg));
+  if (rc == 0) return 0;
+  int size;
+  MPI_Type_size(p2p_log_head.datatype, &size);
+  p2p_log = malloc(sizeof(struct p2p_log_msg) + size * p2p_log_head.count);
+  rc = readall(fd, p2p_log->data, size * p2p_log->count);
+  if (rc == 0) {
+    free(p2p_log);
+    return rc;
+  }
+  *p2p_log_out = p2p_log;
+  *size_out = size * p2p_log_head.count;
+  return rc;
 }
 #endif
 

--- a/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -24,6 +24,7 @@ struct p2p_log_msg {
   int MPI_ERROR;
   MPI_Comm comm; // comm == MPI_COMM_NULL if this logs a failed MPI_Iprobe
   MPI_Request request;
+  char data[];
 };
 struct p2p_log_request {
   MPI_Request request;
@@ -32,7 +33,7 @@ struct p2p_log_request {
 };
 
 void p2p_log(int count, MPI_Datatype datatype, int source, int tag,
-             MPI_Comm comm, MPI_Status *status, MPI_Request *request);
+             MPI_Comm comm, MPI_Status *status, MPI_Request *request,             void *data);
 void  p2p_replay(int count, MPI_Datatype datatype, int *source, int *tag,
                  MPI_Comm comm);
 void  p2p_replay_pre_irecv(int count, MPI_Datatype datatype, int *source,
@@ -44,7 +45,7 @@ int get_next_msg_iprobe(struct p2p_log_msg *p2p_msg);
 int iprobe_next_msg(struct p2p_log_msg *p2p_msg);
 void set_next_msg(int count, MPI_Datatype datatype,
                   int source, int tag, MPI_Comm comm,
-                  MPI_Status *status, MPI_Request *request);
+                  MPI_Status *status, MPI_Request *request, void *buf);
 void save_request_info(MPI_Request *request, MPI_Status *status);
 
 #ifdef USE_READALL
@@ -108,7 +109,7 @@ ssize_t writeall(int fd, void *buf, size_t count) {
 #define LOG_POST_Recv(source,tag,comm,status,request)
   if (getenv("MANA_P2P_LOG")) {
     p2p_log(bytesRecvd, MPI_CHAR, source, tag, comm,
-            status, NULL /* no request */);
+            status, NULL /* no request */,NULL /* buf */);
   }
 
 // Before MPI_Irecv during original launch/log
@@ -117,11 +118,11 @@ ssize_t writeall(int fd, void *buf, size_t count) {
 
 // After MPI_Irecv during original launch/log
 // FIXME:  Need to add MPI_Recv_init when MANA supports it
-#define LOG_POST_Irecv(source,tag,comm,status,request)
+#define LOG_POST_Irecv(source,tag,comm,status,request,buf)
   if (getenv("MANA_P2P_LOG")) {
     // source and tag will be filled in later, based on request
     // (count, datatype) will be replaced by (bytesRecvd, MPI_CHAR)
-    p2p_log(count, datatype, source, tag, comm, NULL, request);
+    p2p_log(count, datatype, source, tag, comm, NULL, request, buf);
   }
 
 // Before MPI_Probe during original launch/log
@@ -137,7 +138,9 @@ ssize_t writeall(int fd, void *buf, size_t count) {
 // NOT USED:  MPI_Probe wrapper calls MPI_Iprobe
 #define LOG_POST_Probe(source,tag,comm,status,request)
   if (getenv("MANA_P2P_LOG")) {
-    p2p_log(count, MPI_CHAR, source, tag, comm, status, NULL /* no request */);
+    p2p_log(count, MPI_CHAR, source, tag, comm, status,
+            NULL /* no request */,
+            NULL /* no buffer */);
   }
 
 // Before MPI_Iprobe during original launch/log
@@ -163,7 +166,7 @@ ssize_t writeall(int fd, void *buf, size_t count) {
       tag = status->MPI_TAG;
     }
     p2p_log(bytesRecvd, MPI_CHAR, source, tag, comm,
-            status, NULL /* no request */);
+            status, NULL /* no request */, NULL /* buf */);
   }
 
 /****************************************

--- a/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -87,12 +87,12 @@ int readp2pmsg(int fd, struct p2p_log_msg **p2p_log_out, int *size_out)
   int rc;
   struct p2p_log_msg *p2p_log;
   rc = readall(fd, &p2p_log_head, sizeof(struct p2p_log_msg));
-  if (rc == 0) return 0;
+  if (rc <= 0) return rc;
   int size;
   MPI_Type_size(p2p_log_head.datatype, &size);
   p2p_log = malloc(sizeof(struct p2p_log_msg) + size * p2p_log_head.count);
   rc = readall(fd, p2p_log->data, size * p2p_log->count);
-  if (rc == 0) {
+  if (rc <= 0) {
     free(p2p_log);
     return rc;
   }

--- a/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
+++ b/mpi-proxy-split/mpi-wrappers/p2p-deterministic.txt
@@ -48,6 +48,19 @@ void set_next_msg(int count, MPI_Datatype datatype,
                   MPI_Status *status, MPI_Request *request, void *buf);
 void save_request_info(MPI_Request *request, MPI_Status *status);
 
+#ifdef USE_CHECKSUM_LRC
+/* 8 bits lrc checksum */
+char checksum_lrc(char *buf, int size)
+{
+   char lrc = '\0';
+   for (int i = 0; i < size; i++) {
+     lrc = (lrc + buf[i]) & 0xff;
+     lrc = (((lrc ^ 0xff) + 1) & 0xff);
+   }
+   return lrc;
+}
+#endif
+
 #ifdef USE_READALL
 static
 ssize_t readall(int fd, void *buf, size_t count) {


### PR DESCRIPTION
This changes saves the P2P MPI message data to the log file in addition to the message metadata. It also calculates the checksum when using mana_p2p_update_logs to show a log file.