### PR TITLE
Use the right flags for building on Perlmutter

### DIFF
--- a/mpi-proxy-split/Makefile_config.in
+++ b/mpi-proxy-split/Makefile_config.in
@@ -22,7 +22,7 @@ endif
 ifeq ($(findstring gert,$(PLATFORM)),gert)
 IS_GERTY = 1
 endif
-ifeq ($(or $(IS_CORI),$(IS_GERTY)), 1)
+ifeq ($(or $(IS_CORI),$(IS_GERTY), $(IS_PERLMUTTER)), 1)
   MPICC = cc
   MPICXX = CC -std=c++14
   MPIFORTRAN = ftn


### PR DESCRIPTION
This change fixes the broken build on Perlmutter. Please see MANA-310 for the detail of the build failure. 