### PR TITLE
Robust lower-half mmap()

### DIFF
--- a/bin/mana_launch
+++ b/bin/mana_launch
@@ -164,12 +164,19 @@ if [ "$verbose" == 1 ]; then
 fi
 
 # TEMPORARY WORKAROUND:  set MPICH_SMP_SINGLE_COPY_OFF=1
-#   In VASP5 with RPA, it failed on restart, trying to copy to a
-#   /SYSV0* file (created by shmat or XPMEM), but mpi_plugin.cpp says that
-#   /SYSV0* is not saved at ckpt, and so its data is not saved and restored.
-#   NOTE: The upper half should not know about this file. Why do we
-#         need to restore pre-ckpt data on a new MPICH in the lower half? 
-#         (We could create xpmam plugin for DMTCP, but it shouldn't be needed.)
+#   As MANA matures, these environment variable settings will not longer
+#   be needed.  Use these only if you have mysterious segfaults due
+#   to corrupted memory layouts.
+#     Setting this should turn of the use of /SYSV0* memory segments
+#   for SysV shared memory in MPICH.  It turns out that it does not
+#   stop the many /dev/xpmem memory segments from being created if/when
+#   MPICH uses XPMEM.  To stop using XPMEM, set this other environment variable:
+#     MPICH_SMP_SINGLE_COPY_SIZE=81920  [units of bytes]
+#   This is a threshold, below which, it will _not_ create /dev/xpmem
+#   for shared memory communication.  If you still see too many
+#   /dev/xpmem segments, then raise the value 81920 still higher.
+#   The /dev/xpmem segments are created on demand when an MPI call
+#   needs to send/receive a large message.
 
 env LD_LIBRARY_PATH="$libdir:$LD_LIBRARY_PATH" \
     $dir/dmtcp_launch --mpi --coord-host $submissionHost \

--- a/mpi-proxy-split/lower-half/Makefile
+++ b/mpi-proxy-split/lower-half/Makefile
@@ -106,6 +106,11 @@ ${PROXY_BIN_DEFADDR}: ${PROXY_OBJS} ${LIBPROXY}.a ${STATIC_GETHOSTBYNAME}
 ${LIBPROXY}.a: ${LIBPROXY_OBJS}
 	ar cr $@ $^
 
+check-mmap: libmmap.so
+	LD_PRELOAD=$$PWD/libmmap.so ls
+libmmap.so: mmap64.c munmap.c
+	${CC} -shared ${CFLAGS} -DLIBMMAP_SO -I. -g3 -O0 -fPIC -o libmmap.so $^
+
 install: ${PROXY_BIN} ${PROXY_BIN_DEFADDR} ${STATIC_GETHOSTBYNAME}
 	cp -f $^ ${MANA_ROOT}/bin/
 
@@ -115,6 +120,7 @@ tidy:
 
 clean: tidy
 	rm -f ${PROXY_BIN} ${PROXY_BIN_DEFADDR} ${LIBPROXY}.a ${PROXY_OBJS} ${LIBPROXY_OBJS}
+	rm -f libmmap.so
 	rm -f ${MANA_ROOT}/bin/${PROXY_BIN}
 	rm -f ${MANA_ROOT}/bin/${PROXY_BIN_DEFADDR}
 	if test -d gethostbyname-static; then \

--- a/mpi-proxy-split/lower-half/lower_half_api.h
+++ b/mpi-proxy-split/lower-half/lower_half_api.h
@@ -99,8 +99,8 @@ typedef struct _LowerHalfInfo
 #endif
   void *parentStackStart; // Address to the start of the stack of the parent process (FIXME: Not currently used anywhere)
   void *updateEnvironFptr; // Pointer to updateEnviron() function in the lower half
-  void *getMmappedListFptr; // Pointer to getMmapedList() function in the lower half
-  void *resetMmappedListFptr; // Pointer to resetMmapedList() function in the lower half
+  void *getMmappedListFptr; // Pointer to getMmappedList() function in the lower half
+  void *resetMmappedListFptr; // Pointer to resetMmappedList() function in the lower half
   int numCoreRegions; // total number of core regions in the lower half
   void *getLhRegionsListFptr; // Pointer to getLhRegionsList() function in the lower half
   void *vdsoLdAddrInLinkMap; // vDSO's LD address in the lower half's linkmap

--- a/mpi-proxy-split/lower-half/lower_half_api.h
+++ b/mpi-proxy-split/lower-half/lower_half_api.h
@@ -65,6 +65,7 @@ typedef struct __MmapInfo
   void *addr;   // Start address of mmapped region
   size_t len;   // Length (in bytes) of mmapped region
   int unmapped; // 1 if the region was unmapped; 0 otherwise
