### PR TITLE
Track numMmapRegions ptr instead of copying the value

### DIFF
--- a/mpi-proxy-split/lower-half/lower_half_api.h
+++ b/mpi-proxy-split/lower-half/lower_half_api.h
@@ -136,7 +136,7 @@ typedef int (*libcFptr_t) (int (*main) (int, char **, char ** MAIN_AUXVEC_DECL),
 typedef void* (*proxyDlsym_t)(enum MPI_Fncs fnc);
 typedef void* (*updateEnviron_t)(char **environ);
 typedef void (*resetMmappedList_t)();
-typedef MmapInfo_t* (*getMmappedList_t)(int *num);
+typedef MmapInfo_t* (*getMmappedList_t)(int **num);
 typedef LhCoreRegions_t* (*getLhRegionsList_t)(int *num);
 
 // Global variables with lower-half information
@@ -167,7 +167,7 @@ extern void updateEnviron(const char **newenviron);
 // Returns a pointer to the first element of a pre-allocated array of
 // 'MmapInfo_t' objects and 'num' is set to the number of valid items in
 // the array
-extern MmapInfo_t* getMmappedList(int *num);
+extern MmapInfo_t* getMmappedList(int **num);
 
 // Clears the global, pre-allocated array of 'MmapInfo_t' objects
 extern void resetMmappedList();

--- a/mpi-proxy-split/lower-half/mmap64.c
+++ b/mpi-proxy-split/lower-half/mmap64.c
@@ -116,10 +116,10 @@ void *nextFreeAddr = NULL;
 // Returns a pointer to the array of mmap-ed regions
 // Sets num to the number of valid items in the array
 MmapInfo_t*
-getMmappedList(int *num)
+getMmappedList(int **num)
 {
   if (!num) return NULL;
-  *num = numRegions;
+  *num = &numRegions;
   return mmaps;
 }
 

--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -87,7 +87,7 @@ bool CheckAndEnableFsGsBase();
 
 EXTERNC pid_t dmtcp_get_real_tid() __attribute((weak));
 
-int g_numMmaps = 0;
+int *g_numMmaps = NULL;
 MmapInfo_t *g_list = NULL;
 mana_state_t mana_state = UNKNOWN_STATE;
 
@@ -211,7 +211,7 @@ void recordMpiInitMaps()
 
   if (g_list) {
     ostringstream o;
-    for (int i = 0; i < g_numMmaps; i++) {
+    for (int i = 0; i < *g_numMmaps; i++) {
       void *lhMmapStart = g_list[i].addr;
       void *lhMmapEnd = (VA)g_list[i].addr + g_list[i].len;
       if (!g_list[i].unmapped) {
@@ -366,7 +366,7 @@ isLhMmapRegion(const ProcMapsArea *area)
     return false;
   }
 
-  for (int i = 0; i < g_numMmaps; i++) {
+  for (int i = 0; i < *g_numMmaps; i++) {
     void *lhMmapStart = g_list[i].addr;
     void *lhMmapEnd = (VA)g_list[i].addr + g_list[i].len;
     if (!g_list[i].unmapped &&
@@ -658,10 +658,11 @@ getLhMmapList()
 {
   getMmappedList_t fnc = (getMmappedList_t)lh_info.getMmappedListFptr;
   if (fnc) {
+    // Initialize g_numMmaps to point to lower half 'numMmapRegions'
     g_list = fnc(&g_numMmaps);
   }
-  JTRACE("Lower half region info")(g_numMmaps);
-  for (int i = 0; i < g_numMmaps; i++) {
+  JTRACE("Lower half region info")(*g_numMmaps);
+  for (int i = 0; i < *g_numMmaps; i++) {
     JTRACE("Lh region")(g_list[i].addr)(g_list[i].len)(g_list[i].unmapped);
   }
 }

--- a/mpi-proxy-split/mpi_plugin.h
+++ b/mpi-proxy-split/mpi_plugin.h
@@ -49,7 +49,7 @@
 #define PMPI_IMPL(ret, func, ...)                               \
   EXTERNC ret P##func(__VA_ARGS__) __attribute__ ((weak, alias (#func)));
 
-extern int g_numMmaps;
+extern int *g_numMmaps;
 extern MmapInfo_t *g_list;
 
 bool isUsingCollectiveToP2p();

--- a/mpi-proxy-split/mtcp_split_process.h
+++ b/mpi-proxy-split/mtcp_split_process.h
@@ -493,7 +493,7 @@ enum MPI_Fncs {
 typedef void* (*proxyDlsym_t)(enum MPI_Fncs fnc);
 typedef void* (*updateEnviron_t)(char **envp);
 typedef void (*resetMmappedList_t)();
-typedef MmapInfo_t* (*getMmappedList_t)(int *num);
+typedef MmapInfo_t* (*getMmappedList_t)(int **num);
 typedef LhCoreRegions_t* (*getLhRegionsList_t)(int *num);
 
 extern int splitProcess(char *argv0, char **envp);

--- a/mpi-proxy-split/p2p_log_replay.cpp
+++ b/mpi-proxy-split/p2p_log_replay.cpp
@@ -77,7 +77,7 @@ updateCkptDirByRank()
   o << baseDir << "/ckpt_rank_" << g_world_rank;
   dmtcp_set_ckpt_dir(o.str().c_str());
 
-  if (!g_list || g_numMmaps == 0) return;
+  if (!g_list || g_numMmaps == NULL || *g_numMmaps == 0) return;
   o << "/lhregions.dat";
   dmtcp::string fname = o.str();
   int fd = open(fname.c_str(), O_CREAT | O_WRONLY, 0600);
@@ -85,8 +85,8 @@ updateCkptDirByRank()
   // g_range (lh_memory_range) was written for debugging here.
   Util::writeAll(fd, g_range, sizeof(*g_range));
 #endif
-  Util::writeAll(fd, &g_numMmaps, sizeof(g_numMmaps));
-  for (int i = 0; i < g_numMmaps; i++) {
+  Util::writeAll(fd, g_numMmaps, sizeof(*g_numMmaps));
+  for (int i = 0; i < *g_numMmaps; i++) {
     Util::writeAll(fd, &g_list[i], sizeof(g_list[i]));
   }
   close(fd);

--- a/mpi-proxy-split/unit-test/drain-send-recv-test.cpp
+++ b/mpi-proxy-split/unit-test/drain-send-recv-test.cpp
@@ -22,7 +22,7 @@ using namespace dmtcp_mpi;
 static dmtcp::LookupService lsObj;
 proxyDlsym_t pdlsym = NULL;
 LowerHalfInfo_t lh_info;
-int g_numMmaps = 0;
+int *g_numMmaps = NULL;
 MmapInfo_t *g_list = NULL;
 MemRange_t *g_range = NULL;
 

--- a/restart_plugin/mtcp_restart_plugin.c
+++ b/restart_plugin/mtcp_restart_plugin.c
@@ -861,7 +861,7 @@ mtcp_plugin_skip_memory_region_munmap(Area *area, RestoreInfo *rinfo)
 #ifdef USE_LH_MMAPS_ARRAY
   MmapInfo_t *g_list = NULL;
 #endif
-  int g_numMmaps = 0;
+  int *g_numMmaps = NULL;
   int i = 0;
 
 #ifdef USE_LH_MMAPS_ARRAY
@@ -934,7 +934,7 @@ mtcp_plugin_skip_memory_region_munmap(Area *area, RestoreInfo *rinfo)
   // FIXME: use assert(g_list) instead.
   if (!g_list) return 0;
 
-  for (i = 0; i < g_numMmaps; i++) {
+  for (i = 0; i < *g_numMmaps; i++) {
     void *lhMmapStart = g_list[i].addr;
     void *lhMmapEnd = (VA)g_list[i].addr + g_list[i].len;
     if (!g_list[i].unmapped &&

--- a/restart_plugin/mtcp_split_process.h
+++ b/restart_plugin/mtcp_split_process.h
@@ -437,7 +437,7 @@ enum MPI_Fncs {
 typedef void* (*proxyDlsym_t)(enum MPI_Fncs fnc);
 typedef void* (*updateEnviron_t)(char **envp);
 typedef void (*resetMmappedList_t)();
-typedef MmapInfo_t* (*getMmappedList_t)(int *num);
+typedef MmapInfo_t* (*getMmappedList_t)(int **num);
 typedef LhCoreRegions_t* (*getLhRegionsList_t)(int *num);
 
 int splitProcess(RestoreInfo *rinfo);


### PR DESCRIPTION
This is to avoid scenarios where the variable `g_numMmaps` contains stale information of `numRegions` after calling `getLhMmapList` function in the upper half.