### PR TITLE
Warn the end user if no more lower-half memory is available for mmap

### DIFF
--- a/mpi-proxy-split/lower-half/mmap64.c
+++ b/mpi-proxy-split/lower-half/mmap64.c
@@ -199,8 +199,15 @@ getNextAddr(size_t len)
   // Move the pointer to the next free address
   nextFreeAddr = (char*)curr + ROUND_UP(len) + PAGE_SIZE;
 
+  if (nextFreeAddr > lh_memRange.end) {
+    char msg[] = "*** Panic: MANA lower half memory ran out of space\n"
+                 "    Raise 'lh_mem_range.end' in "
+                 "restart_plugin/mtcp_split_process.c\n";
+    write(2, msg, sizeof(msg)); assert(rc == 0);
+  }
   // Assert if we have gone past the end of the lower half memory range
   assert(nextFreeAddr <= lh_memRange.end);
+
   return curr;
 }
 


### PR DESCRIPTION
The default right now is to reserve 1 GB of memory during restart, starting at 0x2aab000... .  Sometimes, we need more than 1 GB.  The error statement tells the end user where to modify MANA, and recompile it with more memory.