### PR TITLE
Fixed a resource leak in registerLocalSendAndRecvs.

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
@@ -50,6 +50,23 @@ USER_DEFINED_WRAPPER(int, Comm_group, (MPI_Comm) comm, (MPI_Group *) group)
   return retval;
 }
 
+int
+MPI_Comm_internal_vgroup(MPI_Comm comm, MPI_Group *group)
+{
+  int retval;
+  DMTCP_PLUGIN_DISABLE_CKPT();
+  MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
+  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
+  retval = NEXT_FUNC(Comm_group)(realComm, group);
+  RETURN_TO_UPPER_HALF();
+  if (retval == MPI_SUCCESS) {
+    MPI_Group virtGroup = ADD_NEW_GROUP(*group);
+    *group = virtGroup;
+  }
+  DMTCP_PLUGIN_ENABLE_CKPT();
+  return retval;
+}
+
 USER_DEFINED_WRAPPER(int, Group_size, (MPI_Group) group, (int *) size)
 {
   int retval;

--- a/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
@@ -50,8 +50,10 @@ USER_DEFINED_WRAPPER(int, Comm_group, (MPI_Comm) comm, (MPI_Group *) group)
   return retval;
 }
 
+// Calls MPI_Comm_group to define a new group for internal purposes.
+// See: p2p_drain_send_recv.cpp
 int
-MPI_Comm_internal_vgroup(MPI_Comm comm, MPI_Group *group)
+MPI_Comm_internal_virt_group(MPI_Comm comm, MPI_Group *group)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();

--- a/mpi-proxy-split/p2p_drain_send_recv.cpp
+++ b/mpi-proxy-split/p2p_drain_send_recv.cpp
@@ -45,7 +45,7 @@ extern int MPI_Comm_create_group_internal(MPI_Comm comm, MPI_Group group,
 extern int MPI_Comm_free_internal(MPI_Comm *comm);
 extern int MPI_Comm_group_internal(MPI_Comm comm, MPI_Group *group);
 extern int MPI_Group_free_internal(MPI_Group *group);
-extern int MPI_Comm_internal_vgroup(MPI_Comm comm, MPI_Group *group);
+extern int MPI_Comm_internal_virt_group(MPI_Comm comm, MPI_Group *group);
 int *g_sendBytesByRank; // Number of bytes sent to other ranks
 int *g_rsendBytesByRank; // Number of bytes sent to other ranks by MPI_rsend
 int *g_bytesSentToUsByRank; // Number of bytes other ranks sent to us
@@ -76,7 +76,7 @@ registerLocalSendsAndRecvs()
   // Get a copy of MPI_COMM_WORLD
   MPI_Group group_world;
   MPI_Comm mana_comm;
-  MPI_Comm_internal_vgroup(MPI_COMM_WORLD, &group_world);
+  MPI_Comm_internal_virt_group(MPI_COMM_WORLD, &group_world);
   MPI_Comm_create_group_internal(MPI_COMM_WORLD, group_world, 1, &mana_comm);
 
   // broadcast sendBytes and recvBytes
@@ -85,10 +85,13 @@ registerLocalSendsAndRecvs()
   g_bytesSentToUsByRank[g_world_rank] = 0;
 
   // Free resources
-  // Semantics -- although mana_comm IS a real id, and MPI_Comm_free_internal does look up a virtual id to remove, since it cannot find the virtual id, the real id is returned back and freed in the lh. So there is no leak with mana_comm.
+  // mana_comm is a real id, and MPI_Comm_free_internal expects a
+  // virtual id, but it works out because virtualToReal(real_id) is
+  // defined to be real_id.
   MPI_Comm_free_internal(&mana_comm);
 
-  // Because group_world is a virtual group, we have to free both its virtual and real id to clean up correctly.
+  // Because group_world is a virtual group, we have to free both its
+  // virtual and real id to clean up correctly.
   MPI_Group_free_internal(&group_world);
   REMOVE_OLD_GROUP(group_world);
 }

--- a/mpi-proxy-split/p2p_drain_send_recv.cpp
+++ b/mpi-proxy-split/p2p_drain_send_recv.cpp
@@ -45,6 +45,7 @@ extern int MPI_Comm_create_group_internal(MPI_Comm comm, MPI_Group group,
 extern int MPI_Comm_free_internal(MPI_Comm *comm);
 extern int MPI_Comm_group_internal(MPI_Comm comm, MPI_Group *group);
 extern int MPI_Group_free_internal(MPI_Group *group);
+extern int MPI_Comm_internal_vgroup(MPI_Comm comm, MPI_Group *group);
 int *g_sendBytesByRank; // Number of bytes sent to other ranks
 int *g_rsendBytesByRank; // Number of bytes sent to other ranks by MPI_rsend
 int *g_bytesSentToUsByRank; // Number of bytes other ranks sent to us


### PR DESCRIPTION
The old code here had a few problems: it wouldn't free an old virtual and real id, and it would also make extra LOG_CALL.
This is because the userspace `MPI_Comm_group` wrapper was used. It conveniently creates a virtual id, which is relevant to the algorithm run here, but it also does a LOG_CALL if `MPI_LOGGING()` is defined. 

I write a new function that does the `MPI_Comm_group` without logging.

I clean up the lower-half `group_world` real-id as well as the upper-half `virtual-id`.

I left some commentary to explain my thinking. These can be removed by another quick commit in the GitHub interface.

It should be ensured that this is completely correct, because this is a highly critical part of MANA.