### PR TITLE
MANA fails to build on Perlmutter fix

### DIFF
--- a/mpi-proxy-split/lower-half/static_libs.txt
+++ b/mpi-proxy-split/lower-half/static_libs.txt
@@ -1,1 +1,1 @@
--lpmi -lpmi2 /opt/cray/libfabric/1.15.2.0/lib64/libfabric.a -lcxi -L/global/homes/z/zz217/local/lib -ljson-c  -lcurl  -lssl -lcrypto -lz -latomic -lpthread /opt/cray/pe/pals/default/lib/libpals.a
+-lpmi -lpmi2 /opt/cray/libfabric/1.15.2.0/lib64/libfabric.a -lcxi -L/global/homes/z/zz217/local/lib -ljson-c  -lcurl  -lssl -lcrypto -lz -latomic -lpthread /opt/cray/pe/pals/1.2.4/lib/libpals.a


### PR DESCRIPTION
MANA fails to build on Perlmutter on main,

To reproduce the issue, follow steps:
```
module unload darshan Nsight-Compute Nsight-Systems cudatoolkit craype-accel-nvidia80 gpu
module load cray-pmi

git submodule update --init
./configure
make -j install
```


or instead of running make, 
`cd mpi-proxy-split/lower-half/`
run 
```
cc -static -Wl,--wrap -Wl,__munmap -Wl,--wrap -Wl,shmat -Wl,--wrap -Wl,shmget -o lh_proxy_da -Wl,-start-group \
            lh_proxy.o libproxy.a gethostbyname-static/gethostbyname_static.o -lmpich `cat static_libs.txt` -Wl,--end-group; \
```
error message:

