### PR TITLE
gdb-dmtcp-utils: (gdb) load-symbols-library #GDBv8

### DIFF
--- a/util/gdb-dmtcp-utils
+++ b/util/gdb-dmtcp-utils
@@ -24,12 +24,16 @@ import textwrap
 # This adds a GDB command:  add-symbol-files-all    (no arguments)
 # To use it, either do:
 #     gdb -x gdb-dmtcp-utils TARGET_PROGRAM PID
-#     (gdb) add-symbol-files-all
 # OR:
 #     gdb attach PID
 #     (gdb) source gdb-dmtcp-utils
-#     (gdb) add-symbol-files-all
 #       [ TIP: You can also add 'source gdb-dmtcp-utils' to ~/gdbinit ]
+# Then you can try either of:
+#     (gdb) add-symbol-files-all  # Better for older GDB versions
+#     (gdb) load-symbols  # Better for newer GDB versions
+#     (gdb) load-symbols-library ADDR_OR_FILE  # Better for newer GDB versions
+#            [Deletes prev. symbols; add-symbols-files-all will no longer work]
+
 # This also adds GDB commands:
 #     (gdb) dmtcp [or DMTCP]  # Prints out a list of available GDB commands for DMTCP.
 #     (gdb) procmaps
@@ -40,6 +44,8 @@ import textwrap
 #     (gdb) lsof
 #     (gdb) rlimit
 #     (gdb) signals
+#     (gdb) load-symbols [FILENAME]
+#     (gdb) load-symbols-library [FILENAME_OR_ADDRESS]
 #     (gdb) add-symbol-file-from-filename-and-address FILENAME ADDRESS
 #         (Needed if FILENAME not listed in procmaps;
 #          Better version of add-symbol-file; ADDRESS anywhere in memory range)
@@ -48,9 +54,12 @@ import textwrap
 #                                   (e.g., add-symbol-file-from-substring libc)
 #     (gdb) add-symbol-file-at-address MEMORY_ADDRESS
 #                                   (e.g., add-symbol-file-at-address 0x400000)
+#     (gdb) ...
+## To interactively test and modify these commands:  (gdb) python-interactive
+## Executing GDB commands:  gdb.execute(), gdb.parse_and_eval()
 
-dmtcp_commands = "add-symbol-files-all, " +\
-  "add-symbol-file-from-filename-and-address, " +\
+dmtcp_commands = "load-symbols, load-symbols-library, " +\
+  "add-symbol-files-all, add-symbol-file-from-filename-and-address, " +\
   "add-symbol-file-from-substring, add-symbol-file-at-address, " +\
   "show-filename-at-address (OR: whereis-address), " +\
   "procmaps, procfd, procfdinfo, procenviron, pstree, lsof, rlimit, signals"
@@ -64,10 +73,74 @@ def print_dmtcp_commands():
   print(textwrap.fill(dmtcp_commands, break_on_hyphens=False,
                       initial_indent="    ", subsequent_indent="    "))
 
+def is_recent_gdb():
+  if not hasattr(is_recent_gdb, "value"):
+    if "[-o OFF]" in gdb.execute("help symbol-file", False, True):
+      is_recent_gdb.value = True
+    else:
+      is_recent_gdb.value = False
+  return is_recent_gdb.value
+def load_symbols(exec_file=None):
+  if not is_recent_gdb():
+    print("Older GDB; use add-symbol-files-all (This GDB is version: " +
+          gdb.VERSION + ")")
+    return
 
