### PR TITLE
WIP:make start of stack more robust

### DIFF
--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -758,13 +758,15 @@ computeUnionOfCkptImageAddresses()
      *         and then re-use that information here, during a second restart.
      *  if (strcmp(area.name, "[stack]") == 0)
      */
-    if (prev_addr_end != NULL && prev_addr_end == libsEnd)
-    {
-      highMemStart = area.addr; // This should be the start of the stack.
-    }
+    static void* stackEndAddr = NULL;
     if (strcmp(area.name, "[stack]") == 0)
     {
       highMemStart = area.addr; // This should be the start of the stack.
+      stackEndAddr = area.endAddr;
+    }
+    if (stackEndAddr && area.endAddr == stackEndAddr) {
+      void* stackStartAddr = stackEndAddr - area.size;
+      highMemStart = stackStartAddr;
     }
     // FIXME:  We are no longer using min/maxAddrBeyondHeap.
     //         Given that heapAddr is poorly defined between launch and restart,


### PR DESCRIPTION
Successfully tested with wave_mpi, need more testing.
Basic logic: use a static variable to record the end of stack address when first time we encountered it.
Then during restart we use that address and stack size to decide the proper stack start in case of the stack would grow.