### PR TITLE
Extend restart_plugin/README with more detail

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,3 @@
-@SET_MAKE@
 LN_S=@LN_S@ -f
 MKDIR_P=@MKDIR_P@
 CC=@CC@

--- a/README.md
+++ b/README.md
@@ -3,18 +3,27 @@
 MANA is an implementation of transparent checkpointing for MPI.  It is
 built as a plugin on top of [DMTCP](https://github.com/dmtcp/dmtcp).
 
-We are currently concentrating on making MANA robust (especially on Cori
-and Perlmutter at NERSC).  We plan to roll this ot to other platforms
-(CentOS 7 with MPICH, etc.), over time.  If you have the technical expertise
-to help in this rollout, help is appreciated.  Please see the README.md
-file, below, for further details.  Note that MANA currently requires
-the ability to create a statically linked MPI executable (using `libmpi.a`).
-In a later phase, this restriction will be lifted.
+We are currently concentrating on making MANA robust (with special
+testing on Perlmutter at NERSC, and now on CentOS&nbsp;7), using Slurm.
+If you have the technical expertise and interest, we welcome more
+collaborators.
 
-**Warning!** MANA currently may have large runtime overhead or loss
-of accuracy on restart.  This is still under development.  Please test
-your application on MANA first, before using MANA.
+Please see the README.md file, below, for further details.  Note that
+MANA currently requires the ability to create a statically linked MPI
+executable (using `libmpi.a`).  In a later phase, this restriction will
+be lifted.
 
 For details of installing and using MANA, please see:
 - [MANA README file](mpi-proxy-split/README.md)
 - [the MANA 'man' page](manpages/mana.1.md) (or `man ./mana.1` on a local copy)
+
+For technical details, see:
+* "Implementation-Oblivious Transparent Checkpoint-Restart for MPI",
+  Yao Xu, Leonid Belyaev, Twinkle Jain,
+    Derek Schafer, Anthony Skjellum, Gene Cooperman, SuperCheck-SC23 Workshop
+	at SC'23.
+  (production version of MANA)
+* "MANA for MPI: MPI-Agnostic Network-Agnostic Transparent Checkpointing",
+  Rohan Garg, Gregory Price, and Gene Cooperman, HPDC'19.
+  (original academic prototype)
+* [MANA internals for restart](restart_plugin/README)

--- a/manpages/mana.1
+++ b/manpages/mana.1
@@ -7,8 +7,8 @@
 \f[B]mana\f[R] \[en] MANA family of commands for checkpointing MPI jobs
 .SH SYNOPSIS
 .PP
-\f[B]mana_launch\f[R] [--help] [--verbose] [DMTCP_OPTIONS] [--ckptdir
-\f[I]DIR\f[R]] COMMAND [\f[I]ARGS\&...\f[R]]
+\f[B]mana_launch\f[R] [--help] [--verbose] [--timing] [DMTCP_OPTIONS]
+[--ckptdir \f[I]DIR\f[R]] COMMAND [\f[I]ARGS\&...\f[R]]
 .PD 0
 .P
 .PD
@@ -44,6 +44,10 @@ Show additional DMTCP_OPTIONS for a MANA command.
 \f[B]\f[R]\f[C]--verbose\f[R]\f[B]\f[R]
 Display the underlying DMTCP command and DMTCP_OPTIONS used, and other
 info.
+.TP
+\f[B]\f[R]\f[C]--timing\f[R]\f[B]\f[R]
+Print times to stderr for INIT, EXIT, and ckkpt-restart events.
+(stays active during both mana_launch and mana_restart)
 .SH MANA PROGRAM EXECUTION
 .PP
 Execute a MANA command with \f[C]--help\f[R] for a usage statement.
@@ -139,6 +143,20 @@ then execute \f[C]mana_p2p_update_logs\f[R] and set this variable before
 (Currently, you need to set this before \f[C]mana_launch\f[R], but this
 may be fixed later.)
 .PP
+\f[B]\f[CB]MANA_USE_ALLREDUCE_REPRODUCIBLE\f[B]\f[R]
+.PP
+When MPI_Allreduce specifies an associative/commutative operation, the
+MPI library must choose an ordering of the operation during reduce.
+The ordering may vary when calling MPI_Allreqduce after launch or after
+replay.
+By setting the environment variable MANA_USE_ALLREDUCE_REPRODUCIBLE at
+the time of launch, you can direct MANA to call the operations in a
+deterministic order, so that the output after checkpoint-restart will
+produce the same output as running after launch with no
+checkpoint-restart.
+.PP
+\f[B]\f[CB]INSPECTING MANA for DEBUGGING\f[B]\f[R]
+.PP
 To see status of ranks (especially during checkpoint), try:
 .IP
 .nf
@@ -155,12 +173,12 @@ util/readdmtcp.sh ckpt_rank0/ckpt_*.dmtcp
 \f[R]
 .fi
 .PP
-To debug during restart, try:
+To debug during restart at stage `N', replace `N' Below, and execute:
 .IP
 .nf
 \f[C]
-srun ... env DMTCP\[rs]_RESTART\[rs]_PAUSE=1 mana\[rs]_restart ... APPLICATION
-gdb APPLICATION PID  # from a different terminal
+srun ... env DMTCP\[rs]_RESTART\[rs]_PAUSE=N mana\[rs]_restart ... APPLICATION &
+gdb -p APPLICATION PID  # from a different terminal
 \f[R]
 .fi
 .PP
@@ -169,10 +187,9 @@ following:
 .IP
 .nf
 \f[C]
-(gdb) add-symbol-file bin/lh_proxy
 (gdb) source util/gdb-dmtcp-utils
-(gdb) add-symbol-files-all
-(gdb) dmtcp
+(gdb) load-symbol-library ADDRESS-OR-LIBRARY-SUBSTRING
+(gdb) dmtcp  # to see other available commands
 \f[R]
 .fi
 .PP
@@ -183,36 +200,21 @@ If you are debugging the lower half internals of MANA, you may need:
 (gdb) file bin/lh_proxy
 \f[R]
 .fi
+.PP
+If debugging the low-level restart process, please read
+restart/plugin/README.
 .SH BUGS
-.PP
-NOTE: Compiling VASP-5.4.4 uncovered some bugs in the combination of
-\f[C]icpc-19.0.3.199\f[R] and GNU \f[C]gcc\f[R].
-.PP
-The validation results were:
-.IP \[bu] 2
-\f[B]icpc+gcc-7.5.0 (built at NERSC)\f[R]: Fails at runtime on VASP
-\f[C]during restart\f[R] unless configured with:
-.RS 2
-.IP
-.nf
-\f[C]
-\&./configure CXXFLAGS=\[aq]-fno-omit-frame-pointer -fno-optimize-sibling-calls\[aq]
-\f[R]
-.fi
-.RE
-.IP \[bu] 2
-\f[B]icpc+gcc-9.3.0\f[R]: Works correctly
-.IP \[bu] 2
-\f[B]icpc_gcc-10.1.0 (built at NERSC)\f[R]: Fails to link using
-ld-2.35.1
 .PP
 Report bugs in MANA to: https://github.com/mpickpt/mana
 .SH SEE ALSO
 .PP
-\f[B]dmtcp\f[R](1), \f[B]dmtcp_coordinator\f[R](1),
-\f[B]dmtcp_launch\f[R](1), \f[B]dmtcp_restart\f[R](1),
-\f[B]dmtcp_command\f[R](1)
+\f[B]MANA home page:\f[R] <https://github.com/mpickpt/mana>,
 .PD 0
 .P
 .PD
-\f[B]MANA home page:\f[R] <https://github.com/mpickpt/mana>
+\f[B]dmtcp\f[R](1), \f[B]dmtcp_coordinator\f[R](1),
+\f[B]dmtcp_launch\f[R](1),
+.PD 0
+.P
+.PD
+\f[B]dmtcp_restart\f[R](1), \f[B]dmtcp_command\f[R](1)

--- a/mpi-proxy-split/NOTES
+++ b/mpi-proxy-split/NOTES
@@ -1,3 +1,5 @@
+# NOTE: These notes date from 2020, and are slowly becoming obsolete.
+
 ## More detailed notes are here:
 
    https://www.overleaf.com/project/5bb13ac57a2367687c54c68d

--- a/mpi-proxy-split/README.md
+++ b/mpi-proxy-split/README.md
@@ -48,7 +48,7 @@ See `man mana` or `nroff -man MANA_ROOT_DIR/manpages/mana.1` for the MANA man pa
 
 ## 2. Building MANA
 
-   On Perlmutter, unload a few modules which are incompatible with MANA. Not all or fhte modules are currently present.   We also need to load the PMI module.
+   On Perlmutter, unload a few modules which are incompatible with MANA. Not all of the modules are currently present.   We also need to load the PMI module.
    ```bash
    $ module unload cudatoolkit gpu craype-accel-nvidia80
    $ module unload darshan Nsight-Compute Nsight-Systems

--- a/mpi-proxy-split/lower-half/README.mpich-static
+++ b/mpi-proxy-split/lower-half/README.mpich-static
@@ -7,8 +7,17 @@ The MPICH library, at least as packaged in CentOS 7, requires:
   * libxml2: found in libxml2-static package, but often not installed
   * libzma.a: not provided in any package; see instructions below
   * libz.a: found in zlib-static package, but often not installed
-Both of these libraries can be installed in your own account, without
-root privilege.
+All of these libraries can be installed in your own account, without
+root privilege.  Currently, mpi-proxy-split/lower-half/Makefile uses a flag:
+    -L$HOME/mpich-static/usr/lib64
+This directory contains the missing .a libraries.  You may need to modify
+the path to poit to your own local .a libraries.
+
+Depending on how your static MPICH library was compiled, you may find
+that more or fewer extra static libraries are required.
+
+Other MPI implementations (e.g., Open MPI) do not seem to require additional
+static libraries.
 
 You will want to do:  module load mpich  (or build libmpi.a from source)
 
@@ -54,5 +63,6 @@ Then run.  Something like one of:
   ^ srun -N1 -n2 mpirun -np 2 ./a.out
   ^ salloc -N1 -n2
       mpirun -np 2 ./a.out
+  * sbatch (with sbatch script)
 [ At least on the Northeastern Discovery cluster with MPICH in 2021,
-  only the first form works. ]
+  only the first and last forms work. ]

--- a/restart_plugin/README
+++ b/restart_plugin/README
@@ -1,3 +1,21 @@
+The purpose of the restart_plugin directory is to compile an executable,
+bin/mtcp_restart, in the MANA bin subdirectory.  This DMTCP plugin
+replaces the standard dmtcp/bin/mtcp_restart that would be compiled
+from dmtcp/src/mtcp/mtcp_restart.c.
+
+This document is divided into several parts:
+  A.  HOW ARE THESE restart_plugin FILES USED DURING dmtcp_restart/mana_restart?
+  B.  WHAT ARE THE PREREQUISITE CONCEPTS FOR UNDERSTANDING THE RESTART PROCESS?
+  C.  WHAT IS A HIGH-LEVEL OVERVIEW OF THE RESTART PROCESS?
+  D.  WHAT ARE THE FUNCTIONS INVOKED DURING THE RESTART PROCESS?
+  E.  HOW ARE THE RESERVED MEMORY REGIONS COMPUTED?
+        [libsStart, libsEnd]+[highMemStart/STACK, highMemEnd]
+  F.  WHAT ARE SOME TOOLS FOR DEBUGGING THE RESTART PROCESS?
+  G.  HOW SHOULD ONE DEBUG MANA ISSUES THAT OCCUR AFTER RESTART?
+
+=============================================================================
+A.  HOW ARE THESE restart_plugin FILES USED DURING dmtcp_restart/mana_restart?
+
 When ./configure-mana is called in MANA, it calls ./configure, which
 in turn configures the DMTCP submodule as:
   ./configure ... --enable-debug CFLAGS=-fno-stack-protector CXXFLAGS=-fno-stack-protector MPI_BIN=/usr/local/bin ...  --with-mana-helper-dir=../restart_plugin --disable-dlsym-wrapper ...
@@ -13,11 +31,113 @@ ifneq ($(MANA_HELPER_DIR),)
   OBJS += mtcp_restart_plugin.o mtcp_split_process.o getcontext.o
   CFLAGS += -DMTCP_PLUGIN_H="<lower_half_api.h>"
   INCLUDES += -I$(MANA_HELPER_DIR)
-endif 
+endif
 
 (Note that MANA_HELPER_DIR was set by ./configure using --with-mana-helper-dir.)
 
-====
+=============================================================================
+B.  WHAT ARE THE PREREQUISITE CONCEPTS FOR UNDERSTANDING THE RESTART PROCESS?
+  MANA uses a split-process technique.
+  During launch:
+    The MPI application starts normally.  When it
+  calls MPI_Init/MPI_Init_thread, it invokes
+  mpi-proxy-split/split_process.cpp to create a child proxy process which
+  execs into the lh_proxy program (defined in the lower-half directory).
+  The child then pauses during initialization, while the parent "copies
+  the bits" of the child into the parent.  The parent then initializes
+  the lower-half program that was copied into the current process.
+
+  During restart:
+    The mtcp_restart application (compiled with files from dmtcp/src/mtcp
+  and files from the restart_plugin directory) then calls
+  restart_plugin/mtcp_split_process.c, which carries out operations
+  similar to those invoked during launch.  Then, it calls MPI_Init or
+  MPI_Init_thread to get an MPI rank.  Finally, it restores the upper half.
+  from the checkpoint image corresponding to that rank.
+
+  Data structures:
+    In order to accomplish this, there are three data structures to maintain:
+
+  a. rinfo: traditional DMTCP struct saved in header of ckpt image at the
+            time of ckpt, and then extracted from header during mtcp_restart.
+
+  b. lh_info:  a struct created by the child process executing lh_proxy.
+              During launch, this is copied into the upper half via
+            the code in mpi-proxy-split/split_process.cpp.
+              During restart, this is copied into the mtcp_restart program
+            and after restoring the upper half, it should be copied to
+            the upper half.  [We cheat here.  Since lh_proxy is statically
+            linked and set ADDR_NO_RANDOMIZE to true, the restarted
+            upper half can use the lh_proxy found in its restored memory,
+            which should be identical to the one seen in mtcp_restart.]
+              The lh_info struct contains information allowing the upper
+            half to detect the memory regions of lh_proxy, and avoid saving
+            them during checkpoint.  After all, we want a fresh lh_proxy
+            (lower half) at the time of the eventual restart.
+              Finally, when mtcp_restart munmap's all memory regions outside
+            of mtcp_restart itself, it calls
+            mtcp_plugin_skip_memory_region_munmap() on each memory "area",
+            to determine if the area is part of the lh_proxy program
+            (part of the lower half).  If so, it skips munmap'ing that
+            memory "area".  In order to decide if the area is part of
+            lh_proxy, it must use information from the lh_info struct,
+            which was passed from the child proxy process into the
+            lower half (the lh_proxy memory regions).
+
+  c. pluginInfo:  At the time of checkpoint, each MPI process reports to the
+            DMTCP coordinator an address range that includes the addresses
+            of all of its memory regions.  This includes the memory regions
+            for the upper-half libraries and for memory near the stack.
+            The DMTCP coordinator has a kvdb (key-value database) inspired
+            by Redis, which computes a superset of the memory regions
+            (e.g., minLibsStart and maxLibsEnd), and returns that back
+            to the MPI process at the time of checkpoint.  Those addresses
+            are then saved in a pluginInfo struct, which is saved in the
+            header of the checkpoint image.
+              At the time of restart, the pluginInfo struct is extracted
+            from the header of the checkpoint image, and used to decide
+            what memory regions must be reserved for when the upper half
+            will be restored.  The mtcp_restart program then uses this
+            information to temporarily mmap these regions before calling
+            MPI_Init or MPI_Init_thread.  So, any shm, /dev/xpmem, and
+            other special memory regions are forced into other addresses.
+            Then the temporarily mmap'ed regions are munmap'ed, and the
+            upper half is restored from the checkpoint image.
+              After this, the pluginInfo struct is no longer needed.
+
+=============================================================================
+C.  WHAT IS A HIGH-LEVEL OVERVIEW OF THE RESTART PROCESS?
+  The order of operations is:
+    1. DMTCP (dmtcp_restart/mana_restart) calls mtcp_restart, which
+    invokes
+         mtcp_plugin_hook() in this dir.
+    2. This calls mtcp_split_process.c:splitProcess() in this dir.
+    3. Fork a child lh_proxy process.  It will stop deep inside the
+    _start fnc.  4. Use 'copy-the-bits' to copy the memory into the
+    parent process.
+       We are now executing in mpi-proxy-split/lower-half (but in
+       upper half)
+    5. Call reset (*resetMmappedListFptr)() to reset any regions that
+         were mmap'ed back to all zero.
+    6. Call __libc_start_main() to finish initializing libc and stop
+         at main.
+    7. Call (*getRankFptr)(), which calls MPI_Init and MPI_Comm_rank
+         in the lower half.
+    8. We now know our rank, and therefore the correct upper-half ckpt
+         image file to restore.. We return to mtcp_plugin_hook(), and
+         then to mtcp_restart, and restore the upper-half memory of the
+         chosen file.
+
+  NOTE: For historical reasons, the upper-half and lower-half sometimes
+    still use different variable names for the equivalent variables.
+    For a translation between the two, see:
+      mpi-proxy-split/lower-half/mmap_internal.h
+  FIXME:  When MANA is more stable, we need to do a PR to rename variables
+    to correspond in the lower and upper half.
+
+=============================================================================
+D.  WHAT ARE THE FUNCTIONS INVOKED DURING THE RESTART PROCESS?
+
 When MANA restarts using mana_restart, the relevant logic is found in the
 files of this directory (at the time of restart) and
 ../mpi-proxy-split/mpi_plugin.cpp (earlier at the time of checkpoint).
@@ -27,22 +147,27 @@ MTCP header of each checkpoint image at the time of checkpoint.
 
 At the time of checkpoint, control comes to:
   ../mpi-proxy-split/mpi_plugin.cpp:computeUnionOfCkptImageAddresses()
-    (i) which computes libsStart, libsEnd, highMemStart
+    (i) which computes libsStart, libsEnd, highMemStart, highMemEnd
     (ii) and saves it in the MTCP header of the checkpoint image,
-    (iii) such that [libsStart, libsEnd]+[highMemStart, STACK] should
-          cover all memory regions of the upper half for every rank.
+    (iii) such that [libsStart, libsEnd]+[highMemStart/STACK, highMemEnd]
+          should cover all memory regions of the upper half for every rank.
 
 At the time of restart, control comes to:
   ../dmtcp/src/mtcp/mtcp_restart.c:main() ->
-  mtcp_restart_plugin.c:mtcp_plugin_hook() ->
-  mtcp_split_process.c:splitProcess() -> 
-  mtcp_split_process.c:initializeLowerHalf() -> 
-    (i) mtcp_split_process.c:splitProcess()
-          // forks proxy process for lower half
-          // and then copies it into cur. process
-    (ii) initializes the lower half with libc_start_main (now that it is
-         in the current process)
-    (iii) returns to 'splitProcess()', which returns to 'mtcp_plugin_hook()':
+      // which reads the rinfo (restore info) from the ckpt header, and calls:
+  mtcp_restart_plugin.c:mtcp_plugin_hook(RestoreInfo *rinfo) ->
+  mtcp_split_process.c:splitProcess(RestoreInfo *rinfo) ->
+    mtcp_split_process.c:startProoxy(); // forks proxy process for lower half
+                                    // child/lh_proxy stops at libc_start_main()
+    mtcp_split_process.c:setLhMemRange() [ called by parent after 'fork()'
+           // Chooses lh_mem_range based on  rinfo->minHighMemStart (see above)
+    mtcp_split_process.c:read_lh_proxy_bits(); // copies child into cur. process
+    // kills the child process (child has been copied into cur. (parent) process
+    mtcp_split_process.c:initializeLowerHalf() ->
+      (i) call mmap64.c:resetMmappedList()
+      (ii) initializes the lower half by calling its __libc_start_main (now that
+           it has been copied into the parent (current) process)
+      (iii) returns to 'splitProcess()', which returns to 'mtcp_plugin_hook()':
   mtcp_restart_plugin.c:mtcp_plugin_hook() ->
     (i) We finished 'splitProcess()', above.
     (ii) reserve_fds_upper_half()
@@ -64,10 +189,37 @@ At the time of restart, control comes to:
     (ii) Control passes to program counter and stack from time of checkpoint
     (iii) The upper half then rebinds MPI wrappers, etc.
 
-====
+=============================================================================
+E.  HOW ARE THE RESERVED MEMORY REGIONS COMPUTED?
+      [libsStart, libsEnd]+[highMemStart/STACK, highMemEnd]
+In ../mpi-proxy-split/mpi_plugin.cpp:computeUnionOfCkptImageAddresses()
+we try to compute a minLibsStart, maxLibsEnd, minHighMemStart, maxHighMemEnd
+In this way, we are reserving a superset (over all ranks) of the memory
+that will be used by the upper half when the upper half memory is later
+restored.  All of upper half memory for any ckpt image file should always
+fit within that range.  (And you can use readdmtcp.sh to see if a ckpt
+image fits within the given range.
+
+The way that minHighMemStart (and others) are computed is that just before
+ckpt (in mp-proxy-split/mpi_plugin.cpp ), each MPI rank computes its own
+highMemStart.  It then uses the DMTCP kvdb (key-value database) to send
+the value to the DMTCP coordinator, which does a 'min' across values sent
+by all ranks.  In mpi_plugin.cpp, they then read back from the kvdb the
+minimum value, and store it as minHighMemStart in the ckpt image header.
+(And similarly, it computes a 'max' for 'libsEnd', etc.)
+In mpi_plugin.cpp:DMTCP_EVENT_PRECHECKPOINT, save_mana_header(file)
+saves these values into the header of the checkpoint image file.
+At the time of restart, that header is read back in, and we use:
+  [libsStart, libsEnd]+[highMemStart/STACK, highMemEnd]
+to reserve memory before calling MPI_Init.
+
+=============================================================================
+F.  WHAT ARE SOME TOOLS FOR DEBUGGING THE RESTART PROCESS?
+
 DEBUGGING mana_restart:
-  Note that the coordinator dumps a *.json file in the directory where the
-    coordinator was launched, at the time of checkpoint (and during restart).
+  Note that the coordinator dumps a dmtcp_coordinator_db_*.json file in the
+    directory where the coordinator was launched, at the time of
+    checkpoint (and during restart).
     The checkpoint version includes:
       libsStart, libsEnd, highMemStart, and the /proc/*/maps during checkpoint.
   This can be used to verify that [libsStart, libsEnd]+[highMemStart, STACK]
@@ -77,3 +229,175 @@ DEBUGGING mana_restart:
     checkpoint image file, with the /proc/self/maps when afterward executing
     the statement 'case DMTCP_EVENT_RESTART:' in the file
     ../mpi-proxy-split/mpi_plugin.cpp.
+
+  Another tool is dmtcp/util/readdmtcp.sh [ckpt_rank*/ckpt_*.dmtcp]
+    One can choose one of the matching files and call readdmtcp.sh to
+    determine the memory regions that are saved in the checkpoint image file.
+
+  Upon finishing mtcp_plugin_hook(), we restore the upper-half memory
+    in mtcp_restart.c.  We can change dmtcp/src/mtcp/mtcp_util.h
+    to set '#define LOGGING'.  This causes DPRINTF in mtcp_restart.c
+    to print debugging information ('D' in DPRINTF for 'Debugging').
+    Then do 'rm bin/mtcp_restart && make mana' to update mtcp_restart
+    while continuing to use the same ckpt image files.
+  Another possibility is to set the environment variable
+    DMTCP_DEBUG_MTCP_RESTART and to specifically set DMTCP_RESTART_PAUSE=1
+    prior to running the mana_restart command.  This stops in a special
+    special debugging session that allows you to attach GDB within
+    mtcp_restart.  (But a second checkpoint-restart from this session
+    may not be possible.)
+
+  Using GDB to test MANA with one MPI rank is especially easy.  Most sites
+    will allow you to test MPI for one rank in an interactive node.  Some
+    typical command lines are as follows.  (And since GDB can't debug scripts,
+    convert a MANA launch/restart script to an executable using 'env'.)
+      bin/mana_coordinator
+      gdb --args env bin/mana_launch mpi-proxy-split/test/wave_mpi.mana.exe
+      bin/mana_coordinator
+      gdb --args env bin/restart # See DMTCP restart environment variables below
+    And within GDB, you'll typically want to do:
+      (gdb) break _exit
+      (gdb) handle SIGUSR2 nostop print pass
+      (gdb) hbreak computeUnionOfCkptImageAddresses()
+      (gdb) break mtcp_plugin_hook
+      (gdb) run  # Run until segfault, if that's what you're debugging.
+    [ Note that we use hbreak for computeUnionOfCkptImageAddresses().
+      The hardware breakpoint is preferred, since the default software
+      breakpoint would embed an illegal instruction in the ckpt image file. ]
+    Next, for GDB at a second ckpt-restart (ckpt-restart-ckpt-restart), add
+        fprintf(stderr, "***At dummy\n"); int dummy=1; while(dummy);
+      to the beginning of computeUnionOfCkptImageAddresses(), recompile MANA,
+      and then go through the ckpt (attach with GDB and create a ckpt image),
+      and then restart from the ckpt image file:  env bin/mana_restart -i2 &
+      and then attach with GDB at the second checkpoint.
+
+  After finishing restoring the upper-half memory, it's useful to stop
+    and attach with GDB.  To do this, try:
+      env DMTCP_RESTART_PAUSE=[NUM] mana_restart
+    or alternatively:
+      mana_restart --debug-restart-pause [NUM]
+    with 'NUM' varying from '1' to '7' to stop at different places in
+    the MANA restart sequence.  Do 'gdb -p [PID]' and 'print dummy=0'.
+    After attaching with GDB, you may need to do 'source util/gdb-dmtcp-utils'
+    and then load-symbols-library [ADDRESS] for some ADDRESS on the
+    stack for which you are not seeing symbol names.
+  NOTE:  If DMTCP/MANA stops due to a DMTCP_RESTART_PAUSE environment
+    variable, and after attaching with GDB, you can set the hidden
+    variable, restartPauseLevel, to a larger integer and continue.
+    This allows you to to step from '1' through '7' in a single session.
+    Similarly, if you stop at '1' (before restoring the upper half), then
+    attach in GDB and 'print dummy=0' to continue into a restored upper half.
+
+  Be sure to compare the 'info proc mappings' or 'cat /proc/[PID]/maps'
+    (a) during normal execution
+    (b) during checkpoint (using 'readdmtcp.sh' or dmtcp_coordinator_db_*.json)
+    (c) during restart at the end of mtcp_plugin_hook() (before restoring mem)
+         [ An easy way to do this is with DMTCP_RESTART_PAUSE=1. ]
+    (d) after restoring upper-half memory (e.g., DMTCP_RESTART_PAUSE=2)
+  The goal is that each memory region is associated with the lower half
+    or else the upper half.  Make sure that no lower-half memory regions
+    are saved in the checkpoint image.  Note that MPI_Init is called
+    _before_ restoring the upper-half memory.  Make sure that no lower-half
+    memory regions created by MPI_Init or the MPI library are unmapped (munmap)
+    when restoring upper-half memory.  Note that:
+      mtcp_restart_plugin.c:mtcp_plugin_skip_memory_region_munmap()
+    is called within mtcp_restart for each existing memory region.
+    It should return 1 (skip munmap) if the memory region is associated
+    with the lower half.  The lower half includes 'lh_core' regions
+    (created when lh_proxy initializes itself), 'mmaps[]' regions
+    (interposed by mmap64.c:mmap64() during MPI calls), and
+    memory regions that might be created through ioctl() instead of mmap()
+    (e.g., possibly such as /anon_hugepages or /dev/xpmem).
+
+  In orer to get a stack trace, consider the following strategies:
+  If DMTCP exits due to a JASSERT failure, the process will have
+  a return code of 99.  You can use '(gb) break _exit' to try to
+  capture the process before it exits.  DMTCP also supports two
+  useful "magic" environment variables  DMTCP_ABORT_ON_FAILIRE' and
+  'DMTCP_SLEEP_ON_FAILIRE', to abort or go into an infinite loop
+  on a JASSERT failure.  (Raise your limit on core dumps to get
+  a core dump with DMTCP_ABORT_ON_FAILIRE'.)  And if Fortran is
+  showing you a Fortran-specific stack that gets in the way, then set
+  FOR_DISABLE_STACK_TRACE.  And for all environment variables, be
+  sure to set them during the initial launch o the application.
+  MANA/DMTCP will restore the original environment variables on restart.
+
+  FIXME:  'getLhRegionsList' should be renamed 'getLhCoreRegionsList'
+
+  FIXME:  In some future version of MANA, it's probably better to
+    determine what are the memory regions of mtcp_restart that _should_
+    be nunmap'ed, rather than skipping the munmap for memory regions
+    that _should not_ be munmap'ed.  This would remove the somewhat
+    arbitrary logic of mtcp_plugin_skip_memory_region_munmap(), which
+    checks for weird things link /dev/xpmem and /anon_hugepages.
+
+  FIXME:  At the time of checkpoint, mpi-proxy-split/mpi_plugin.cpp:
+    has some arbitrary logic in computeUnionOfCkptImageAddresses()
+    to add to the header of the DMTCP ckpt image file:
+      "MANA_MinLibsStart", "MANA_MaxLibsEnd", "MANA_MinHighMemStart", etc.,
+    These are later read back by
+      restart_plugin/dmtcp_restart_plugin.cpp:dmtcp_restart_plugin()
+    We still have to document dmtcp_restart_plugin().
+    This scheme is fragile, since the lower-half MPI library can
+      create an /anon_hugepage memory region for the lower half,
+      and the MPI application code might create an /anon_hugepage memory
+      region for the upper half.  MANA currently assumes that all
+      upper half memory stops at MANA_MinHighMemStart
+      and so any /anon_hugepage (usually created at
+      very high memory: 0x7ffff...) are assumed to belong to the lower half.
+      But an MPI application might allocate its own /anon_hugepage.
+      Although we don't see this as of this writing, we should modify
+      the code to be ready for this.
+
+
+=============================================================================
+G.  HOW SHOULD ONE DEBUG MANA ISSUES THAT OCCUR AFTER RESTART?
+
+  We discuss two typical post-restart problems:  a call to sbrk after restart,
+    and a possible issue with using lh_info.fsaddr to call the lower half.
+
+  After restart, the value of sbrk(0) (end-of-heap) is no longer accurate,
+    since the heap reflects the original mtcp_restart process, and not
+    the MPI target process.  Luckily, most MPI applications allocate memory
+    early in their life.  So, after restart, it is unlikely that they
+    will cause a new malloc request to call sbrk().  (For small malloc's,
+    the malloc arena has not yet been filled up, and for very large malloc's,
+    it will call mmap instead of sbrk.
+  FIXME:  There are several ways to fix this, if this becomes a problem.
+    1. One way is to set the malloc tunables through environment variables.
+       For example, one can set:  MALLOC_MMAP_THRESHOLD_=8192 to prefer
+       mmap over sbrk for medium-size malloc requests.
+    2. Another possible fix is to call malloc on a medium-size allocation
+       before the _first_ checkpoint.  This may force a call to sbrk(),
+       which is safe before the first checkpoint.  After than, one
+       can free the memory allocation, thus creating space for future
+       allocations.
+    3. A third way to interpose on the glibc symbol __GI___sbrk.
+       (__GI___sbrk may or may not be at the same address as sbrk or __sbrk.)
+       It is sysmalloc that calls sbrk through this internal symbol.
+       The symbol __GI___sbrk (and possibly internal calls to __sbrk/sbrk
+       are called in a library-internal manner ("hidden").  If so, one
+       computes the address of __GI___sbrk, and then patches the function.
+       The address of the symbol can be computed in various ways.  One way
+       is to discover the offset from where libc.so was loaded into memory:
+           nm -D /lib/x86_64-linux-gnu/libc.so.6 | grep sbrk
+       (assuming sbrk and __GI__sbrk have the same address).
+       Then add the lowest address of all memory segments for libc.so.
+       Another way to compute the offset of the internal symbol __GI___sbrk,
+       and then compute the offset of a publicly visible symbol,
+       like sbrk.  Then, one adds code to compute at runtime:
+         addressof(__GI_sbrk) = @sbrk + offsetof(__GI_sbrk) - offsetof(sbrk)
+
+  In mpi-proxy-split/split_process.cpp, the lh_info (lower-half information)
+    is allocated:
+      LowerHalfInfo_t lh_info;
+    At the time of launch, this was initialized when the target MPI
+    process forked a child proxy process and copied the bits.  The lh_info
+    was calculated in the lower half, and then copied into the upper half.
+  At the time of restart, we currently depend on setting ADDR_NO_RANDOMIZE
+    in restart_plugin/mtcp_split_process.c.  This was also done during
+    launch, in mpi-proxy-split/split_process.cpp.  This make the restarted
+    lower half deterministic, with the same memory layout as the lower half
+    during launch.
+  FIXME:  It will be safer add code during restart, to copy the
+    re-computed lh_info of the lower half into the upper-half struct.

--- a/restart_plugin/README-old
+++ b/restart_plugin/README-old
@@ -1,0 +1,79 @@
+When ./configure-mana is called in MANA, it calls ./configure, which
+in turn configures the DMTCP submodule as:
+  ./configure ... --enable-debug CFLAGS=-fno-stack-protector CXXFLAGS=-fno-stack-protector MPI_BIN=/usr/local/bin ...  MANA_USE_LH_FIXED_ADDRESS=1 --with-mana-helper-dir=../restart_plugin --disable-dlsym-wrapper ...
+
+Hence, '--with-mana-helper-dir' above points to this directory.
+
+In ../dmtcp/src/mtcp/Makefile.in, it has hardwired MANA-specific code
+to compile the local filenames here as object files in ../dmtcp/src/mtcp:
+
+ifneq ($(MANA_HELPER_DIR),)
+  HEADERS += $(MANA_HELPER_DIR)/mtcp_split_process.h \
+             $(MANA_HELPER_DIR)/ucontext_i.h
+  OBJS += mtcp_restart_plugin.o mtcp_split_process.o getcontext.o
+  CFLAGS += -DMTCP_PLUGIN_H="<mtcp_restart_plugin.h>"
+  INCLUDES += -I$(MANA_HELPER_DIR)
+endif 
+
+(Note that MANA_HELPER_DIR was set by ./configure using --with-mana-helper-dir.)
+
+====
+When MANA restarts using mana_restart, the relevant logic is found in the
+files of this directory (at the time of restart) and
+../mpi-proxy-split/mpi_plugin.cpp (earlier at the time of checkpoint).
+
+mpi_plugin.cpp has written libsStart, libsEnd and highMemStart into the
+MTCP header of each checkpoint image at the time of checkpoint.
+
+At the time of checkpoint, control comes to:
+  ../mpi-proxy-split/mpi_plugin.cpp:computeUnionOfCkptImageAddresses()
+    (i) which computes libsStart, libsEnd, highMemStart
+    (ii) and saves it in the MTCP header of the checkpoint image,
+    (iii) such that [libsStart, libsEnd]+[highMemStart, STACK] should
+          cover all memory regions of the upper half for every rank.
+
+At the time of restart, control comes to:
+  ../dmtcp/src/mtcp/mtcp_restart.c:main() ->
+  mtcp_restart_plugin.c:mtcp_plugin_hook() ->
+  mtcp_split_process.c:splitProcess() -> 
+  mtcp_split_process.c:initializeLowerHalf() -> 
+    (i) mtcp_split_process.c:splitProcess()
+          // forks proxy process for lower half
+          // and then copies it into cur. process
+    (ii) initializes the lower half with libc_start_main (now that it is
+         in the current process)
+    (iii) returns to 'splitProcess()', which returns to 'mtcp_plugin_hook()':
+  mtcp_restart_plugin.c:mtcp_plugin_hook() ->
+    (i) We finished 'splitProcess()', above.
+    (ii) reserve_fds_upper_half()
+         reserveUpperHalfMemoryRegionsForCkptImgs() // mmap memory regions
+                                                    // of future upper half
+    (iii) JUMP_TO_LOWER_HALF()
+    (iv) // MPI_Init is called here. Network memory areas are loaded by MPI_Init
+         // Also, MPI_Cart_create will be called to restore cartesian topology.
+         // Based on the coordinates, checkpoint image is restored instead of
+         // world rank.
+         // This includes /dev/xpmem, *shared_mem*, etc.
+    (v) RETURN_TO_UPPER_HALF()
+    (vi) releaseUpperHalfMemoryRegionsForCkptImgs()
+         unreserve_fds_upper_half()
+    (vii) getCkptImageByRank() // Sets ckpt image for upper half for this rank
+    (viii) returns to ../dmtcp/src/mtcp/mtcp_restart.c:main()
+  ../dmtcp/src/mtcp/mtcp_restart.c:main() ->
+    (i) Load ckpt image file found by 'mtcp_plugin_hook()'
+    (ii) Control passes to program counter and stack from time of checkpoint
+    (iii) The upper half then rebinds MPI wrappers, etc.
+
+====
+DEBUGGING mana_restart:
+  Note that the coordinator dumps a *.json file in the directory where the
+    coordinator was launched, at the time of checkpoint (and during restart).
+    The checkpoint version includes:
+      libsStart, libsEnd, highMemStart, and the /proc/*/maps during checkpoint.
+  This can be used to verify that [libsStart, libsEnd]+[highMemStart, STACK]
+    truly covers all upper-half memory regions.
+  This can also be checked in GDB by comparing /proc/self/maps inside
+    ../dmtcp/src/mtcp/mtcp_restart.c:main() just before it loads the
+    checkpoint image file, with the /proc/self/maps when afterward executing
+    the statement 'case DMTCP_EVENT_RESTART:' in the file
+    ../mpi-proxy-split/mpi_plugin.cpp.

--- a/util/gdb-dmtcp-utils
+++ b/util/gdb-dmtcp-utils
@@ -118,14 +118,14 @@ def load_symbols_library(filename_or_address):
   # If filename is a substring, search for full filename in /proc/self/maps
   candidates = [(f, addr) for (f, addr, _, _) in memory_regions()
                           if filename in f]
-  if candidates: # If we have a valid filename.
+  if candidates and is_exec_file(filename):
+    (filename, _) = candidates[0]
+    # ELF executables already have hard-wired absolute address
+    print("EXECUTABLE FILE:")
+    add_symbol_files_from_filename(filename, 0)
+  else if candidates: # If we have a valid filename, not executable
     (filename, start_addr) = candidates[0]
-    if is_exec_file(filename):
-      # ELF executables already have hard-wired absolute address
-      print("EXECUTABLE FILE:")
-      add_symbol_files_from_filename(filename, 0)
-    else:
-      gdb.execute("add-symbol-file -o " + str(start_addr) + " " + filename)
+    gdb.execute("add-symbol-file -o " + str(start_addr) + " " + filename)
   else:
     print("No matching FILENAME_OR_ADDRESS found\n")
 


### PR DESCRIPTION
This extends `restart_plugin/README` with more details about the sequence of events during MANA restart.  To review it, ignore the github 'diff', and just view the new version of the 'README' file.

@karya0 and @JainTwinkle,
    Could each of you also take a quick look at this README file?
    In addition to suggesting changes, _please do_ suggest additional parts of the restart that should be documented.

One of the reasons that we sometimes have trouble debugging the restart is that even if we once understood the code, we forget it by the next time that we need to debug something.  One of my roles in the collaboration seems to be acting as "secretary"  :-), and updating the documentation.  I'm happy to do that, if this accelerates our debugging sessions.

A second reason for me doing this is that we eventually want to switch from a statically linked lower half to a dynamically linked lower half.  Two students are writing a self-contained prototype based on a  framework provided by @JainTwinkle.  When it comes time to port their prototype to MANA, we will want to review MANA's design, in order to do a clean port from the prototype to MANA.  This  README file should greatly help at that stage, too.

Your careful reviews will help me to ensure that this documentation is easily understood -- even by the two students working on a dynamically linked version of the lower half.