-def is_executable(filename):
+  if exec_file:
+    exec_files = [exec_file]
+  else:
+    exec_files = []
+    for (filename, _, _, _) in memory_regions_executable():
+      exec_files += [filename]
+    exec_files = [filename for filename in exec_files
+                           if is_exec_file(filename)]
+
+  if len(exec_files) == 1:
+    # Accept the first matching address even if not the text segment:
+    exec_address = next(address
+                        for (filename, address, _, _) in memory_regions()
+                        if filename == exec_files[0])
+    gdb.execute("file " + exec_files[0])
+    gdb.execute("symbol-file -o " + str(exec_address) + " " + exec_files[0])
+  elif len(exec_files) > 1:
+    print("Multiple exec-files found: " + str(exec_files) + "\n")
+    print("Call 'load-symbols EXEC_FILE' for the primary executable file.\n")
+  else: # else len(exec_files) == 0
+    print("No exec-files found\n")
+def load_symbols_library(filename_or_address):
+  if not is_recent_gdb():
+    print("Older GDB; use add-symbol-file-from-substring (GDB is version: " +
+          gdb.VERSION + ")")
+    return
+  filename = filename_or_address
+  if cast_to_memory_address(filename) != None: # if this is a valid address:
+    (filename, _, _, _) = memory_region_at_address(filename)
+  # If filename is a substring, search for full filename in /proc/self/maps
+  candidates = [(f, addr) for (f, addr, _, _) in memory_regions()
+                          if filename in f]
+  if candidates: # If we have a valid filename.
+    (filename, start_addr) = candidates[0]
+    if is_exec_file(filename):
+      # ELF executables already have hard-wired absolute address
+      print("EXECUTABLE FILE:")
+      add_symbol_files_from_filename(filename, 0)
+    else:
+      gdb.execute("add-symbol-file -o " + str(start_addr) + " " + filename)
+  else:
+    print("No matching FILENAME_OR_ADDRESS found\n")
+
+
+def is_exec_file(filename):
   if not os.path.exists(filename):
+    print("**** path");print("\n")
     return False
+  tmp = filename
+  tmp = tmp[0 if "/" not in tmp else tmp.rindex("/")+1:] 
+  if (tmp.startswith("lib") or tmp.startswith("ld")) and ".so" in tmp:
+    return False  # This is a library
+  return os.access(filename, os.X_OK)
+
+  #### FIXME:  Remove the rest when this is working.
   # 16 bytes for ELF magic number; then 2 bytes (short) for ELF type
   header = open(filename, "rb")
   elf_magic_number = header.read(16)
@@ -76,6 +149,7 @@ def is_executable(filename):
   elf_type = elf_type[0] if sys.byteorder == "little" else elf_type[1]
   # Handle both Python2.7 and Python3: type 2 is executable; type 3 is .so file
   elf_type = elf_type if isinstance(elf_type, int) else ord(elf_type)
+  header.read(6) # Skip next 6 bytes
   return elf_type == 2
 
 # FROM: https://stackoverflow.com/questions/33049201/gdb-add-symbol-file-all-sections-and-load-address
@@ -120,11 +194,14 @@ class dmtcp(gdb.Command):
 
   def invoke(self, dummy_args, from_tty):
     print_dmtcp_commands()
+# This will add the new gdb command: dmtcp
 dmtcp()
-try:
-  gdb.execute("DMTCP")
-except gdb.error:
-  gdb.execute("alias DMTCP=dmtcp")
+
+gdb.execute("dmtcp")
+# try:
+#   gdb.execute("alias DMTCP=dmtcp")
+# except:
+#   pass
 
 class AddSymbolFileFromSubstring(gdb.Command):
   """add-symbol-file-from-substring FILENAME_SUBSTRING"""
@@ -179,17 +256,22 @@ class ShowFilenameAtAddress(gdb.Command):
         else:
           memory_region = "%s 0x%x-0x%x (%s)" % \
                           memory_region_at_address(memory_address)
-          #GDB-8:  For some unknown reason (e.g., after: 'bt' and 'frame 4' in MANA),
-          #  the 'gdb.execute' reports '"' not allowed, and (') doesn't work.
-          #  Perhaps it's an interaction between GDB and the Python API.
+          #GDB-8:  For some unknown reason (e.g., after: 'bt' and 'frame 4'
+          #  in MANA), the 'gdb.execute' reports '"' not allowed,
+          #  and (') doesn't work.  Perhaps it's an interaction
+          #  between GDB and the Python API.
           #WAS: gdb.execute('print "' + memory_region + '"', False, False)
           print(memory_region)
 # This will add the new gdb command: show-filename-at-address MEMORY_ADDRESS
 ShowFilenameAtAddress()
+# try:
+#   gdb.execute("whereis-address 0x0")
+# except gdb.error:
+#   gdb.execute("alias whereis-address=show-filename-at-address")
 try:
-  gdb.execute("whereis-address 0x0")
-except gdb.error:
   gdb.execute("alias whereis-address=show-filename-at-address")
+except:
+  pass
 
 
 class AddSymbolFileAtAddress(gdb.Command):
