### PR TITLE
Use exec at end of mana_launch/restart scripts

### DIFF
--- a/bin/mana_launch
+++ b/bin/mana_launch
@@ -178,8 +178,8 @@ fi
 #   The /dev/xpmem segments are created on demand when an MPI call
 #   needs to send/receive a large message.
 
-env LD_LIBRARY_PATH="$libdir:$LD_LIBRARY_PATH" \
-    $dir/dmtcp_launch --mpi --coord-host $submissionHost \
+exec env LD_LIBRARY_PATH="$libdir:$LD_LIBRARY_PATH" \
+    $dir/dmtcp_launch --coord-host $submissionHost \
           --coord-port $submissionPort --no-gzip \
           --join-coordinator --disable-dl-plugin \
           --with-plugin $libdir/libmana.so $options

--- a/bin/mana_restart
+++ b/bin/mana_restart
@@ -122,7 +122,7 @@ if [ "$verbose" == 1 ]; then
   set -x
 fi
 
-$dir/dmtcp_restart  --mpi --join-coordinator \
+exec $dir/dmtcp_restart  --mpi --join-coordinator \
                     --coord-host $submissionHost --coord-port $submissionPort \
                     $options
 


### PR DESCRIPTION
Using 'exec' at end of scripts for 'ana_launch' and 'mana_restart'.

By doing this, we have one less process.  (The bash script execs into the MANA process.)  So, there are fewer mistakes in identifying the running MANA process.