### PR TITLE
Modify drainSendRecv() for easy debugging

### DIFF
--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -704,7 +704,7 @@ computeUnionOfCkptImageAddresses()
         minAddrBeyondHeap = area.addr;
       }
 
-      if (strcmp(area.name, "[vsyscall]") != NULL) {
+      if (strcmp(area.name, "[vsyscall]") != 0) {
         maxAddrBeyondHeap = area.endAddr;
       }
     }


### PR DESCRIPTION
This PR should _not_ be pushed in.  It's here only to make debugging easy.  By making this a PR, it's easy to find, and the Jenkins test will help get rid of minor bugs in the code.

See the generous comments in `drainSendRecv()` for an explanation of why this makes debugging easy.  In summary:
*  STAGE 1:  Test and complete requests, only.
*  STAGE 2:  If all requests that can be completed have been completed, it should now be safe to drain messages to the MANA internal buffer.