+  int dontuse;  // 1 if preexisting mmap in region (e.g., xpmem); 0 otherwise
   int guard;    // 1 if the region has additional guard pages around it; 0 otherwise
 } MmapInfo_t;
 

--- a/mpi-proxy-split/lower-half/mmap64.c
+++ b/mpi-proxy-split/lower-half/mmap64.c
@@ -17,6 +17,7 @@
    License along with the GNU C Library; if not, see
    <http://www.gnu.org/licenses/>.  */
 
+#include <linux/version.h>
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>
@@ -28,6 +29,8 @@
 #include "mmap_internal.h"
 #include "mpi_copybits.h"
 #include <sys/syscall.h>
+
+#define HAS_MAP_FIXED_NOREPLACE LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
 
 #ifndef __set_errno
 # define __set_errno(Val) errno = (Val)
@@ -59,13 +62,15 @@
 // Modified to keep track of regions mmaped by lower half
 
 // TODO:
-//  1. Make the size of list dynamic
+//  1. Add byte, 0b10101010, everywhere to lh_memRange, when first
+//     calling mmap within 'if (!initialized)' logic, below.
+//  2. Make the size of list dynamic
 
 // Number of valid objects in the 'mmaps' list below
 int numRegions = 0;
 
 // List of regions mmapped by the lower half
-MmapInfo_t mmaps[MAX_TRACK] = {0};
+MmapInfo_t mmaps[MAX_TRACK] = {{0}};
 
 // Pointer to the next free address used for allocation
 void *nextFreeAddr = NULL;
@@ -118,9 +123,7 @@ getNextAddr(size_t len)
   nextFreeAddr = (char*)curr + ROUND_UP(len) + PAGE_SIZE;
 
   // Assert if we have gone past the end of the lower half memory range
-  if (nextFreeAddr > lh_memRange.end) {
-    assert(0);
-  }
+  assert(nextFreeAddr <= lh_memRange.end);
   return curr;
 }
 
@@ -162,6 +165,38 @@ getNextHugeAddr(size_t len)
 void *
 __mmap64 (void *addr, size_t len, int prot, int flags, int fd, __off_t offset)
 {
+  static int initialized = 0;
+  if (!initialized) {
+    int length = lh_memRange.end - lh_memRange.start;
+# if 0
+    // FIXME: After we copy into upper half, call mmap as below.
+    //        But don't call this when lh_proxy first executes by itself.
+    //        So, we need to recognize if we are executing lh_proxy
+    //          or the target MPI application.
+# if HAS_MAP_FIXED_NOREPLACE
+    void *rc = mmap(lh_memRange.start, length,
+                    PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED_NOREPLACE,
+                    -1, 0);
+    if (rc == MAP_FAILED && errno == EEXIST) {
+      char msg[] = "*** Panic: MANA lower half: can't initialize lh_memRange\n";
+      write(2, msg, sizeof(msg)); assert(rc == 0);
+    }
+#else
+    void *rc = mmap(lh_memRange.start, length,
+                    PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+    if (rc != lh_memRange.start) {
+      if (rc != MAP_FAILED) {
+        munmap(rc, length);
+      }
+      char msg[] = "*** Panic: MANA lower half: can't initialize lh_memRange\n";
+      write(2, msg, sizeof(msg)); assert(rc != lh_memRange.start);
+    }
+# endif
+# endif
+#endif
+    initialized = 1;
+  }
+
   void *ret = MAP_FAILED;
   MMAP_CHECK_PAGE_UNIT ();
 
@@ -192,11 +227,21 @@ __mmap64 (void *addr, size_t len, int prot, int flags, int fd, __off_t offset)
         // TODO: Check fd is pointing to hugetlbfs
         addr = getNextHugeAddr(len);
       } else {
+        // FIXME:  This appears to be for hugetlbfs with no backing store.
+        //         How is it used?
         addr = NULL;
       }
     }
+    // FIXME: Check if original caller had used MAP_FIXED
+    //          or MAP_FIXED_NOREPLACE; If so, we have a big problem here.
+    //          Abort and tell user for now??  Or just make the
+    //          call directly now, and hope for the best??
     if (addr) {
-      flags |= MAP_FIXED;
+#if HAS_MAP_FIXED_NOREPLACE
+      flags |= MAP_FIXED_NOREPLACE;
+#else
+      flags |= MAP_FIXED; // Dangerous!  We might clobber unknown mmap region.
+#endif
     }
   }
 
@@ -207,15 +252,44 @@ __mmap64 (void *addr, size_t len, int prot, int flags, int fd, __off_t offset)
     extraGuardPage = 1;
     totalLen += 2 * PAGE_SIZE;
   }
