### PR TITLE
[MANA-244] Add MPI_File_[get|set]_errhandler API

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_fortran_wrappers.txt
+++ b/mpi-proxy-split/mpi-wrappers/mpi_fortran_wrappers.txt
@@ -125,3 +125,6 @@ int MPI_File_sync(MPI_File fh);
 int MPI_File_get_position(MPI_File fh, MPI_Offset* offset);
 int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence);
 int MPI_File_close(MPI_File* fh);
+int MPI_File_set_errhandler(MPI_File fh, MPI_Errhandler errhandler);
+int MPI_File_get_errhandler(MPI_File fh, MPI_Errhandler* errhandler);
+int MPI_File_delete(const char* filename, MPI_Info info);

--- a/mpi-proxy-split/mpi-wrappers/mpi_fortran_wrappers.txt
+++ b/mpi-proxy-split/mpi-wrappers/mpi_fortran_wrappers.txt
@@ -128,3 +128,5 @@ int MPI_File_close(MPI_File* fh);
 int MPI_File_set_errhandler(MPI_File fh, MPI_Errhandler errhandler);
 int MPI_File_get_errhandler(MPI_File fh, MPI_Errhandler* errhandler);
 int MPI_File_delete(const char* filename, MPI_Info info);
+int MPI_Get_library_version(char* version, int* resultlen);
+int MPI_Get_address(const void* location, MPI_Aint* address);


### PR DESCRIPTION
Add MPI_File_get_errhandler and MPI_File_set_errhandler API to the fortran wrapper.