```

if cc -v 2>&1 | grep -q 'MPICH version'; then \
  rm -f tmp.sh; \
  cc -show -static -Wl,--wrap -Wl,__munmap -Wl,--wrap -Wl,shmat -Wl,--wrap -Wl,shmget -o lh_proxy_da -Wl,-start-group \
    lh_proxy.o libproxy.a gethostbyname-static/gethostbyname_static.o -lmpich -lrt -lpthread -lc -Wl,-end-group | \
    sed -e 's^-lunwind ^ ^'> tmp.sh; \
  sh tmp.sh; \
  rm -f tmp.sh; \
elif true; then \
  cc -static -Wl,--wrap -Wl,__munmap -Wl,--wrap -Wl,shmat -Wl,--wrap -Wl,shmget -o lh_proxy_da -Wl,-start-group \
            lh_proxy.o libproxy.a gethostbyname-static/gethostbyname_static.o -lmpich `cat static_libs.txt` -Wl,--end-group; \
else \
  cc -static -Wl,--wrap -Wl,__munmap -Wl,--wrap -Wl,shmat -Wl,--wrap -Wl,shmget -o lh_proxy_da -Wl,-start-group \
  lh_proxy.o libproxy.a gethostbyname-static/gethostbyname_static.o -lmpich -lrt -lpthread -lc -ldl -Wl,-end-group; \
fi
/usr/bin/ld: libproxy.a(libproxy.o): in function `getVdsoPointerInLinkMap':
/global/cfs/cdirs/cr/jiamingz/git/mana/mpi-proxy-split/lower-half/libproxy.c:233: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: libproxy.a(libproxy.o): in function `getVdsoPointerInLinkMap':
/global/cfs/cdirs/cr/jiamingz/git/mana/mpi-proxy-split/lower-half/libproxy.c:233: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /global/homes/z/zz217/local/lib/libcurl.a(libcurl_la-netrc.o): in function `Curl_parsenetrc':
netrc.c:(.text+0x5ec): warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /global/homes/z/zz217/local/lib/libcurl.a(libcurl_la-netrc.o): in function `Curl_parsenetrc':
netrc.c:(.text+0x5ec): warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /usr/bin/ld: gethostbyname-static/gethostbyname_static.o: in function `gethostbyname2_r':
gethostbyname-static/gethostbyname_static.o/global/cfs/cdirs/cr/jiamingz/git/mana/mpi-proxy-split/lower-half/gethostbyname-static/gethostbyname_static.c:: in function `154gethostbyname2_r: ':
warning: /global/cfs/cdirs/cr/jiamingz/git/mana/mpi-proxy-split/lower-half/gethostbyname-static/gethostbyname_static.c:Using 'gethostbyname_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking154
: warning: Using 'gethostbyname_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: warning: lib_libmpi_gnu_91_la-cray_memcpy_rome.o: missing .note.GNU-stack section implies executable stack
/usr/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
/usr/bin/ld: warning: lib_libmpi_gnu_91_la-cray_memcpy_rome.o: missing .note.GNU-stack section implies executable stack
/usr/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `spawn_pack':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1050: undefined reference to `json_array'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1064: undefined reference to `json_string'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1064: undefined reference to `json_array_insert_new'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1070: undefined reference to `json_pack_ex'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1078: undefined reference to `json_array_append_new'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `json_decref':
/usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `pals_app_spawn':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1260: undefined reference to `json_array_size'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1265: undefined reference to `json_array_get'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1266: undefined reference to `json_integer_value'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1265: undefined reference to `json_array_size'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `json_decref':
/usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `spawn_pack':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1090: undefined reference to `json_pack_ex'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `pipe_send':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1119: undefined reference to `json_dumps'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `json_decref':
/usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `pals_app_spawn':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1245: undefined reference to `json_unpack_ex'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1252: undefined reference to `json_unpack_ex'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `pipe_recv':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1188: undefined reference to `json_loads'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-string_array.o): in function `json_decref':
/usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-string_array.o): in function `json_dumps_safe':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:83: undefined reference to `json_dumps'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-string_array.o): in function `int_array_to_json':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:101: undefined reference to `json_array'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:106: undefined reference to `json_integer'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:106: undefined reference to `json_array_append_new'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-string_array.o): in function `json_int_array_convert':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:128: undefined reference to `json_array_size'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:133: undefined reference to `json_array_get'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:139: undefined reference to `json_integer_value'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:133: undefined reference to `json_array_size'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-string_array.o): in function `string_array_to_json':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:158: undefined reference to `json_array'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:163: undefined reference to `json_string'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:163: undefined reference to `json_array_append_new'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `spawn_pack':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1050: undefined reference to `json_array'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1064: undefined reference to `json_string'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1064: undefined reference to `json_array_insert_new'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1070: undefined reference to `json_pack_ex'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1078: undefined reference to `json_array_append_new'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `json_decref':
/usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `pals_app_spawn':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1260: undefined reference to `json_array_size'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1265: undefined reference to `json_array_get'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1266: undefined reference to `json_integer_value'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1265: undefined reference to `json_array_size'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `json_decref':
/usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `spawn_pack':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1090: undefined reference to `json_pack_ex'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `pipe_send':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1119: undefined reference to `json_dumps'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `json_decref':
/usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `pals_app_spawn':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1245: undefined reference to `json_unpack_ex'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1252: undefined reference to `json_unpack_ex'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-libpals.o): in function `pipe_recv':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/libpals/libpals.c:1188: undefined reference to `json_loads'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-string_array.o): in function `json_decref':
/usr/include/jansson.h:112: undefined reference to `json_delete'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-string_array.o): in function `json_dumps_safe':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:83: undefined reference to `json_dumps'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-string_array.o): in function `int_array_to_json':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:101: undefined reference to `json_array'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:106: undefined reference to `json_integer'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:106: undefined reference to `json_array_append_new'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-string_array.o): in function `json_int_array_convert':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:128: undefined reference to `json_array_size'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:133: undefined reference to `json_array_get'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:139: undefined reference to `json_integer_value'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:133: undefined reference to `json_array_size'
/usr/bin/ld: /opt/cray/pe/pals/default/lib/libpals.a(libpals_la-string_array.o): in function `string_array_to_json':
/home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:158: undefined reference to `json_array'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:163: undefined reference to `json_string'
/usr/bin/ld: /home/jenkins/rpmbuild/BUILD/cray-pals-1.2.9-20230120142255.19f340a/src/shared/string_array.c:163: undefined reference to `json_array_append_new'
collect2: error: ld returned 1 exit status
make[3]: *** [Makefile:75: lh_proxy] Error 1
make[3]: *** Waiting for unfinished jobs....
collect2: error: ld returned 1 exit status
make[3]: *** [Makefile:91: lh_proxy_da] Error 1
make[3]: Leaving directory '/global/cfs/cdirs/cr/jiamingz/git/mana/mpi-proxy-split/lower-half'
make[2]: *** [Makefile:106: ../bin/lh_proxy] Error 2
make[2]: Leaving directory '/global/cfs/cdirs/cr/jiamingz/git/mana/mpi-proxy-split'
make[1]: *** [Makefile:120: install] Error 2
make[1]: Leaving directory '/global/cfs/cdirs/cr/jiamingz/git/mana/mpi-proxy-split'
make: *** [Makefile:49: mana] Error 2
```