+  while (1) {
 #ifdef __NR_mmap2
-  ret = MMAP_CALL (mmap2, addr, totalLen, prot, flags, fd,
-            (off_t) (offset / MMAP2_PAGE_UNIT));
+    if (addr) {
+      int rc = munmap(addr, totalLen);
+      if (rc == -1) {
+        char msg[] = "*** Panic: MANA lower half: can't munmap a region.\n";
+        write(2, msg, sizeof(msg)); assert(rc == 0);
+      }
+    }
+# define MMAP mmap2
+    ret = (void *) MMAP_CALL (MMAP, addr, totalLen, prot, flags, fd,
+                                    (off_t) (offset / MMAP2_PAGE_UNIT));
 #else
-  ret = (void *) MMAP_CALL (mmap, addr, totalLen, prot, flags, fd, offset);
+# define MMAP mmap
+    ret = (void *) MMAP_CALL (MMAP, addr, totalLen, prot, flags, fd, offset);
 #endif
 
+    if (ret == MAP_FAILED && errno == EEXIST) {
+      // Someone stole our mmap slot (via ioctl?).  This can happen if
+      //   a network or shared-memory library (e.g. xpmem) uses ioctl
+      //   to allocate memory.  Look for the next available address.
+      do { addr += PAGE_SIZE;
+         }
+      while ((void *)MMAP_CALL(MMAP, addr, PAGE_SIZE, PROT_NONE, MAP_PRIVATE,
+                               0, -1)
+             == MAP_FAILED);
+      nextFreeAddr = addr;
+      // FIXME:  We need to recognize dontuse everywhere.
+      mmaps[getMmapIdx(ret)].dontuse = 1; // Skip past the stolen region.
+      mmaps[getMmapIdx(ret)].len = addr-ret; // Set length of stolen region.
+      addr = getNextAddr(len); // FIXME: Maybe we want getNextHugeAddr()
+    } else {
+      break;
+    }
+  }  // end of while loop using MMAP_CALL
+
   // Accounting of the lower-half mmap regions