@@ -234,10 +316,44 @@ class AddSymbolFilesAll(gdb.Command):
 AddSymbolFilesAll()
 
 
+class LoadSymbols(gdb.Command):
+    """load-symbols [FILENAME] (load fresh symbols from /proc/self/maps)"""
+
+    def __init__(self):
+        super(LoadSymbols,
+              self).__init__("load-symbols",
+                             gdb.COMMAND_FILES, gdb.COMPLETE_FILENAME)
+        self.dont_repeat()
+
+    def invoke(self, filename, from_tty):
+        if filename:
+          filename = os.path.abspath(filename)
+          load_symbols(filename.split()[0])
+        else:
+          load_symbols()
+# This will add the new gdb command: load-symbols
+LoadSymbols()
+
+
+class LoadSymbolsLibrary(gdb.Command):
+    """load-symbols-library [FILENAME-OR-ADDRESS] (load symbols from library)"""
+
+    def __init__(self):
+        super(LoadSymbolsLibrary,
+              self).__init__("load-symbols-library",
+                             gdb.COMMAND_FILES, gdb.COMPLETE_FILENAME)
+        self.dont_repeat()
+
+    def invoke(self, filename_or_address, from_tty):
+        load_symbols_library(filename_or_address.split()[0])
+# This will add the new gdb command: load-symbols-library
+LoadSymbolsLibrary()
+
+
 def add_symbol_files_from_filename(filename, base_addr):
   if not os.path.exists(filename):
     return
-  if is_executable(filename):
+  if is_exec_file(filename):
     base_addr = 0  # ELF executables already have hard-wired absolute address
   (textaddr, sections) = relocatesections(filename)
   cmd = "add-symbol-file %s 0x%x" % (filename, int(textaddr, 16) + base_addr)
@@ -255,8 +371,8 @@ def getpid():
 def usingCore():
   # In Linux 4.12, gdb 8.3, our getpid()==1,
   #   /proc/1/maps has read permission, but "Permission denied"
-  return (not os.path.exists("/proc/" + str(getpid()) + "/maps" or
-          getpid() != 1))
+  return (not os.path.exists("/proc/" + str(getpid()) + "/maps") or
+          getpid() == 1)
 
 class Procmaps(gdb.Command):
   """procmaps (same as:  shell cat /proc/INFERIOR_PID/maps)"""
@@ -425,10 +541,10 @@ def memory_region(filename_substring):
     return ("", 0, 0, "")
 
 
-def memory_region_at_address(memory_address):
+def cast_to_memory_address(memory_address):
   if type(memory_address) == int:
     memory_address = hex(memory_address)  # This converts it to a hex string.
-  if "0x" in memory_address:
+  elif "0x" in memory_address:
     memory_address = hex(int(str(gdb.parse_and_eval(memory_address))))
   elif set(str(memory_address)).issubset("0123456789abcdef"):
     if set(str(memory_address)) & set("abcdef"):
@@ -436,7 +552,12 @@ def memory_region_at_address(memory_address):
       memory_address = "0x" + memory_address
     else:
       print("Assuming " + memory_address + " is decimal. Prepend '0x' for hex.")
-  memory_address = int(memory_address, 0)
+  else:
+    return None
+  return int(memory_address, 0)
+
+def memory_region_at_address(memory_address):
+  memory_address = cast_to_memory_address(memory_address)
   regions = memory_regions()
   match = [region for region in regions
            if memory_address >= region[1] and memory_address < region[2]]


### PR DESCRIPTION
* Somewhere around GDB-v8 (or some Linux kernel), (gdb) add-symbol-files-all no longer sufficed to see symbols in GDB.
 * GDB-v8 introduced the option '[-o OFF]' for the GDB commands 'symbol-file' and 'add-symbol-file'.  'load-symbols'uses '[-o OFF]' with 'symbol-file EXEC_FILE' to replace all symbols. With no argument, 'load-symbols' guesses the EXEC_FILE.
 * For the sake of debugging split processes on restart: (gdb) symbol-file -o OFF UPPER_HALF_EXEC_FILE 
     (gdb) load-symbols
     (gdb) load-symbols-file LIBRARY
  EQUIVALENT TO:
     (gdb) load-symbols -o OFF UPPER_HALF_EXEC_FILE
     (gdb) add-symbol-file -o OFF LOWER_HALF_LIBRARY.so