### PR TITLE
add FFLAG to test if -fallow-argument-mismatch works for Fortran compiler

### DIFF
--- a/configure
+++ b/configure
@@ -616,8 +616,12 @@ enable_option_checking=no
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
 PANDOC
+FFLAGS
 DEBUG
 subdirs
+ac_ct_FC
+FCFLAGS
+FC
 HAVE_CXX14
 CPP
 ac_ct_CC
@@ -646,9 +650,6 @@ build_os
 build_vendor
 build_cpu
 build
-MAINT
-MAINTAINER_MODE_FALSE
-MAINTAINER_MODE_TRUE
 target_alias
 host_alias
 build_alias
@@ -691,7 +692,6 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
-enable_maintainer_mode
 enable_debug
 enable_timing
 enable_logging
@@ -709,7 +709,9 @@ CPPFLAGS
 CCC
 CC
 CFLAGS
-CPP'
+CPP
+FC
+FCFLAGS'
 ac_subdirs_all='dmtcp'
 
 # Initialize some variables set by options.
@@ -1332,9 +1334,6 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
-  --enable-maintainer-mode
-                          enable make rules and dependencies not useful (and
-                          sometimes confusing) to the casual installer
   --enable-debug          Use debugging flags "-Wall -g3 -O0" on DMTCP libs
                           (default is disabled); also, see --enable-logging
 
@@ -1350,6 +1349,8 @@ Some influential environment variables:
   CC          C compiler command
   CFLAGS      C compiler flags
   CPP         C preprocessor
