### PR TITLE
Simplify copy bits

### DIFF
--- a/restart_plugin/dmtcp_restart_plugin.cpp
+++ b/restart_plugin/dmtcp_restart_plugin.cpp
@@ -53,6 +53,9 @@ void dmtcp_restart_plugin(const string &restartDir,
   mtcpArgs.push_back((char*) "--minHighMemStart");
   mtcpArgs.push_back((char*) kvmap.at("MANA_MinHighMemStart").c_str());
 
+  mtcpArgs.push_back((char*) "--maxHighMemEnd");
+  mtcpArgs.push_back((char*) kvmap.at("MANA_MaxHighMemEnd").c_str());
+
   if (!restartDir.empty()) {
     mtcpArgs.push_back((char *)"--restartdir");
     mtcpArgs.push_back((char *)restartDir.c_str());

--- a/restart_plugin/mtcp_restart_plugin.c
+++ b/restart_plugin/mtcp_restart_plugin.c
@@ -568,10 +568,10 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
     //   mtcp_split_process.c, in both restart_plugin and mpi-proxy-split dirs.
     end1 = rinfo->maxLibsEnd;
 
-    // Reserve 8MB above min high memory region. That should include space for
-    // stack, argv, env, auxvec.
+    // maxHighMemEnd reserves 8MB above min high memory region.
+    // That should include space for stack, argv, env, auxvec.
     start2 = rinfo->minHighMemStart - 1 * GB; // Allow for stack to grow
-    end2 = rinfo->minHighMemStart + 8 * MB;
+    end2 = rinfo->maxHighMemEnd;
     // Ignore region start2:end2 if it is overlapped with region start1:end1
     if (is_overlap(start1, end1, start2, end2)) {
       if (end1 < end2) { end1 = end2; }
@@ -649,10 +649,10 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
     Area stack_area;
     MTCP_ASSERT(getMappedArea(&stack_area, "[stack]") == 1);
     end1 = MIN(stack_area.endAddr - 4 * GB, rinfo->minHighMemStart - 4 * GB);
-    // Reserve 8MB above min high memory region. That should include space for
-    // stack, argv, env, auxvec.
+    // maxHighMemEnd reserves 8MB above min high memory region.
+    // That should include space for stack, argv, env, auxvec.
     start2 = rinfo->minHighMemStart;
-    end2 = rinfo->minHighMemStart + 8 * MB;
+    end2 = rinfo->maxHighMemEnd;
     // Ignore region start2:end2 if it is overlapped with region start1:end1
     if (is_overlap(start1, end1, start2, end2)) {
       start2 = 0;
@@ -787,10 +787,10 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
     //   mtcp_split_process.c, in both restart_plugin and mpi-proxy-split dirs.
     end1 = rinfo->maxLibsEnd;
 
-    // Reserve 8MB above min high memory region. That should include space for
-    // stack, argv, env, auxvec.
+    // maxHighMemEnd reserves 8MB above min high memory region.
+    // That should include space for stack, argv, env, auxvec.
     start2 = rinfo->minHighMemStart - 1 * GB; // Allow for stack to grow
-    end2 = rinfo->minHighMemStart + 8 * MB;
+    end2 = rinfo->maxHighMemEnd;
     // Ignore region start2:end2 if it is overlapped with region start1:end1
     if (is_overlap(start1, end1, start2, end2)) {
       if (end1 < end2) { end1 = end2; }
@@ -868,10 +868,10 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
     Area stack_area;
     MTCP_ASSERT(getMappedArea(&stack_area, "[stack]") == 1);
     end1 = MIN(stack_area.endAddr - 4 * GB, rinfo->minHighMemStart - 4 * GB);
-    // Reserve 8MB above min high memory region. That should include space for
-    // stack, argv, env, auxvec.
+    // maxHighMemEnd reserves 8MB above min high memory region.
+    // That should include space for stack, argv, env, auxvec.
     start2 = rinfo->minHighMemStart;
-    end2 = rinfo->minHighMemStart + 8 * MB;
+    end2 = rinfo->maxHighMemEnd;
     // Ignore region start2:end2 if it is overlapped with region start1:end1
     if (is_overlap(start1, end1, start2, end2)) {
       start2 = 0;

--- a/restart_plugin/mtcp_restart_plugin.c
+++ b/restart_plugin/mtcp_restart_plugin.c
@@ -579,6 +579,12 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
       end2 = 0;
     }
 
+    Area vvar_area;
+    MTCP_ASSERT(getMappedArea(&vvar_area, "[vvar]") == 1);
+    // if (end2 > vvar_area.addr) {
+    //   end2 = vvar_area.addr;
+    // }
+
     // ADJUST THE [start2, end2] AROUND THE LOWER-HALF STACK:
     // The lower-half stack is present.  We will restore the upper-half
     // stack later, while restoring the upper half.  We may have an
@@ -659,7 +665,14 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
       end2 = 0;
     }
   }
-  // FIXME:  End of '#if 1'; Remove '# else' branch when the code is stable.
+
+  Area vvar_area;
+  MTCP_ASSERT(getMappedArea(&vvar_area, "[vvar]") == 1);
+  if (end2 > vvar_area.addr) {
+    end2 = vvar_area.addr;
+  }
+
+  // FIXME:  End of '#if 1'; Remove this '# else' branch when the code is stable
 # endif
 
   reserveUpperHalfMemoryRegionsForCkptImgs(start1, end1, start2, end2);
@@ -798,6 +811,12 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
       end2 = 0;
     }
 
+    Area vvar_area;
+    MTCP_ASSERT(getMappedArea(&vvar_area, "[vvar]") == 1);
+    // if (end2 > vvar_area.addr) {
+    //   end2 = vvar_area.addr;
+    // }
+
     // ADJUST THE [start2, end2] AROUND THE LOWER-HALF STACK:
     // The lower-half stack is present.  We will restore the upper-half
     // stack later, while restoring the upper half.  We may have an
@@ -868,6 +887,7 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
     Area stack_area;
     MTCP_ASSERT(getMappedArea(&stack_area, "[stack]") == 1);
     end1 = MIN(stack_area.endAddr - 4 * GB, rinfo->minHighMemStart - 4 * GB);
+    MTCP_ASSERT(getMappedArea(&vvar_area, "[vvar]") == 1);
     // maxHighMemEnd reserves 8MB above min high memory region.
     // That should include space for stack, argv, env, auxvec.
     start2 = rinfo->minHighMemStart;
@@ -878,7 +898,14 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
       end2 = 0;
     }
   }
-  // FIXME:  End of '#if 1'; Remove '# else' branch when the code is stable.
+
+  Area vvar_area;
+  MTCP_ASSERT(getMappedArea(&vvar_area, "[vvar]") == 1);
+  if (end2 > vvar_area.addr) {
+    end2 = vvar_area.addr;
+  }
+
+  // FIXME:  End of '#if 1'; Remove this '# else' branch when the code is stable
 # endif
 
   char full_filename[PATH_MAX];


### PR DESCRIPTION
This has various bug fixes from dev/gdc0/simplifyCopyBits on origin, as well as cleaning up some code.  I've tried to re-organize the order of the commits so that the obviously important commits come first.  There was a report by @JainTwinkle that some of the commits caused problems when experimenting with Open MPI.  I'm hoping that at least up to 31c953882529e6c21 , everything is vanilla, and should work.

@JainTwinkle , could you test up to this commit (any maybe to the last commit), and tell us what works and what doesn't work for Open MPI?

Thanks.