### PR TITLE
Fix for running MANA on CentOS

### DIFF
--- a/mpi-proxy-split/lower-half/Makefile
+++ b/mpi-proxy-split/lower-half/Makefile
@@ -27,7 +27,7 @@ DMTCP_INCLUDE=${DMTCP_ROOT}/include
 JALIB_INCLUDE=${DMTCP_ROOT}/jalib
 PLUGIN_INCLUDE=${PLUGIN_ROOT}
 
-override CFLAGS += -fPIC -I${DMTCP_INCLUDE}
+override CFLAGS += -fPIC -I${DMTCP_INCLUDE} -g3 -O0
 override CXXFLAGS += -fPIC -I${DMTCP_INCLUDE} -I${JALIB_INCLUDE} \
                      -I${DMTCP_ROOT}/src
 
@@ -75,13 +75,13 @@ ${PROXY_BIN}: ${PROXY_OBJS} ${LIBPROXY}.a ${STATIC_GETHOSTBYNAME}
 	if ${MPICC} -v 2>&1 | grep -q 'MPICH version'; then \
 	  rm -f tmp.sh; \
 	  ${MPICC} -show ${PROXY_LD_FLAGS} ${TEXTSEG_ADDR_FLAG} -o $@ -Wl,-start-group \
-	    $^ ${MPI_LD_FLAG} -lrt -lpthread -lc -Wl,-end-group | \
+	    $^ ${MPI_LD_FLAG} -lrt -lpthread -lc -ldl -Wl,-end-group | \
 	    sed -e 's^-lunwind ^ ^'> tmp.sh; \
 	  sh tmp.sh; \
 	  rm -f tmp.sh; \
 	elif ${STATIC_LIBS}; then \
 	  ${MPICC} ${PROXY_LD_FLAGS} ${TEXTSEG_ADDR_FLAG} -o $@ -Wl,-start-group \
-            $^ ${MPI_LD_FLAG} `cat static_libs.txt` -Wl,--end-group; \
+            $^ ${MPI_LD_FLAG} `cat static_libs.txt` -ldl -Wl,--end-group; \
 	else \
 	  ${MPICC} ${PROXY_LD_FLAGS} ${TEXTSEG_ADDR_FLAG} -o $@ -Wl,-start-group \
             $^ ${MPI_LD_FLAG} -lrt -lpthread -lc -ldl -Wl,-end-group; \
@@ -91,13 +91,13 @@ ${PROXY_BIN_DEFADDR}: ${PROXY_OBJS} ${LIBPROXY}.a ${STATIC_GETHOSTBYNAME}
 	if ${MPICC} -v 2>&1 | grep -q 'MPICH version'; then \
 	  rm -f tmp.sh; \
 	  ${MPICC} -show ${PROXY_LD_FLAGS} -o $@ -Wl,-start-group \
-	    $^ ${MPI_LD_FLAG} -lrt -lpthread -lc -Wl,-end-group | \
+	    $^ ${MPI_LD_FLAG} -lrt -lpthread -lc -ldl -Wl,-end-group | \
 	    sed -e 's^-lunwind ^ ^'> tmp.sh; \
 	  sh tmp.sh; \
 	  rm -f tmp.sh; \
 	elif ${STATIC_LIBS}; then \
 	  ${MPICC} ${PROXY_LD_FLAGS} -o $@ -Wl,-start-group \
-            $^ ${MPI_LD_FLAG} `cat static_libs.txt` -Wl,--end-group; \
+            $^ ${MPI_LD_FLAG} `cat static_libs.txt` -ldl -Wl,--end-group; \
 	else \
 	  ${MPICC} ${PROXY_LD_FLAGS} -o $@ -Wl,-start-group \
 	  $^ ${MPI_LD_FLAG} -lrt -lpthread -lc -ldl -Wl,-end-group; \

--- a/mpi-proxy-split/split_process.cpp
+++ b/mpi-proxy-split/split_process.cpp
@@ -471,6 +471,11 @@ getUhVdsoLdAddr()
 void
 updateVdsoLinkmapEntry(void * l_ld_addr)
 {
+  if (l_ld_addr == NULL) {
+    // The lower-half link map did not have a link to "vdso".
+    // So, we can skip patching the lower-half link map.
+    return;
+  }
   void *uh_l_ld_vdso = getUhVdsoLdAddr();
   // now update it in the lower-half's linkmap
   *(uint64_t *)l_ld_addr = (uint64_t)uh_l_ld_vdso;

--- a/mpi-proxy-split/test/Makefile
+++ b/mpi-proxy-split/test/Makefile
@@ -25,6 +25,8 @@ DEMO_PORT=7787
 ## Reordering the tests:
 # Several tests are excluded from this Makefile because they are redundant:
 # multi_send_recv, send_recv, send_recv_many
+# Comment out FILES_FORTRAN if you don't have an mmpifort compiler.
+FILES_FORTRAN= f_ibarrier wave_mpi day1_mpi quad_mpi poisson_nonblock_mpi
 FILES=mpi_hello_world \
       hello_mpi_init_thread Sendrecv_test Gatherv_test \
       keyval_test file_test Scatterv_test Gather_test \
@@ -38,8 +40,8 @@ FILES=mpi_hello_world \
       Abort_test Allreduce_test Alltoall_test Alltoallv_test \
       Allgather_test Group_size_rank Type_commit_contiguous \
       Irecv_test Alloc_mem sendrecv_replace_test \
-      f_ibarrier Type_hvector_test Type_vector_test \
-      wave_mpi day1_mpi quad_mpi poisson_nonblock_mpi \
+      Type_hvector_test Type_vector_test \
+      ${FILES_FORTRAN} \
       send_recv_loop large_async_p2p \
 	  File_read_write_test File_characteristics_test File_size_test \
 	  File_read_write_all_test \


### PR DESCRIPTION
* Small commit to separate out Fortran tests from C/C++ tests.
* Primary commit:  Allow MANA to run with recent versions of CentOS.  (It used to work with CentOS.  Apparently, something in CentOS changed.)