+  FC          Fortran compiler command
+  FCFLAGS     Fortran compiler flags
 
 Use these variables to override the choices made by `configure' or to help
 it to find libraries and programs with nonstandard names/locations.
@@ -1548,6 +1549,45 @@ fi
   as_fn_set_status $ac_retval
 
 } # ac_fn_c_try_cpp
+
+# ac_fn_fc_try_compile LINENO
+# ---------------------------
+# Try to compile conftest.$ac_ext, and return whether this succeeded.
+ac_fn_fc_try_compile ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  rm -f conftest.$ac_objext conftest.beam
+  if { { ac_try="$ac_compile"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+printf "%s\n" "$ac_try_echo"; } >&5
+  (eval "$ac_compile") 2>conftest.err
+  ac_status=$?
+  if test -s conftest.err; then
+    grep -v '^ *+' conftest.err >conftest.er1
+    cat conftest.er1 >&5
+    mv -f conftest.er1 conftest.err
+  fi
+  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; } && {
+	 test -z "$ac_fc_werror_flag" ||
+	 test ! -s conftest.err
+       } && test -s conftest.$ac_objext
+then :
+  ac_retval=0
+else $as_nop
+  printf "%s\n" "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+	ac_retval=1
+fi
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+  as_fn_set_status $ac_retval
+
+} # ac_fn_fc_try_compile
 ac_configure_args_raw=
 for ac_arg
 do
@@ -2538,30 +2578,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 # TODO(kapil): Add 'subdir-objects after automake 1.16 has been released.
 # AM_INIT_AUTOMAKE([foreign])
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to enable maintainer-specific portions of Makefiles" >&5
-printf %s "checking whether to enable maintainer-specific portions of Makefiles... " >&6; }
-    # Check whether --enable-maintainer-mode was given.
-if test ${enable_maintainer_mode+y}
-then :
-  enableval=$enable_maintainer_mode; USE_MAINTAINER_MODE=$enableval
-else $as_nop
-  USE_MAINTAINER_MODE=no
-fi
-
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $USE_MAINTAINER_MODE" >&5
-printf "%s\n" "$USE_MAINTAINER_MODE" >&6; }
-   if test $USE_MAINTAINER_MODE = yes; then
-  MAINTAINER_MODE_TRUE=
-  MAINTAINER_MODE_FALSE='#'
-else
-  MAINTAINER_MODE_TRUE='#'
-  MAINTAINER_MODE_FALSE=
-fi
-
-  MAINT=$MAINTAINER_MODE_TRUE
-
-
+# AM_MAINTAINER_MODE
 
 
 
@@ -4960,6 +4977,277 @@ else $as_nop
 fi
 
 
+ac_ext=${ac_fc_srcext-f}
+ac_compile='$FC -c $FCFLAGS $ac_fcflags_srcext conftest.$ac_ext >&5'
+ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_fc_compiler_gnu
+
+ac_ext=${ac_fc_srcext-f}
+ac_compile='$FC -c $FCFLAGS $ac_fcflags_srcext conftest.$ac_ext >&5'
+ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_fc_compiler_gnu
+if test -n "$ac_tool_prefix"; then
+  for ac_prog in gfortran g95 xlf95 f95 fort ifort ifc efc pgfortran pgf95 lf95 ftn nagfor xlf90 f90 pgf90 pghpf epcf90 g77 xlf f77 frt pgf77 cf77 fort77 fl32 af77
+  do
+    # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
+set dummy $ac_tool_prefix$ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_FC+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$FC"; then
+  ac_cv_prog_FC="$FC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_FC="$ac_tool_prefix$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+FC=$ac_cv_prog_FC
+if test -n "$FC"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $FC" >&5
+printf "%s\n" "$FC" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+    test -n "$FC" && break
+  done
+fi
+if test -z "$FC"; then
+  ac_ct_FC=$FC
+  for ac_prog in gfortran g95 xlf95 f95 fort ifort ifc efc pgfortran pgf95 lf95 ftn nagfor xlf90 f90 pgf90 pghpf epcf90 g77 xlf f77 frt pgf77 cf77 fort77 fl32 af77
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_ac_ct_FC+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$ac_ct_FC"; then
+  ac_cv_prog_ac_ct_FC="$ac_ct_FC" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_ac_ct_FC="$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+ac_ct_FC=$ac_cv_prog_ac_ct_FC
+if test -n "$ac_ct_FC"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_FC" >&5
+printf "%s\n" "$ac_ct_FC" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+  test -n "$ac_ct_FC" && break
+done
+
+  if test "x$ac_ct_FC" = x; then
+    FC=""
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    FC=$ac_ct_FC
+  fi
+fi
+
+
+# Provide some information about the compiler.
+printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for Fortran compiler version" >&5
+set X $ac_compile
+ac_compiler=$2
+for ac_option in --version -v -V -qversion; do
+  { { ac_try="$ac_compiler $ac_option >&5"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+printf "%s\n" "$ac_try_echo"; } >&5
+  (eval "$ac_compiler $ac_option >&5") 2>conftest.err
+  ac_status=$?
+  if test -s conftest.err; then
+    sed '10a\
+... rest of stderr output deleted ...
+         10q' conftest.err >conftest.er1
+    cat conftest.er1 >&5
+  fi
+  rm -f conftest.er1 conftest.err
+  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }
+done
+rm -f a.out
+
+# If we don't use `.F' as extension, the preprocessor is not run on the
+# input file.  (Note that this only needs to work for GNU compilers.)
+ac_save_ext=$ac_ext
+ac_ext=F
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports GNU Fortran" >&5
+printf %s "checking whether the compiler supports GNU Fortran... " >&6; }
+if test ${ac_cv_fc_compiler_gnu+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  cat > conftest.$ac_ext <<_ACEOF
+      program main
+#ifndef __GNUC__
+       choke me
+#endif
+
+      end
+_ACEOF
+if ac_fn_fc_try_compile "$LINENO"
+then :
+  ac_compiler_gnu=yes
+else $as_nop
+  ac_compiler_gnu=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ac_cv_fc_compiler_gnu=$ac_compiler_gnu
+
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_fc_compiler_gnu" >&5
+printf "%s\n" "$ac_cv_fc_compiler_gnu" >&6; }
+ac_compiler_gnu=$ac_cv_fc_compiler_gnu
+
+ac_ext=$ac_save_ext
+ac_test_FCFLAGS=${FCFLAGS+y}
+ac_save_FCFLAGS=$FCFLAGS
+FCFLAGS=
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $FC accepts -g" >&5
+printf %s "checking whether $FC accepts -g... " >&6; }
+if test ${ac_cv_prog_fc_g+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  FCFLAGS=-g
+cat > conftest.$ac_ext <<_ACEOF
+      program main
+
+      end
+_ACEOF
+if ac_fn_fc_try_compile "$LINENO"
+then :
+  ac_cv_prog_fc_g=yes
+else $as_nop
+  ac_cv_prog_fc_g=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_fc_g" >&5
+printf "%s\n" "$ac_cv_prog_fc_g" >&6; }
+if test $ac_test_FCFLAGS; then
+  FCFLAGS=$ac_save_FCFLAGS
+elif test $ac_cv_prog_fc_g = yes; then
+  if test "x$ac_cv_fc_compiler_gnu" = xyes; then
+    FCFLAGS="-g -O2"
+  else
+    FCFLAGS="-g"
+  fi
+else
+  if test "x$ac_cv_fc_compiler_gnu" = xyes; then
+    FCFLAGS="-O2"
+  else
+    FCFLAGS=
+  fi
+fi
+
+if test $ac_compiler_gnu = yes; then
+  GFC=yes
+else
+  GFC=
+fi
+ac_ext=${ac_fc_srcext-f}
+ac_compile='$FC -c $FCFLAGS $ac_fcflags_srcext conftest.$ac_ext >&5'
+ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_fc_compiler_gnu
+
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether Fortran compiler accepts -fallow-argument-mismatch" >&5
+printf %s "checking whether Fortran compiler accepts -fallow-argument-mismatch... " >&6; }
+if test ${ax_cv_check_fcflags___fallow_argument_mismatch+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$FCFLAGS
+  FCFLAGS="$FCFLAGS  -fallow-argument-mismatch"
+  cat > conftest.$ac_ext <<_ACEOF
+      program main
+
+      end
+_ACEOF
+if ac_fn_fc_try_compile "$LINENO"
+then :
+  ax_cv_check_fcflags___fallow_argument_mismatch=yes
+else $as_nop
+  ax_cv_check_fcflags___fallow_argument_mismatch=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  FCFLAGS=$ax_check_save_flags
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_fcflags___fallow_argument_mismatch" >&5
+printf "%s\n" "$ax_cv_check_fcflags___fallow_argument_mismatch" >&6; }
+if test "x$ax_cv_check_fcflags___fallow_argument_mismatch" = xyes
+then :
+  FFLAGS="${FFLAGS} -fallow-argument-mismatch"
+else $as_nop
+  :
+fi
+
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
 ac_configure_args="$ac_configure_args --with-mana-helper-dir=../restart_plugin"
 ac_configure_args="$ac_configure_args --disable-dlsym-wrapper"
 
