### PR TITLE
Fix memory range

### DIFF
--- a/restart_plugin/mtcp_split_process.c
+++ b/restart_plugin/mtcp_split_process.c
@@ -289,6 +289,15 @@ setLhMemRange(RestoreInfo *rinfo)
 #if !defined(MANA_USE_LH_FIXED_ADDRESS)
     lh_mem_range.start = (VA)area.addr - TWO_GB;
     lh_mem_range.end = (VA)area.addr - ONE_GB;
+    // High memory region occupies more than 1GB below stack region.
+    // Use minHighMemStart to set lower half memory range.
+    // Plugin_hook reserves region that ends 4GB below high memory region
+    // (See mtcp_plugin_hook). LH reserved 1GB size region that ends at 1GB
+    // below (high memory start - 4GB), so 5GB below high memory.
+    if (lh_mem_range.end > (VA) rinfo->minHighMemStart) {
+      lh_mem_range.end = rinfo->minHighMemStart - 5 * ONE_GB;
+      lh_mem_range.start = lh_mem_range.end - 1 * ONE_GB;
+    }
 #else
     lh_mem_range.start = 0x2aab00000000;
     lh_mem_range.end =   0x2aab00000000 + ONE_GB;

--- a/restart_plugin/mtcp_split_process.c
+++ b/restart_plugin/mtcp_split_process.c
@@ -306,6 +306,7 @@ setLhMemRange(RestoreInfo *rinfo)
     DPRINTF("Failed to find [stack] memory segment\n");
     mtcp_abort();
   }
+  MTCP_ASSERT(lh_mem_range.end < (VA) rinfo->minHighMemStart);
   return lh_mem_range;
 }
 


### PR DESCRIPTION
The memory layout is changed when no_randomize is enabled. The assumption that lower half would be 1GB below stack region is not valid anymore. This change uses region below minHighMemStart as the lower half.

This change has to used with Gene's DMTCP PR #1063 ADDR_NO_RANDOMIZE. 