### PR TITLE
Use FFLAGS in mpi-proxy-split/test:Makefile

### DIFF
--- a/mpi-proxy-split/test/Makefile
+++ b/mpi-proxy-split/test/Makefile
@@ -159,10 +159,10 @@ check-integrated_dmtcp_text: tidy integrated_dmtcp_test
 # Argument mistmatch is a legacy feature that newer fortran compilers do not
 # allow, but is still used in two of our test cases
 %.exe: %.f90
-	$(MPIFORTRAN) -g3 -O0 -o $@ $< -fPIC -fallow-argument-mismatch
+	$(MPIFORTRAN) ${FFLAGS} -g3 -O0 -o $@ $<
 
 %.mana.exe: %.f90
-	$(MPIFORTRAN) -g3 -O0 -o $@ $< -fPIC -fallow-argument-mismatch \
+	$(MPIFORTRAN) ${FFLAGS} -g3 -O0 -o $@ $<
 	  ${LDFLAGS_DUMMY}
 
 %.exe: %.o


### PR DESCRIPTION
I forgot to include this commit in the previous PR #324.  So, it's a new PR.
PR #324 created the FFLAGS Makefile variable.  This PR uses it in the test directory.