### PR TITLE
Add FORTRAN_MPI_IN_PLACE to other collective calls

### DIFF
--- a/mpi-proxy-split/lower-half/gethostbyname-static/gethostbyname_static.c
+++ b/mpi-proxy-split/lower-half/gethostbyname-static/gethostbyname_static.c
@@ -1,11 +1,11 @@
 /* Copyright 2021 Gene Cooperman (gene@ccs.neu.edu)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -226,7 +226,7 @@ int main(int argc, char *argv[]) {
   if (argc == 2) {
     gethostbyname_r(argv[1], &ret, buf, sizeof(buf), &result, &h_errnop);
     printf("First and second alias: %s %s\n",
-           ret.h_aliases[0], ret.h_aliases[1]); 
+           ret.h_aliases[0], ret.h_aliases[1]);
     printf("First address: %u.%u.%u.%u\n",
            BYTE(0), BYTE(1), BYTE(2), BYTE(3));
   } else if (argc == 3) {

--- a/mpi-proxy-split/lower-half/lower_half_api.h
+++ b/mpi-proxy-split/lower-half/lower_half_api.h
@@ -45,7 +45,7 @@
 #endif // ifdef MAIN_AUXVEC_ARG
 
 #define ROUND_UP(addr)  \
-    ((unsigned long)(addr + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1))
+    (((unsigned long)addr + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1))
 
 #define ROUND_DOWN(addr) ((unsigned long)addr & ~(PAGE_SIZE - 1))
 

--- a/mpi-proxy-split/mpi-wrappers/Makefile
+++ b/mpi-proxy-split/mpi-wrappers/Makefile
@@ -71,8 +71,8 @@ mpi_p2p_wrappers.o: mpi_p2p_wrappers.cpp p2p-deterministic.h
 mpi_request_wrappers.o: mpi_request_wrappers.cpp p2p-deterministic.h
 	${MPICXX} ${CXXFLAGS} -c -o $@ $<
 
-# FIXME:  This assumes that the 'CFLAGS' are compatible with the FORTRAN.
-#         But MANA does not define 'FFLAGS'.
+# FIXME:  This assumes 'CFLAGS' is compatible with FORTRAN, since MANA does not
+#         define 'FFLAGS'.  But Fortran doesn't use '-std=gnu11' from CFLAGS.
 fortran_constants.o: fortran_constants.f90
 	${MPIFORTRAN} ${CFLAGS} -fPIC -c -o $@ $<
 

--- a/mpi-proxy-split/mpi-wrappers/fortran_constants.f90
+++ b/mpi-proxy-split/mpi-wrappers/fortran_constants.f90
@@ -9,8 +9,8 @@
 !         them at C level.
 ! For example, note that the MPI_Allreduce wrapper contains:
 !   if (sendbuf == FORTRAN_MPI_IN_PLACE) {
-!     retval = NEXT_FUNC(Allreduce)(MPI_IN_PLACE, recvbuf, count,
-!                                   realType, realOp, realComm);
+!     sendbuf = MPI_IN_PLACE;
+!   }
 ! MPI 3.1 standard:
 !   The constants that cannot be used in initialization expressions or
 !   assignments in Fortran are as follows:

--- a/mpi-proxy-split/mpi-wrappers/get_fortran_constants.c
+++ b/mpi-proxy-split/mpi-wrappers/get_fortran_constants.c
@@ -1,6 +1,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+// FIXME:
+//     We should test for the presence of mpifort (MPI/Fortran support).
+//     Then, if mpifort is not supported, we define get_fortran_constants()
+//     to set FORTRAN_MPI_XXX to XXX inside get_fortran_constants().
+//     Alternatively, initialize FORTRAN_MPI_XXX to XXX.  Then, this is safe
+//     to use in the collective calls.
+//       if (sendbuf == FORTRAN_MPI_XXX) { sendbuf = XXX; }
+
 // In C, we call get_fortran_constants(), which eventually calls
 // get_fortran_constants_helper(FORTRAN_CONSTANT) which calls
 //  get_fortran_constants_helper-(int *t) in this file, which allows

--- a/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
+++ b/mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs.c
@@ -99,7 +99,7 @@ int show_msg_file(char *name)
   int fd_log = open(name, O_RDWR);
   if (fd_log == -1) {
     fprintf(stderr, "show_log_file open: fle %s, error: %s\n", name, strerror(errno));
-    return 1; 
+    return 1;
   }
 
   while (1) {
@@ -143,7 +143,7 @@ int show_request_file(char *name)
   }
   return 0;
 }
- 
+
 int show_log(char *name)
 {
   int rank;

--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
@@ -115,7 +115,7 @@ int MPI_Gather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                int root, MPI_Comm comm) {
   PROLOG_Comm_rank_size;
   int i;
-  int inplace = (sendbuf == MPI_IN_PLACE || FORTRAN_MPI_IN_PLACE);
+  int inplace = (sendbuf == MPI_IN_PLACE || sendbuf == FORTRAN_MPI_IN_PLACE);
   if (rank != root) {
     MPI_Send(sendbuf, sendcount, sendtype, root, 0, comm);
   } else { // else: rank == root
@@ -146,7 +146,7 @@ int MPI_Gatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                 MPI_Datatype recvtype, int root, MPI_Comm comm) {
   PROLOG_Comm_rank_size;
   int i;
-  int inplace = (sendbuf == MPI_IN_PLACE || FORTRAN_MPI_IN_PLACE);
+  int inplace = (sendbuf == MPI_IN_PLACE || sendbuf == FORTRAN_MPI_IN_PLACE);
   if (rank != root) {
     for (i = 0; i < size; i++) {
       if (i != root) {
@@ -182,7 +182,7 @@ int MPI_Scatter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                 int root, MPI_Comm comm) {
   PROLOG_Comm_rank_size;
   int i;
-  int inplace = (sendbuf == MPI_IN_PLACE || FORTRAN_MPI_IN_PLACE);
+  int inplace = (recvbuf == MPI_IN_PLACE || recvbuf == FORTRAN_MPI_IN_PLACE);
   if (inplace) { // if true, MPI says to ignore recvcount/recvtype
     recvcount = sendcount;
     recvtype = sendtype;
@@ -224,7 +224,7 @@ int MPI_Scatterv(const void* sendbuf, const int sendcounts[],
                  int root, MPI_Comm comm) {
   PROLOG_Comm_rank_size;
   int i;
-  int inplace = (sendbuf == MPI_IN_PLACE || FORTRAN_MPI_IN_PLACE);
+  int inplace = (recvbuf == MPI_IN_PLACE || recvbuf == FORTRAN_MPI_IN_PLACE);
   if (rank == root) {
     MPI_Aint lower_bound;
     MPI_Aint sendextent;
@@ -257,6 +257,7 @@ int MPI_Allgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                   MPI_Comm comm) {
   PROLOG_Comm_rank_size;
   int root;
+  // sendbuf can propagate MPI_IN_PLACE and FORTRAN_MPI_IN_PLACE
   for (root = 0; root < size; root++) {
     MPI_Gather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
                root, comm);
@@ -282,7 +283,7 @@ int MPI_Alltoall(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                  MPI_Comm comm) {
   PROLOG_Comm_rank_size;
   int i;
-  int inplace = (sendbuf == MPI_IN_PLACE || FORTRAN_MPI_IN_PLACE);
+  int inplace = (sendbuf == MPI_IN_PLACE || sendbuf == FORTRAN_MPI_IN_PLACE);
   if (inplace) { // if true, MPI says to ignore recvcount/recvtype
     recvcount = sendcount;
     recvtype = sendtype;
@@ -335,7 +336,7 @@ int MPI_Alltoallv(const void* sendbuf, const int sendcounts[],
 
   PROLOG_Comm_rank_size;
   int i;
-  int inplace = (sendbuf == MPI_IN_PLACE || FORTRAN_MPI_IN_PLACE);
+  int inplace = (sendbuf == MPI_IN_PLACE || sendbuf == FORTRAN_MPI_IN_PLACE);
   if (inplace) { // if true, MPI says to ignore recvcount/recvtype
     recvcounts = sendcounts;
     recvtype = sendtype;
@@ -425,7 +426,7 @@ int MPI_Reduce(const void* sendbuf, void* recvbuf, int count,
   MPI_Aint lower_bound;
   MPI_Aint extent;
   MPI_Type_get_extent(datatype, &lower_bound, &extent);
-  int inplace = (sendbuf == MPI_IN_PLACE || FORTRAN_MPI_IN_PLACE);
+  int inplace = (sendbuf == MPI_IN_PLACE || sendbuf == FORTRAN_MPI_IN_PLACE);
   if (inplace && rank == root) {
     sendbuf = recvbuf;
   }
@@ -457,6 +458,7 @@ int MPI_Reduce(const void* sendbuf, void* recvbuf, int count,
 
 int MPI_Allreduce(const void* sendbuf, void* recvbuf, int count,
                   MPI_Datatype datatype, MPI_Op op, MPI_Comm comm) {
+  // sendbuf can propagate MPI_IN_PLACE and FORTRAN_MPI_IN_PLACE
   MPI_Reduce(sendbuf, recvbuf, count, datatype, op, 0 /* root */, comm);
   MPI_Bcast(recvbuf, count, datatype, 0 /* root */, comm);
   return MPI_SUCCESS;