-  // XXX: Why are we doing this? Given that all the lower half memory
+  // XXX (Rohan): Why are we doing this? Given that all the lower half memory
   //      allocations are restricted to a specified range, do we need to do
   //      this?
   if (ret != MAP_FAILED) {
@@ -223,6 +297,7 @@ __mmap64 (void *addr, size_t len, int prot, int flags, int fd, __off_t offset)
     if (idx != -1) {
       mmaps[idx].len = ROUND_UP(len);
       mmaps[idx].unmapped = 0;
+      mmaps[idx].dontuse = 0;
     } else {
       int idx2 = extendExistingMmap(ret);
       if (idx2 != -1) {
@@ -236,6 +311,14 @@ __mmap64 (void *addr, size_t len, int prot, int flags, int fd, __off_t offset)
         mmaps[numRegions].unmapped = 0;
         idx = numRegions;
         numRegions = (numRegions + 1) % MAX_TRACK;
+        // FIXME: A better fix, below, is to set nextFreeAddr back to the start,
+        //   and then to test the size of any gap.  That can be done
+        //   by checking each known region.  Hopefully, there are not many.
+        //   Or at least, we can re-use any unmapped regions.
+        if (numRegions == 0) {
+          char msg[] = "*** Panic: MANA lower half: no more space for mmap.\n";
+          write(2, msg, sizeof(msg)); assert(numRegions > 0);
+        }
       }
     }
     if (extraGuardPage) {

--- a/mpi-proxy-split/lower-half/munmap.c
+++ b/mpi-proxy-split/lower-half/munmap.c
@@ -34,6 +34,11 @@
 // tracking of munmapped regions
 extern int __real___munmap(void *, size_t );
 
+#ifdef LIBMMAP_SO
+// Lower-half memory range to use; initialized in mmap64.c
+MemRange_t lh_memRange;
+#endif
+
 static inline int
 alignedWithLastPage(const void *haystackStart,
                const void *haystackEnd,

--- a/mpi-proxy-split/split_process.cpp
+++ b/mpi-proxy-split/split_process.cpp
@@ -410,8 +410,11 @@ findLHMemRange(MemRange_t *lh_mem_range)
     // be loaded. So, it is better to reserve 2GB space for the lower half mmaps
     // near the next address instead of the previous address with a one-page
     // distance to avoid memory overlap.
-    if ((prev_addr_end + 2 * ONEGB + PAGE_SIZE) <= next_addr_start) {
-      lh_mem_range->start = (VA)next_addr_start - (2 * ONEGB + PAGE_SIZE) ;
+    // FIXME:  Changed 2GB to 8GB for larger region between lower and upper
+    //         half.  We should allocate 10 MB above lower half, with CANARY
+    //         and PROT_NONE, and test if the pages were disturbed in mmap().
+    if ((prev_addr_end + 8 * ONEGB + PAGE_SIZE) <= next_addr_start) {
+      lh_mem_range->start = (VA)next_addr_start - (8 * ONEGB + PAGE_SIZE) ;
       lh_mem_range->end = (VA)next_addr_start - PAGE_SIZE;
       is_set = true;
       break;

--- a/mpi-proxy-split/test/Makefile
+++ b/mpi-proxy-split/test/Makefile
@@ -26,7 +26,7 @@ DEMO_PORT=7787
 # Several tests are excluded from this Makefile because they are redundant:
 # multi_send_recv, send_recv, send_recv_many
 # Comment out FILES_FORTRAN if you don't have an mmpifort compiler.
-## FILES_FORTRAN= f_ibarrier wave_mpi day1_mpi quad_mpi poisson_nonblock_mpi
+FILES_FORTRAN= f_ibarrier wave_mpi day1_mpi quad_mpi poisson_nonblock_mpi
 FILES=mpi_hello_world \
       hello_mpi_init_thread Sendrecv_test Gatherv_test \
       keyval_test file_test Scatterv_test Gather_test \

--- a/mpi-proxy-split/test/Makefile
+++ b/mpi-proxy-split/test/Makefile
@@ -26,7 +26,7 @@ DEMO_PORT=7787
 # Several tests are excluded from this Makefile because they are redundant:
 # multi_send_recv, send_recv, send_recv_many
 # Comment out FILES_FORTRAN if you don't have an mmpifort compiler.
-FILES_FORTRAN= f_ibarrier wave_mpi day1_mpi quad_mpi poisson_nonblock_mpi
+## FILES_FORTRAN= f_ibarrier wave_mpi day1_mpi quad_mpi poisson_nonblock_mpi
 FILES=mpi_hello_world \
       hello_mpi_init_thread Sendrecv_test Gatherv_test \
       keyval_test file_test Scatterv_test Gather_test \


### PR DESCRIPTION
**[This PR has now been updated.  It no longer mmap's the lhMemRange in advance.  @jiamingz9925 reports that this allows the PR to succeed with VASP6/Si256, when executing with  `MPICH_SMP_SINGLE_COPY_SIZE=819200`.  We should test this again, after PR #328 is pushed in.]**

If this PR succeeds, we can push it int, and then go back and analyze why mmap'ing the lhMemRange causes a problem.  Reserving lhMemRange in advance may be necessary in order to avoid using `MPICH_SMP_SINGLE_COPY_SIZE=819200`.  That would allow for greater use of `/dev/xpmem` segments, which can improve performance.

And this raises 2 GB to 8 GB in a commit, to increase the gap between lower and upper half.

I'm attaching the text from the most important commit in this PR.

 Make lower-half mmap/munmap more robust:
1. libxpmem (and maybe other kernel drivers) can use ioctl to mmap
        additional memory segments, such as /dev/xpmem.  If they mmap
        many such segments or a few large ones, they can occupy a lot
        of the lower-half lh_memRange (aka lh_mem_range in split_process.cpp).
2. This can cause a problem either:  because the lh_memRange does not
        have enough empty space for the lower half to mmap; or more often
        when there are many upper-half libraries, whose mmap allocations
        grow downward and enter the lh_memRange.
3. The lower half adds MAP_FIXED to its mmap's, thinking that it controls
        all of lh_memRange, and trying to allocate its mmaps contiguously
        and growing upward in lh_memRange.  Its mmap can receive an ENOMEM
        if it tries to clobber /dev/xpmem.  It then abandons the mmap on
        the assumption that the caller to mmap (libmpi) would want to see
        the ENOMEM.  The libmpi caller can then test another region with
        mmap (maybe with mmap and a specified address or with mmap/MAP_FIXED
        and a specified address, followed by munmap).  The lower-half mmap
        adds the MAP_FIXED flag, as usual.  This can cause the lower-half
        mmap to clobber an upper-half mmap, if the upper-half mmap had
        been allocated in the lh_memRange.  (The upper-half mmap may enter
        the lh_memRange if the upper half has very many libraries, since
        libraries are populated using mmap without a suggested address,
        and those mmap's grow downward.)
4. The (partial) solution is for the lower-half mmap to use
        MAP_FIXED_NOREPLACE instead of MAP_FIXED, and test for EEXIST.
        Additionally, it may be necessary in a future commit to choose a
        different lh_memRange further away from the many upper-half libraries
        that are being mmap'ed.