@@ -4974,9 +5262,9 @@ enable_option_checking=fatal
 if test -n "$ac_unrecognized_opts"; then
   case $enable_option_checking in
     no) ;;
-    fatal) { $as_echo "$as_me: error: unrecognized options: $ac_unrecognized_opts" >&2
+    fatal) { printf "%s\n" "$as_me: error: unrecognized options: $ac_unrecognized_opts" >&2
    { (exit 1); exit 1; }; } ;;
-    *)     $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2 ;;
+    *)     printf "%s\n" "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2 ;;
   esac
 fi
 
@@ -5002,6 +5290,9 @@ else
   DEBUG=no
 
 fi
+
+FFLAGS=$FFLAGS
+
 
 # Keeping these DMTCP flags only for convenience.
 # Check whether --enable-timing was given.
@@ -5223,10 +5514,6 @@ LIBOBJS=$ac_libobjs
 LTLIBOBJS=$ac_ltlibobjs
 
 
-if test -z "${MAINTAINER_MODE_TRUE}" && test -z "${MAINTAINER_MODE_FALSE}"; then
-  as_fn_error $? "conditional \"MAINTAINER_MODE\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
 
 : "${CONFIG_STATUS=./config.status}"
 ac_write_fail=0

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_INIT([MANA],
 AC_PREREQ([2.60])
 # TODO(kapil): Add 'subdir-objects after automake 1.16 has been released.
 # AM_INIT_AUTOMAKE([foreign])
-AM_MAINTAINER_MODE
+# AM_MAINTAINER_MODE
 AC_CANONICAL_HOST
 AC_PROG_INSTALL
 # Automake uses 'ar cru' by default.  The 'ar' program then issues a warning.
@@ -30,6 +30,14 @@ AX_CHECK_COMPILE_FLAG([-std=gnu11],
                       [CFLAGS="${CFLAGS} -std=gnu11"],
                       [echo "C compiler cannot compile gnu11 code"; exit -1])
 
+dnl gfortran-10 errors out if argument mismatch
+dnl See if Fotran compiler supports -fallow-argument-mismatch for legacy code
+AC_LANG_PUSH([Fortran])
+AX_CHECK_COMPILE_FLAG([-fallow-argument-mismatch],
+                      [FFLAGS="${FFLAGS} -fallow-argument-mismatch"],
+                      [])
+AC_LANG_POP([Fortran])
+
 ac_configure_args="$ac_configure_args --with-mana-helper-dir=../restart_plugin"
 ac_configure_args="$ac_configure_args --disable-dlsym-wrapper"
 AC_CONFIG_SUBDIRS([dmtcp])
@@ -45,9 +53,9 @@ enable_option_checking=fatal
 if test -n "$ac_unrecognized_opts"; then
   case $enable_option_checking in
     no) ;;