@@ -494,7 +496,7 @@ int MPI_Scan(const void* sendbuf, void* recvbuf, int count,
   int retval;
 
   // Deal with buffers in place
-  int inplace = (sendbuf == MPI_IN_PLACE || FORTRAN_MPI_IN_PLACE);
+  int inplace = (sendbuf == MPI_IN_PLACE || sendbuf == FORTRAN_MPI_IN_PLACE);
   if (inplace) {
     sendbuf = recvbuf;
   }

--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -183,16 +183,13 @@ USER_DEFINED_WRAPPER(int, Allreduce,
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
   MPI_Op realOp = VIRTUAL_TO_REAL_OP(op);
-  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
-  // FIXME: Ideally, we should only check FORTRAN_MPI_IN_PLACE
-  //        in the Fortran wrapper.
+  // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
   if (sendbuf == FORTRAN_MPI_IN_PLACE) {
-    retval = NEXT_FUNC(Allreduce)(MPI_IN_PLACE, recvbuf, count,
-        realType, realOp, realComm);
-  } else {
-    retval = NEXT_FUNC(Allreduce)(sendbuf, recvbuf, count,
-        realType, realOp, realComm);
+    sendbuf = MPI_IN_PLACE;
   }
+  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
+  retval = NEXT_FUNC(Allreduce)(sendbuf, recvbuf, count,
+      realType, realOp, realComm);
   RETURN_TO_UPPER_HALF();
   DMTCP_PLUGIN_ENABLE_CKPT();
   commit_finish(comm, passthrough);
@@ -211,6 +208,10 @@ USER_DEFINED_WRAPPER(int, Reduce,
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
   MPI_Op realOp = VIRTUAL_TO_REAL_OP(op);
+  // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
+  if (sendbuf == FORTRAN_MPI_IN_PLACE) {
+    sendbuf = MPI_IN_PLACE;
+  }
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Reduce)(sendbuf, recvbuf, count,
                              realType, realOp, root, realComm);
@@ -259,6 +260,10 @@ USER_DEFINED_WRAPPER(int, Reduce_scatter,
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
   MPI_Op realOp = VIRTUAL_TO_REAL_OP(op);
+  // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
+  if (sendbuf == FORTRAN_MPI_IN_PLACE) {
+    sendbuf = MPI_IN_PLACE;
+  }
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Reduce_scatter)(sendbuf, recvbuf, recvcounts,
                                      realType, realOp, realComm);
@@ -286,6 +291,10 @@ MPI_Alltoall_internal(const void *sendbuf, int sendcount,
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   MPI_Datatype realSendType = VIRTUAL_TO_REAL_TYPE(sendtype);
   MPI_Datatype realRecvType = VIRTUAL_TO_REAL_TYPE(recvtype);
+  // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
+  if (sendbuf == FORTRAN_MPI_IN_PLACE) {
+    sendbuf = MPI_IN_PLACE;
+  }
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Alltoall)(sendbuf, sendcount, realSendType, recvbuf,
       recvcount, realRecvType, realComm);
@@ -303,6 +312,7 @@ USER_DEFINED_WRAPPER(int, Alltoall,
   bool passthrough = false;
   commit_begin(comm, passthrough);
   int retval;
+  // sendbuf can propagate MPI_IN_PLACE and FORTRAN_MPI_IN_PLACE
   retval = MPI_Alltoall_internal(sendbuf, sendcount, sendtype,
                                  recvbuf, recvcount, recvtype, comm);
   commit_finish(comm, passthrough);
@@ -319,6 +329,10 @@ USER_DEFINED_WRAPPER(int, Alltoallv,
   bool passthrough = false;
   commit_begin(comm, passthrough);
   int retval;
+  // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
+  if (sendbuf == FORTRAN_MPI_IN_PLACE) {
+    sendbuf = MPI_IN_PLACE;
+  }
   DMTCP_PLUGIN_DISABLE_CKPT();
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   MPI_Datatype realSendType = VIRTUAL_TO_REAL_TYPE(sendtype);
@@ -340,10 +354,18 @@ USER_DEFINED_WRAPPER(int, Gather, (const void *) sendbuf, (int) sendcount,
   bool passthrough = true;
   commit_begin(comm, passthrough);
   int retval;
+  // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
+  if (sendbuf == FORTRAN_MPI_IN_PLACE) {
+    sendbuf = MPI_IN_PLACE;
+  }
   DMTCP_PLUGIN_DISABLE_CKPT();
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   MPI_Datatype realSendType = VIRTUAL_TO_REAL_TYPE(sendtype);
   MPI_Datatype realRecvType = VIRTUAL_TO_REAL_TYPE(recvtype);
+  // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
+  if (sendbuf == FORTRAN_MPI_IN_PLACE) {
+    sendbuf = MPI_IN_PLACE;
+  }
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Gather)(sendbuf, sendcount, realSendType,
                              recvbuf, recvcount, realRecvType,
@@ -362,6 +384,10 @@ USER_DEFINED_WRAPPER(int, Gatherv, (const void *) sendbuf, (int) sendcount,
   bool passthrough = true;
   commit_begin(comm, passthrough);
   int retval;
+  // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
+  if (sendbuf == FORTRAN_MPI_IN_PLACE) {
+    sendbuf = MPI_IN_PLACE;
+  }
   DMTCP_PLUGIN_DISABLE_CKPT();
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   MPI_Datatype realSendType = VIRTUAL_TO_REAL_TYPE(sendtype);
@@ -383,6 +409,10 @@ USER_DEFINED_WRAPPER(int, Scatter, (const void *) sendbuf, (int) sendcount,
   bool passthrough = true;
   commit_begin(comm, passthrough);
   int retval;
+  // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
+  if (recvbuf == FORTRAN_MPI_IN_PLACE) {
+    recvbuf = MPI_IN_PLACE;
+  }
   DMTCP_PLUGIN_DISABLE_CKPT();
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   MPI_Datatype realSendType = VIRTUAL_TO_REAL_TYPE(sendtype);
@@ -405,6 +435,10 @@ USER_DEFINED_WRAPPER(int, Scatterv, (const void *) sendbuf,
   bool passthrough = true;
   commit_begin(comm, passthrough);
   int retval;
+  // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
+  if (recvbuf == FORTRAN_MPI_IN_PLACE) {
+    recvbuf = MPI_IN_PLACE;
+  }
   DMTCP_PLUGIN_DISABLE_CKPT();
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   MPI_Datatype realSendType = VIRTUAL_TO_REAL_TYPE(sendtype);
@@ -426,6 +460,10 @@ USER_DEFINED_WRAPPER(int, Allgather, (const void *) sendbuf, (int) sendcount,
   bool passthrough = false;
   commit_begin(comm, passthrough);
   int retval;
+  // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
+  if (sendbuf == FORTRAN_MPI_IN_PLACE) {
+    sendbuf = MPI_IN_PLACE;
+  }
   DMTCP_PLUGIN_DISABLE_CKPT();
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   MPI_Datatype realSendType = VIRTUAL_TO_REAL_TYPE(sendtype);
@@ -472,6 +510,10 @@ USER_DEFINED_WRAPPER(int, Scan, (const void *) sendbuf, (void *) recvbuf,
   DMTCP_PLUGIN_DISABLE_CKPT();
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
+  // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
+  if (sendbuf == FORTRAN_MPI_IN_PLACE) {
+    sendbuf = MPI_IN_PLACE;
+  }
   MPI_Op realOp = VIRTUAL_TO_REAL_TYPE(op);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Scan)(sendbuf, recvbuf, count,

--- a/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
@@ -80,13 +80,13 @@ struct KeyvalTuple {
 static std::vector<int> keyvalVec;
 static std::unordered_map<int, KeyvalTuple> tupleMap;
 
-// The following are prvalues, so we need an address to point them to.
+// The following are prvalues. So we need an address to point them to.
 // On Cori, this is 2^22 - 1, but it just needs to be greater than 2^15 - 1.
 static const int MAX_TAG_COUNT = 2097151;
 // We're actually supposed to check the rank of the HOST process in the group
 // associated with the MPI_COMM_WORLD communicator, but even the standard says
 // "MPI does not specify what it means for a process to be a HOST, nor does it
-// require that a HOST exists", so we just use a no HOST value.
+// require that a HOST exists". So we just use a no HOST value.
 static const int MPI_HOST_RANK = MPI_PROC_NULL;
 static const int MPI_IO_SOURCE = MPI_ANY_SOURCE;
 static const int MPI_WTIME_IS_GLOBAL_VAL = 0;

--- a/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
@@ -177,7 +177,7 @@ USER_DEFINED_WRAPPER(int, Type_create_struct, (int) count,
   return retval;
 }
 
-// Perlmutter cray_mpich both implement MPI 3.1. However, they use different 
+// Perlmutter cray_mpich both implement MPI 3.1. However, they use different
 // APIs. We use MPICH_NUMVERSION (3.4a2) to differentiate the cray-mpich on Cori
 // and Perlmuttter. This ad-hoc workaround should be removed once the cray-mpich
 // on Perlmutter is fixed to use the right API.

--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -704,7 +704,7 @@ computeUnionOfCkptImageAddresses()
         minAddrBeyondHeap = area.addr;
       }
 
-      if (strcmp(area.name, "[vsyscall]") != NULL) {
+      if (strcmp(area.name, "[vsyscall]") != 0) {
         maxAddrBeyondHeap = area.endAddr;
       }
     }

--- a/mpi-proxy-split/mtcp_split_process.c
+++ b/mpi-proxy-split/mtcp_split_process.c
@@ -23,7 +23,7 @@
 int mtcp_sys_errno;
 LowerHalfInfo_t lh_info;
 // FIXME:  The value of pdlsym must be passed from mtcp_restart to
-//         the upper half, so that NEXT_FNC() in mpi-wrappers in libmana.so in 
+//         the upper half, so that NEXT_FNC() in mpi-wrappers in libmana.so in
 //         can use the updated pdlsym in case the address of the lower half
 //         in the restarted process has changed.
 //         But the lower half is loaded at a fixed address.  So, the address of
@@ -172,7 +172,7 @@ startProxy(char *argv0, char **envp)
   // Child does execve to lh_proxy from mpi-split-process/lower-half.
   // lh_proxy executes the constructor in libproxy.c that intializes lh_info
   // and writes lh_info to the stdout, which was redirected to pipefd_in.
-  // Parent reads lh_info from child through pipefd_out. 
+  // Parent reads lh_info from child through pipefd_out.
   // Parent calls read_lh_proxy_bits, which calls procss_vm_read on child.
   // Then the parent kills the child.
   int childpid = mtcp_sys_fork();

--- a/mpi-proxy-split/p2p_drain_send_recv.cpp
+++ b/mpi-proxy-split/p2p_drain_send_recv.cpp
@@ -178,7 +178,7 @@ drainRemainingP2pMsgs()
     // if the color is specified on only one side of the intercommunicator, or
     // specified as MPI_UNDEFINED by the program. In this case, the MPI function
     // still returns MPI_SUCCESS. So the MPI_COMM_NULL can be added to the
-    // active communicator set `active_comms'. 
+    // active communicator set `active_comms'.
     if (*comm == MPI_COMM_NULL) {
       continue;
     }
@@ -243,7 +243,7 @@ allDrained()
   }
   return true;
 }
-    
+
 void
 drainSendRecv()
 {
@@ -252,7 +252,7 @@ drainSendRecv()
     while (!allDrained()) {
       // If pending MPI_Irecv or MPI_Isend, use MPI_Test to try to complete it.
       completePendingP2pRequests();
-      // If MPI_Irecv not posted but msg was sent, use MPI_Iprobe to drain msg 
+      // If MPI_Irecv not posted but msg was sent, use MPI_Iprobe to drain msg.
       drainRemainingP2pMsgs();
     }
     sleep(5);
@@ -339,7 +339,7 @@ localRankToGlobalRank(int localRank, MPI_Comm localComm)
   NEXT_FUNC(Comm_group)(MPI_COMM_WORLD, &worldGroup);
   NEXT_FUNC(Comm_group)(realComm, &localGroup);
   NEXT_FUNC(Group_translate_ranks)(localGroup, 1, &localRank,
-                                   worldGroup, &worldRank); 
+                                   worldGroup, &worldRank);
   NEXT_FUNC(Group_free)(&worldGroup);
   NEXT_FUNC(Group_free)(&localGroup);
   RETURN_TO_UPPER_HALF();

--- a/mpi-proxy-split/p2p_drain_send_recv.cpp
+++ b/mpi-proxy-split/p2p_drain_send_recv.cpp
@@ -175,9 +175,9 @@ drainRemainingP2pMsgs()
   for (comm = active_comms.begin(); comm != active_comms.end(); comm++) {
     // If the communicator is MPI_COMM_NULL, skip it.
     // MPI_COMM_NULL can be returned from functions like MPI_Comm_split
-    // if the color is specified on only one side of the inter-communicator, or
+    // if the color is specified on only one side of the intercommunicator, or
     // specified as MPI_UNDEFINED by the program. In this case, the MPI function
-    // still returns MPI_SUCCESS, so the MPI_COMM_NULL can be added to the
+    // still returns MPI_SUCCESS. So the MPI_COMM_NULL can be added to the
     // active communicator set `active_comms'. 
     if (*comm == MPI_COMM_NULL) {
       continue;

--- a/mpi-proxy-split/seq_num.cpp
+++ b/mpi-proxy-split/seq_num.cpp
@@ -45,7 +45,7 @@ sem_t ckpt_thread_sem;
 *      current_phase = STOP_BEFORE_CS;
 *
 *  Note that this situation can still occur with only a semaphore to
-*  implement the freepass, so another semaphore is required to
+*  implement the freepass. So another semaphore is required to
 *  enforce that the thread in commit_begin cannot enter the state
 *  STOP_BEFORE_CS until we verify that the thread giving the free pass
 *  has checked the thread state

--- a/mpi-proxy-split/virtual-ids.h
+++ b/mpi-proxy-split/virtual-ids.h
@@ -202,7 +202,7 @@ namespace dmtcp_mpi
 
       // Adds the given real id to the virtual id table and creates a new
       // corresponding virtual id.
-      // Returns the new virtual id on success, null id otherwise
+      // Returns the new virtual id on success, null id otherwise.
       T onCreate(T real)
       {
         T vId = _nullId;
@@ -302,7 +302,7 @@ namespace dmtcp_mpi
         MPI_Comm_size(comm, &commSize);
         int rbuf[commSize];
         // FIXME: Use MPI_Group_translate_ranks instead of Allgather.
-        // MPI_Group_translate_ranks only execute localy, so we can avoid
+        // MPI_Group_translate_ranks only executes locally. So we can avoid
         // the cost of collective communication
         // FIXME: cray cc complains "catastrophic error" that can't find
         // split-process.h

--- a/restart_plugin/mtcp_split_process.c
+++ b/restart_plugin/mtcp_split_process.c
@@ -26,7 +26,7 @@
 int mtcp_sys_errno;
 
 // FIXME:  The value of pdlsym must be passed from mtcp_restart to
-//         the upper half, so that NEXT_FNC() in mpi-wrappers in libmana.so in 
+//         the upper half, so that NEXT_FNC() in mpi-wrappers in libmana.so in
 //         can use the updated pdlsym in case the address of the lower half
 //         in the restarted process has changed.
 //         But the lower half is loaded at a fixed address.  So, the address of
@@ -179,7 +179,7 @@ startProxy(RestoreInfo *rinfo)
   // Child does execve to lh_proxy from mpi-split-process/lower-half.
   // lh_proxy executes the constructor in libproxy.c that intializes lh_info
   // and writes lh_info to the stdout, which was redirected to pipefd_in.
-  // Parent reads lh_info from child through pipefd_out. 
+  // Parent reads lh_info from child through pipefd_out.
   // Parent calls read_lh_proxy_bits, which calls procss_vm_read on child.
   // Then the parent kills the child.
   int childpid = mtcp_sys_fork();


### PR DESCRIPTION
It was missing from all except MPI_Allreduce.
This also fixes a bad bug in mpi_collective_p2p.c that was added in commit 377eaf62 .

I also added three separate, minor commits to:
 * Fix a minor compiler warning
 * Fix minor English grammar errors
 * Remove spaces at end of line