### PR TITLE
MPI_MANA_Internal: Called in lh on restart (debug)

### DIFF
--- a/mpi-proxy-split/lower-half/libproxy.c
+++ b/mpi-proxy-split/lower-half/libproxy.c
@@ -46,6 +46,8 @@
 #include "../cartesian.h"
 #endif
 
+extern int MPI_MANA_Internal(char *dummy);
+
 #include "libproxy.h"
 #include "mpi_copybits.h"
 #include "procmapsutils.h"
@@ -241,6 +243,13 @@ getVdsoPointerInLinkMap()
     map = map->l_next;
   }
   return NULL;
+}
+
+
+// This does nothing, unless modified.  See mpi-wrappers/mpi_wrappers.cpp for
+// its definition, and how to use it for debugging lower half during restart.
+int MPI_MANA_Internal(char *dummy) {
+  return 0;
 }
 
 #ifdef SINGLE_CART_REORDER

--- a/mpi-proxy-split/lower-half/libproxy.h
+++ b/mpi-proxy-split/lower-half/libproxy.h
@@ -402,6 +402,7 @@ do {                                                                           \
   MACRO(Win_wait), \
   MACRO(Wtick), \
   MACRO(Wtime), \
+  MACRO(MANA_Internal), \
   MACRO(Aint_diff),
 
 #endif // define _LIBPROXY_H

--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -60,6 +60,8 @@
 #include "protectedfds.h"
 #include "procselfmaps.h"
 
+extern "C" int MPI_MANA_Internal(char *dummy);
+
 using namespace dmtcp;
 using dmtcp::kvdb::KVDBRequest;
 using dmtcp::kvdb::KVDBResponse;
@@ -1085,6 +1087,10 @@ mpi_plugin_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
       updateVdsoLinkmapEntry(lh_info.vdsoLdAddrInLinkMap);
       dmtcp_local_barrier("MPI:Reset-Drain-Send-Recv-Counters");
       resetDrainCounters(); // p2p_drain_send_recv.cpp
+      char str[1];
+      MPI_MANA_Internal(str); // This does nothing.  Modify in lower-half
+                             // for easy debugging of lower half during restart.
+                             // See definition in mpi-wrappers/mpi_wrappers.cpp
       mana_state = RESTART_REPLAY;
 #ifdef SINGLE_CART_REORDER
       dmtcp_global_barrier("MPI:setCartesianCommunicator");

--- a/mpi-proxy-split/mtcp_split_process.h
+++ b/mpi-proxy-split/mtcp_split_process.h
@@ -478,7 +478,8 @@ typedef int (*libcFptr_t) (int (*main) (int, char **, char ** MAIN_AUXVEC_DECL),
   MACRO(Win_unlock_all) \
   MACRO(Win_wait) \
   MACRO(Wtick) \
-  MACRO(Wtime)
+  MACRO(Wtime) \
+  MACRO(MANA_Internal)
 
 #define GENERATE_ENUM(ENUM) MPI_Fnc_##ENUM,
 #define GENERATE_FNC_PTR(FNC) &MPI_##FNC,


### PR DESCRIPTION
This defines a function, MPI_MANA_internal(char *) that calls the same function in the lower half.  The lower-half function normally does nothing.

This is useful for debugging.  You can keep the checkpoint image, and just modify this function in the lower-half to test something in the lower-half environment.

See the comments in the code:
```
// In mpi-proxy-split/lower-half, redefine MPI_MANA_Internal()
//   to do whatever is desired.  Then do:
//   rm bin/lh_proxy
//   module list # Verify the correct 'module' settings
//   make -j mana
//   bin/mana_coordinator
//   bin/mana_restart
```