### PR TITLE
Correctness - Reproducible reduction operation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ build/
 
 mpi-proxy-split/mpi-wrappers/p2p-deterministic.h
 mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs
+
+
+bldlog_*
+manpages/mana.1.gz 

--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,4 @@ build/
 
 mpi-proxy-split/mpi-wrappers/p2p-deterministic.h
 mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs
-
-
-bldlog_*
 manpages/mana.1.gz 

--- a/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
@@ -80,9 +80,10 @@ USER_DEFINED_WRAPPER(int, Reduce_local,
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
+  MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
   MPI_Op realOp = VIRTUAL_TO_REAL_OP(op);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
-  retval = NEXT_FUNC(Reduce_local)(inbuf, inoutbuf, count, datatype, realOp);
+  retval = NEXT_FUNC(Reduce_local)(inbuf, inoutbuf, count, realType, realOp);
   RETURN_TO_UPPER_HALF();
   // This is non-blocking.  No need to log it.
   DMTCP_PLUGIN_ENABLE_CKPT();


### PR DESCRIPTION
 This version, `MPI_Allreduce_reproducible`, can be called from the `MPI_Allreduce` wrapper and returned.  If desired, it could be called selectively on certain sizes or certain types or certain op's.

 Use `MPI_Type_get_envelope` and `MPI_Type_get_contents` to discover if this is a dup of `MPI_DOUBLE`

 https://www.mcs.anl.gov/papers/P4093-0713_1.pdf
   On the Reproducibility of MPI Reduction Operations

 https://www.sciencedirect.com/science/article/pii/S0167819121000612
   An optimisation of allreduce communication in message-passing systems

 MPI standard:

> _Advice to users_
> 
> Some applications may not be able to ignore the non-associative nature of floating-point operations or may use user-defined operations (see Section 5.9.5) that require a special reduction order and cannot be treated as associative. Such applications should enforce the order of evaluation explicitly. For example, in the case of operations that require a strict left-to-right (or right-to-left) evaluation order, this could be done by gathering all operands at a single process (e.g., with MPI_GATHER), applying the reduction operation in the desired order (e.g., with MPI_REDUCE_LOCAL), and if needed, broadcast or scatter the result to the other processes (e.g., with MPI_BCAST). 
> 
> _End of advice to users_

And note that `MPI_Waitany` can receive messages non-deterministically. 


Set the `PERFORM_REPRODUCIBLE_REDUCTION_OPERATION` environment variable to enable (>0) or disable (=0) reproducible reduction operation.