### PR TITLE
Updated split-process to use RESERVE_LH_MEM_RANGE

### DIFF
--- a/mpi-proxy-split/lower-half/libproxy.c
+++ b/mpi-proxy-split/lower-half/libproxy.c
@@ -352,7 +352,7 @@ void first_constructor()
     lh_info.getLhRegionsListFptr = (void*)&getLhRegionsList;
     lh_info.vdsoLdAddrInLinkMap = getVdsoPointerInLinkMap();
     DLOG(INFO, "startText: %p, endText: %p, endOfHeap; %p\n",
-        lh_info.startText, lh_info.endText, lh_info.endOfHeap);
+         lh_info.startText, lh_info.endText, lh_info.endOfHeap);
     // Write lh_info to stdout, for mtcp_split_process.c to read.
     write(1, &lh_info, sizeof lh_info);
     // Write LH core regions list to stdout, for the parent process to read.

--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -150,8 +150,13 @@ void recordPostMpiInitMaps()
     // Now remove those mappings that existed before Mpi_Init.
     JASSERT(preMpiInitMaps != nullptr);
     while (preMpiInitMaps->getNextArea(&area)) {
+      if (area.addr == lh_info.memRange.start) {
+        continue;
+      }
+
       if (mpiInitLhAreas->find(area.addr) != mpiInitLhAreas->end()) {
-        JWARNING(mpiInitLhAreas->at(area.addr) == area.size)(area.addr)(area.size);
+        JWARNING(mpiInitLhAreas->at(area.addr) == area.size)
+                ((void *)area.addr)(area.size);
         mpiInitLhAreas->erase(area.addr);
       } else {
         // Check if a region has the same end addr. E.g., thread stack grew.

--- a/restart_plugin/mtcp_restart_plugin.c
+++ b/restart_plugin/mtcp_restart_plugin.c
@@ -751,6 +751,16 @@ mtcp_plugin_skip_memory_region_munmap(Area *area, RestoreInfo *rinfo)
     }
   }
 
+/**
+ * InitializeLowerHalf and later we mmap a new lower half memory region which is not one of core region of child lh_proxy.
+ * We need to skip unmapping this region as well.
+*/
+#define LOWER_BOUNDARY 0x1000000000
+  if (area->addr >= (char *)lh_regions_list[total_lh_regions - 1].end_addr &&
+      area->endAddr <= (char *)LOWER_BOUNDARY) {
+    return 1;
+  }
+
 #ifdef USE_LH_MMAPS_ARRAY
   // FIXME: use assert(g_list) instead.
   if (!g_list) return 0;

--- a/restart_plugin/mtcp_restart_plugin.c
+++ b/restart_plugin/mtcp_restart_plugin.c
@@ -721,13 +721,20 @@ mtcp_plugin_skip_memory_region_munmap(Area *area, RestoreInfo *rinfo)
   }
 #endif
 
+  // NOTE: Check /proc/self/maps after lh_proxy copied over and MPI_INIT
+  //       A future O/S may have new "special" memory regoins to add here.
   if (mtcp_strstr(area->name, "/dev/shm/mpich") ||
       mtcp_strstr(area->name, "/dev/zero") ||
       mtcp_strstr(area->name, "/dev/kgni") ||
       mtcp_strstr(area->name, "/dev/xpmem") ||
       mtcp_strstr(area->name, "/dev/shm") ||
-      mtcp_strstr(area->name, "/SYS")) {
+      mtcp_strstr(area->name, "/SYS") ||
+      mtcp_strstr(area->name, "/anon_hugepage")) {
     return 1;
+  }
+  if (mtcp_strstr(area->name, "/dev/")) {
+    mtcp_printf("*** WARNING: " __FILE__ ": Consider skipping munmap of %s\n",
+                area->name);
   }
 
   // FROM: lh_proxy:mpi-proxy-split/lower-half/libproxy.c :

--- a/restart_plugin/mtcp_split_process.c
+++ b/restart_plugin/mtcp_split_process.c
@@ -351,7 +351,7 @@ initializeLowerHalf(RestoreInfo *rinfo)
   updateVdsoLinkmapEntry(rinfo->currentVdsoStart,
                          rinfo->pluginInfo.vdsoLdAddrInLinkMap);
   JUMP_TO_LOWER_HALF(rinfo->pluginInfo.fsaddr);
-  resetMmaps();
+  (*resetMmaps)();
   // Set the auxiliary vector to correspond to the values of the lower half
   // (which is statically linked, unlike the upper half). Without this, glibc
   // will get confused during the initialization.


### PR DESCRIPTION
This is joint work between @karya0 and @gc00.
* This fixes a 'JWARNING' in 'recordPostMpiInitMaps()' to cast to '*void*)'.
* This fixes PR $323 for mmap64.c:resetMmappedList() to reserve the lh_memRange in advance.  Thsi works now, with the fix to 'JWARNING'.
* A comment was added to restart_plugin/mtcp_split_process.c:initializeLowerHalf() to better explain what happens during restart when a child is fored, exec'ed to execute lh_proxy, copied back into the parent address space, and then initialized in the current (parent) process