### PR TITLE
Remove MPICH_SINGLE_COPY_OFF to enable xpmem

### DIFF
--- a/bin/mana_launch
+++ b/bin/mana_launch
@@ -170,7 +170,6 @@ fi
 #         (We could create xpmam plugin for DMTCP, but it shouldn't be needed.)
 
 env LD_LIBRARY_PATH="$libdir:$LD_LIBRARY_PATH" \
-    MPICH_SMP_SINGLE_COPY_OFF=1 \
     $dir/dmtcp_launch --coord-host $submissionHost \
           --coord-port $submissionPort --no-gzip \
           --join-coordinator --disable-dl-plugin \


### PR DESCRIPTION
MPICH_SINGLE_COPY_OFF was set to disable xpmem. Older versions of MANA can not tag xpmem regions in the memory correctly so we need to disable it to correctly checkpoint/restart. But disabling xpmem will slow down communications of large data sets. Now MANA is able to handle xpmem so we can remove this environment variable.