### PR TITLE
Fix PMPI decl. of MPI_Comm_rank (bad orig. decl.)

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
@@ -497,7 +497,7 @@ USER_DEFINED_WRAPPER(int, Comm_create_group, (MPI_Comm) comm,
 }
 
 PMPI_IMPL(int, MPI_Comm_size, MPI_Comm comm, int *world_size)
-PMPI_IMPL(int, MPI_Comm_rank, MPI_Group group, int *world_rank)
+PMPI_IMPL(int, MPI_Comm_rank, MPI_Comm comm, int *world_rank)
 PMPI_IMPL(int, MPI_Abort, MPI_Comm comm, int errorcode)
 PMPI_IMPL(int, MPI_Comm_create, MPI_Comm comm, MPI_Group group,
           MPI_Comm *newcomm)

--- a/mpi-proxy-split/mpi-wrappers/mpi_fortran_wrappers.txt
+++ b/mpi-proxy-split/mpi-wrappers/mpi_fortran_wrappers.txt
@@ -27,7 +27,7 @@ int MPI_Scatterv(const void* sendbuf, const int* sendcounts, const int* displs, 
 int MPI_Scan(const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
 
 int MPI_Comm_size(MPI_Comm comm, int* world_size);
-int MPI_Comm_rank(MPI_Group group, int* world_rank);
+int MPI_Comm_rank(MPI_Comm comm, int* world_rank);
 int MPI_Abort(MPI_Comm comm, int errorcode);
 int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm* newcomm);
 int MPI_Comm_dup(MPI_Comm comm, MPI_Comm* newcomm);


### PR DESCRIPTION
@xuyao0127 and @leonidbelyaev discovered this bug.  The original MANA design for Cray MPI/MPICH didn't care because MPI_Comm and MPI_Group were both int's.  Applying MANA to other MPI's exposed this bug.