-    fatal) { $as_echo "$as_me: error: unrecognized options: $ac_unrecognized_opts" >&2
+    fatal) { AS_ECHO(["$as_me: error: unrecognized options: $ac_unrecognized_opts"]) >&2
    { (exit 1); exit 1; }; } ;;
-    *)     $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2 ;;
+    *)     AS_ECHO(["$as_me: WARNING: unrecognized options: $ac_unrecognized_opts"]) >&2 ;;
   esac
 fi
 
@@ -68,6 +76,8 @@ if test "$use_debug" = "yes"; then
 else
   AC_SUBST([DEBUG], [no])
 fi
+
+AC_SUBST([FFLAGS], [$FFLAGS])
 
 # Keeping these DMTCP flags only for convenience.
 AC_ARG_ENABLE([timing])

--- a/mpi-proxy-split/Makefile_config.in
+++ b/mpi-proxy-split/Makefile_config.in
@@ -4,6 +4,7 @@ MANA_USE_LH_FIXED_ADDRESS = @MANA_USE_LH_FIXED_ADDRESS@
 
 CFLAGS = @CFLAGS@
 CXXFLAGS = @CXXFLAGS@
+FFLAGS = ${CXXFLAGS} @FFLAGS@
 
 ifeq ($(findstring cori,$(PLATFORM)),cori)
 IS_CORI = 1
@@ -46,5 +47,6 @@ else
   MPI_LD_FLAG = -L$$HOME/mpich-static/usr/lib64 -lmpi -llzma -lz -lm -lxml2
   MPI_CFLAGS?= @CFLAGS@ -g3 -fPIC
   MPI_CXXFLAGS?= @CXXFLAGS@ -g3 -fPIC
+  MPI_FFLAGS = @FFLAGS@ -g3
   MPI_LDFLAGS?=
 endif


### PR DESCRIPTION
Use MANA configure to test if `-allow-argument-mismatch`, instead of making use modify `mpi-proxy-split/test/Makefile` each time.

This flag is required for gfortran version 10 to support legacy Fortran code, but it doesn't exist for earlier versions.