### PR TITLE
Fixed MPI_Waitany: request completed during ckpt

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -254,10 +254,20 @@ USER_DEFINED_WRAPPER(int, Waitany, (int) count,
   int flag = 0;
   bool all_null = true;
   *local_index = MPI_UNDEFINED;
+  int *is_null = (int*) malloc(sizeof(int) * count);
+  for (int i = 0; i < count; i++) {
+    is_null[i] = local_array_of_requests[i] == MPI_REQUEST_NULL ? 1 : 0;
+  }
   while (1) {
     for (int i = 0; i < count; i++) {
       if (local_array_of_requests[i] == MPI_REQUEST_NULL) {
-        continue;
+        if (is_null[i]) {
+          continue;
+        } else {
+          *local_index = i;
+          free(is_null);
+          return retval;
+        }
       }
       all_null = false;
       DMTCP_PLUGIN_DISABLE_CKPT();
@@ -265,6 +275,7 @@ USER_DEFINED_WRAPPER(int, Waitany, (int) count,
                                  local_status, false);
       if (retval != MPI_SUCCESS) {
         DMTCP_PLUGIN_ENABLE_CKPT();
+        free(is_null);
         return retval;
       }
       if (flag) {
@@ -280,6 +291,12 @@ USER_DEFINED_WRAPPER(int, Waitany, (int) count,
             MPI_Comm comm = g_nonblocking_calls[*request]->comm;
             int worldRank = localRankToGlobalRank(local_status->MPI_SOURCE, comm);
             g_recvBytesByRank[worldRank] += count * size;
+        } else if (*request == MPI_REQUEST_NULL) {
+          if (!is_null[i]) {
+            *local_index = i;
+            free(is_null);
+            return retval;
+          }
         }
 
         if (MPI_LOGGING()) {
@@ -291,12 +308,14 @@ USER_DEFINED_WRAPPER(int, Waitany, (int) count,
         *local_index = i;
 
         DMTCP_PLUGIN_ENABLE_CKPT();
+        free(is_null);
         return retval;
       }
 
       DMTCP_PLUGIN_ENABLE_CKPT();
     }
     if (all_null) {
+      free(is_null);
       return retval;
     }
   }


### PR DESCRIPTION
Fixed a bug in MPI_Waitany. Requests passed into an MPI_Waitany function call may complete during checkpoint time. For example, one of the requests is an MPI_Irecv request, and the request is completed during draining p2p messages during checkpoint time.

Before this fix, the MPI_Waitany wrapper cannot detect completion of requests during checkpoint time. So the MPI_Waitany wrapper may hang after restart. This is observed in a test case of NIMROD.