### PR TITLE
[MANA-244] Additional MPI wrappers used by CP2K

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_unimplemented_wrappers.txt
+++ b/mpi-proxy-split/mpi-wrappers/mpi_unimplemented_wrappers.txt
@@ -88,9 +88,6 @@ int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
 
 int MPI_File_call_errhandler(MPI_File fh, int errorcode);
 int MPI_File_create_errhandler(MPI_File_errhandler_function *function, MPI_Errhandler *errhandler);
-int MPI_File_set_errhandler( MPI_File file, MPI_Errhandler errhandler);
-int MPI_File_get_errhandler( MPI_File file, MPI_Errhandler *errhandler);
-int MPI_File_delete(const char *filename, MPI_Info info);
 int MPI_File_preallocate(MPI_File fh, MPI_Offset size);
 int MPI_File_get_group(MPI_File fh, MPI_Group *group);
 int MPI_File_get_amode(MPI_File fh, int *amode);
@@ -100,8 +97,6 @@ int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_
 int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
 int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
 int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_write_all(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
 int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
 int MPI_File_iwrite(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
 int MPI_File_iread_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
@@ -130,10 +125,8 @@ int MPI_File_write_ordered_end(MPI_File fh, const void *buf, MPI_Status *status)
 int MPI_File_get_type_extent(MPI_File fh, MPI_Datatype datatype, MPI_Aint *extent);
 int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
 int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
-int MPI_Get_address(const void *location, MPI_Aint *address);
 int MPI_Get(void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win);
 int MPI_Get_accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, void *result_addr, int result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
-int MPI_Get_library_version(char *version, int *resultlen);
 int MPI_Get_version(int *version, int *subversion);
 int MPI_Graph_create(MPI_Comm comm_old, int nnodes, const int index[], const int edges[], int reorder, MPI_Comm *comm_graph);
 int MPI_Graph_get(MPI_Comm comm, int maxindex, int maxedges, int index[], int edges[]);

--- a/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
@@ -115,6 +115,29 @@ USER_DEFINED_WRAPPER(int, Get_count,
   return retval;
 }
 
+USER_DEFINED_WRAPPER(int, Get_library_version, (char *) version,
+                    (int *) resultlen)
+{
+  int retval;
+  DMTCP_PLUGIN_DISABLE_CKPT();
+  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
+  retval = NEXT_FUNC(Get_library_version)(version, resultlen);
+  RETURN_TO_UPPER_HALF();
+  DMTCP_PLUGIN_ENABLE_CKPT();
+  return retval;
+}
+
+USER_DEFINED_WRAPPER(int, Get_address, (const void *) location,
+                    (MPI_Aint *) address)
+{
+  int retval;
+  DMTCP_PLUGIN_DISABLE_CKPT();
+  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
+  retval = NEXT_FUNC(Get_address)(location, address);
+  RETURN_TO_UPPER_HALF();
+  DMTCP_PLUGIN_ENABLE_CKPT();
+  return retval;
+}
 
 PMPI_IMPL(int, MPI_Init, int *argc, char ***argv)
 PMPI_IMPL(int, MPI_Finalize, void)
@@ -126,3 +149,5 @@ PMPI_IMPL(int, MPI_Init_thread, int *argc, char ***argv,
           int required, int *provided)
 PMPI_IMPL(int, MPI_Get_count, const MPI_Status *status, MPI_Datatype datatype,
           int *count)
+PMPI_IMPL(int, MPI_Get_library_version, char *version, int *resultlen)
+PMPI_IMPL(int, MPI_Get_address, const void *location, MPI_Aint *address)


### PR DESCRIPTION
This PR adds the following wrappers used by CP2K:
```
mpi_file_delete
mpi_file_read_all
mpi_file_set_errhandler
mpi_file_write_all
mpi_get_library_version
mpi_get_address
```
The following are some remaining APIs that are not implemented in this PR:
```
mpi_iallgather
mpi_iallgatherv
mpi_iallreduce
mpi_iscatter
mpi_iscatterv
mpi_type_create_hindexed <- this is already implemented in PR #256 
----- MPI_Win family APIs should be implemented in PR #239 -----
mpi_rget
mpi_win_create
mpi_win_flush_all
mpi_win_free
mpi_win_lock_all
mpi_win_unlock_all
```