### PR TITLE
Added MANA_FILE_REGEX env var.

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
@@ -60,6 +60,7 @@ USER_DEFINED_WRAPPER(int, Init, (int *) argc, (char ***) argv) {
     fprintf(stderr, collective_p2p_string);
   }
   DMTCP_PLUGIN_DISABLE_CKPT();
+  recordPreMpiInitMaps();
   g_mana_header.init_flag = MPI_INIT_NO_THREAD;
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Init)(argc, argv);
@@ -69,6 +70,7 @@ USER_DEFINED_WRAPPER(int, Init, (int *) argc, (char ***) argv) {
   g_world_comm = ADD_NEW_COMM(g_world_comm);
   LOG_CALL(restoreComms, Comm_dup, MPI_COMM_WORLD, g_world_comm);
   initialize_drain_send_recv();
+  recordPostMpiInitMaps();
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -79,6 +81,7 @@ USER_DEFINED_WRAPPER(int, Init_thread, (int *) argc, (char ***) argv,
     fprintf(stderr, collective_p2p_string);
   }
   DMTCP_PLUGIN_DISABLE_CKPT();
+  recordPreMpiInitMaps();
   g_mana_header.init_flag = required;
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Init_thread)(argc, argv, required, provided);
@@ -88,6 +91,7 @@ USER_DEFINED_WRAPPER(int, Init_thread, (int *) argc, (char ***) argv,
   g_world_comm = ADD_NEW_COMM(g_world_comm);
   LOG_CALL(restoreComms, Comm_dup, MPI_COMM_WORLD, g_world_comm);
   initialize_drain_send_recv();
+  recordPostMpiInitMaps();
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }

--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -733,6 +733,9 @@ mpi_plugin_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
       }
       g_file_flags_map = new map<string, int>();
 
+      // TODO(kapil): Remove from final commit.
+      setenv(MANA_FILE_REGEX_ENV, ".*", 1);
+
       if (file_regex == NULL && getenv(MANA_FILE_REGEX_ENV) != NULL) {
         file_regex = new std::regex(getenv(MANA_FILE_REGEX_ENV));
       }

--- a/mpi-proxy-split/mpi_plugin.h
+++ b/mpi-proxy-split/mpi_plugin.h
@@ -52,6 +52,8 @@ extern int g_numMmaps;
 extern MmapInfo_t *g_list;
 
 bool isUsingCollectiveToP2p();
+void recordPreMpiInitMaps();
+void recordPostMpiInitMaps();
 
 enum mana_state_t {
   UNKNOWN_STATE,


### PR DESCRIPTION
MANA plugin will use this regex to open files in O_APPEND|O_WRONLY mode at ckpt so that they can be properly truncated on restart.