### PR TITLE
Check if a probed msg has a matched pending Irecv

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -92,14 +92,14 @@ USER_DEFINED_WRAPPER(int, Test, (MPI_Request*) request,
   // FIXME: This if statement should be merged into
   // clearPendingRequestFromLog()
   if (*flag && *request != MPI_REQUEST_NULL
-      && g_async_calls.find(*request) != g_async_calls.end()
-      && g_async_calls[*request]->type == IRECV_REQUEST) {
+      && g_nonblocking_calls.find(*request) != g_nonblocking_calls.end()
+      && g_nonblocking_calls[*request]->type == IRECV_REQUEST) {
     int count = 0;
     int size = 0;
     MPI_Get_count(statusPtr, MPI_BYTE, &count);
     MPI_Type_size(MPI_BYTE, &size);
     JASSERT(size == 1)(size);
-    MPI_Comm comm = g_async_calls[*request]->comm;
+    MPI_Comm comm = g_nonblocking_calls[*request]->comm;
     int worldRank = localRankToGlobalRank(statusPtr->MPI_SOURCE, comm);
     g_recvBytesByRank[worldRank] += count * size;
     // For debugging
@@ -270,14 +270,14 @@ USER_DEFINED_WRAPPER(int, Waitany, (int) count,
       if (flag) {
         MPI_Request *request = &local_array_of_requests[i];
         if (*request != MPI_REQUEST_NULL
-          && g_async_calls.find(*request) != g_async_calls.end()
-          && g_async_calls[*request]->type == IRECV_REQUEST) {
+          && g_nonblocking_calls.find(*request) != g_nonblocking_calls.end()
+          && g_nonblocking_calls[*request]->type == IRECV_REQUEST) {
             int count = 0;
             int size = 0;
             MPI_Get_count(local_status, MPI_BYTE, &count);
             MPI_Type_size(MPI_BYTE, &size);
             JASSERT(size == 1)(size);
-            MPI_Comm comm = g_async_calls[*request]->comm;
+            MPI_Comm comm = g_nonblocking_calls[*request]->comm;
             int worldRank = localRankToGlobalRank(local_status->MPI_SOURCE, comm);
             g_recvBytesByRank[worldRank] += count * size;
         }
@@ -330,14 +330,14 @@ USER_DEFINED_WRAPPER(int, Wait, (MPI_Request*) request, (MPI_Status*) status)
     // FIXME: This if statement should be merged into
     // clearPendingRequestFromLog()
     if (flag && *request != MPI_REQUEST_NULL
-        && g_async_calls.find(*request) != g_async_calls.end()
-        && g_async_calls[*request]->type == IRECV_REQUEST) {
+        && g_nonblocking_calls.find(*request) != g_nonblocking_calls.end()
+        && g_nonblocking_calls[*request]->type == IRECV_REQUEST) {
       int count = 0;
       int size = 0;
       MPI_Get_count(statusPtr, MPI_BYTE, &count);
       MPI_Type_size(MPI_BYTE, &size);
       JASSERT(size == 1)(size);
-      MPI_Comm comm = g_async_calls[*request]->comm;
+      MPI_Comm comm = g_nonblocking_calls[*request]->comm;
       int worldRank = localRankToGlobalRank(statusPtr->MPI_SOURCE, comm);
       g_recvBytesByRank[worldRank] += count * size;
     // For debugging
@@ -350,7 +350,7 @@ USER_DEFINED_WRAPPER(int, Wait, (MPI_Request*) request, (MPI_Status*) status)
       if (flag) LOG_POST_Wait(request, statusPtr);
     }
     if (flag && MPI_LOGGING()) {
-      clearPendingRequestFromLog(*request); // Remove from g_async_calls
+      clearPendingRequestFromLog(*request); // Remove from g_nonblocking_calls
       REMOVE_OLD_REQUEST(*request); // Remove from virtual id
       LOG_REMOVE_REQUEST(*request); // Remove from record-replay log
       *request = MPI_REQUEST_NULL;

--- a/mpi-proxy-split/p2p_drain_send_recv.h
+++ b/mpi-proxy-split/p2p_drain_send_recv.h
@@ -37,7 +37,7 @@ extern dmtcp::vector<mpi_message_t*> g_message_queue;
 void initialize_drain_send_recv();
 void registerLocalSendsAndRecvs();
 void drainSendRecv();
-int recvFromAllComms(int source);
+int drainRemainingP2pMsgs(int source);
 int recvMsgIntoInternalBuffer(MPI_Status status);
 bool isBufferedPacket(int source, int tag, MPI_Comm comm, int *flag,
                       MPI_Status *status);

--- a/mpi-proxy-split/p2p_log_replay.h
+++ b/mpi-proxy-split/p2p_log_replay.h
@@ -43,8 +43,8 @@ typedef enum __mpi_req
   IBARRIER_REQUEST,
 } mpi_req_t;
 
-// Struct to store the metadata of an async MPI send/recv call
-typedef struct __mpi_async_call
+// Struct to store the metadata of an nonblocking MPI send/recv call
+typedef struct __mpi_nonblocking_call
 {
   // control data
   mpi_req_t type;  // See enum __mpi_req
@@ -56,7 +56,7 @@ typedef struct __mpi_async_call
   MPI_Comm comm;    // MPI communicator
   int remote_node;  // Can be dest or source depending on the call type
   int tag;          // MPI message tag
-} mpi_async_call_t;
+} mpi_nonblocking_call_t;
 
 // Struct to store and return the MPI message (data) during draining and
 // resuming, also used by p2p_drain_send_recv.h
@@ -95,8 +95,8 @@ extern void updateCkptDirByRank();
 // MPI_Isend and MPI_Irecv requests post restart
 extern void replayMpiP2pOnRestart();
 
-// Saves the async send/recv call of the given type and params to a global map
-// indexed by the MPI_Request 'req'
+// Saves the nonblocking send/recv call of the given type and params to a global
+// map indexed by the MPI_Request 'req'
 extern void addPendingRequestToLog(mpi_req_t , const void* , void* , int ,
                                    MPI_Datatype , int , int ,
                                    MPI_Comm, MPI_Request);
@@ -110,5 +110,5 @@ extern void logRequestInfo(MPI_Request request, mpi_req_t req_type);
 // Lookup a request's info in the request_log
 extern request_info_t* lookupRequestInfo(MPI_Request request);
 
-extern dmtcp::map<MPI_Request, mpi_async_call_t*> g_async_calls;
+extern dmtcp::map<MPI_Request, mpi_nonblocking_call_t*> g_nonblocking_calls;
 #endif // ifndef _P2P_LOG_REPLAY_H


### PR DESCRIPTION
This PR fixes the bit-for-bit bug. While draining p2p messages at checkpoint time, it's possible that MPI_Iprobe detects a message for a pending MPI_Irecv. As a result, the message will be received by an additional MPI_Irecv and put into an internal buffer, which will be used after restart/resume.  In other words, MPI_Iprobe overtakes the message and changes the order of messages that should be drained. This behavior breaks the standard that "Nonblocking communication operations are ordered according to the execution order of the calls that initiate the communication. "

This bug can happen when the network is busy, or messages are too large so that the progress engine doesn't share meta data of messages with the receivers. Pending MPI_Irecv's are not aware of the incoming messages. MPICH's MPI_Iprobe implementation will kick the progress engine if there are no incoming messages and rechecks the message queue. The change of progress and the recheck makes the inserted MPI_Iprobe by MANA can detect metadata before MPI_Irecv. 

In this PR, messages detected by MPI_Iprobe will be compared with pending MPI_Irecvs' envelopes. If there's a matching MPI_Irecv, MANA will call MPI_Wait on the corresponding request to force the pending MPI_Irecv to claim the message and complete the communication. This change enforces the order of messages defined in the MPI standard.