### PR TITLE
Change the mutex lock when ckpt INTENT arrives.

### DIFF
--- a/mpi-proxy-split/seq_num.cpp
+++ b/mpi-proxy-split/seq_num.cpp
@@ -241,22 +241,22 @@ void download_targets(std::map<unsigned int, unsigned long> &target) {
 }
 
 void share_seq_nums(std::map<unsigned int, unsigned long> &target) {
-  pthread_mutex_lock(&seq_num_lock);
   upload_seq_num();
   dmtcp_global_barrier("mana/comm-seq-round");
   download_targets(target);
-  pthread_mutex_unlock(&seq_num_lock);
 }
 
 
 rank_state_t preSuspendBarrier(query_t query) {
   switch (query) {
     case INTENT:
+      pthread_mutex_lock(&seq_num_lock);
       share_seq_nums(target_start_triv_barrier);
       // Set the ckpt_pending after sharing sequence numbers.
       // Otherwise, the user thread can enter the trivial barrier
       // before target_seq_num are properly updated.
       ckpt_pending = true;
+      pthread_mutex_unlock(&seq_num_lock);
       break;
     case FREE_PASS:
       sem_post(&freepass_sem);


### PR DESCRIPTION
This may solve the occasional hanging issue during checkpoints. Previously, a process may share the sequence numbers and run into the critical section (lower half) before ckpt_pending is set to true in the ckpt thread. I move the mutex lock that protects sequence number sharing to protect both sequence number sharing and setting the value of ckpt_pending.