### PR TITLE
fix static lib link issue on perlmutter

### DIFF
--- a/mpi-proxy-split/lower-half/static_libs.txt
+++ b/mpi-proxy-split/lower-half/static_libs.txt
@@ -1,1 +1,1 @@
--lpmi -lpmi2 /opt/cray/libfabric/1.15.2.0/lib64/libfabric.a -lcxi -L/global/homes/z/zz217/local/lib -ljson-c  -lcurl  -lssl -lcrypto -lz -latomic -lpthread /opt/cray/pe/pals/1.2.4/lib/libpals.a
+-lpmi -lpmi2 /opt/cray/libfabric/1.15.2.0/lib64/libfabric.a -lcxi -L/global/homes/z/zz217/local/lib -L/global/cfs/cdirs/cr/pm_dependencies -ljson-c -lcurl  -lssl -lcrypto -lz -latomic -lpthread /opt/cray/pe/pals/1.2.4/lib/libpals.a


### PR DESCRIPTION
This pull request is to resolve the build failure error for MANA on Perlmutter.
Now MANA can be built successfully on Perlmutter and Cori from my end.
Please verify this fix can resolve the issue on other's node as well.