### PR TITLE
Virtual id refactoring

### DIFF
--- a/mpi-proxy-split/Makefile
+++ b/mpi-proxy-split/Makefile
@@ -30,7 +30,7 @@ WRAPPERS_SRCDIR=mpi-wrappers
 # As you add new files to your plugin library, add the object file names here.
 
 LIBOBJS = mpi_plugin.o p2p_drain_send_recv.o p2p_log_replay.o \
-          record-replay.o seq_num.o \
+          record-replay.o seq_num.o virtual-ids.o \
           split_process.o ${LOWER_HALF_SRCDIR}/procmapsutils.o
 
 #MANA_COORD_OBJS = mana_coordinator.o

--- a/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
@@ -129,7 +129,7 @@ USER_DEFINED_WRAPPER(int, Cart_sub, (MPI_Comm) comm,
     int ndims = 0;
     MPI_Cartdim_get(comm, &ndims);
     MPI_Comm virtComm = ADD_NEW_COMM(*new_comm);
-    VirtualGlobalCommId::instance().createGlobalId(virtComm);
+    grant_ggid(virtComm);
     *new_comm = virtComm;
     active_comms.insert(virtComm);
     FncArg rs = CREATE_LOG_BUF(remain_dims, ndims * sizeof(int));
@@ -202,7 +202,7 @@ USER_DEFINED_WRAPPER(int, Cart_create, (MPI_Comm)old_comm, (int)ndims,
 
     if (retval == MPI_SUCCESS && MPI_LOGGING()) {
       MPI_Comm virtComm = ADD_NEW_COMM(*comm_cart);
-      VirtualGlobalCommId::instance().createGlobalId(virtComm);
+      grant_ggid(virtComm);
       *comm_cart = virtComm;
       active_comms.insert(virtComm);
 
@@ -251,7 +251,7 @@ USER_DEFINED_WRAPPER(int, Cart_create, (MPI_Comm) old_comm, (int) ndims,
   RETURN_TO_UPPER_HALF();
   if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Comm virtComm = ADD_NEW_COMM(*comm_cart);
-    VirtualGlobalCommId::instance().createGlobalId(virtComm);
+    grant_ggid(virtComm);
     *comm_cart = virtComm;
     active_comms.insert(virtComm);
     FncArg ds = CREATE_LOG_BUF(dims, ndims * sizeof(int));

--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -633,7 +633,7 @@ USER_DEFINED_WRAPPER(int, Comm_split, (MPI_Comm) comm, (int) color, (int) key,
   RETURN_TO_UPPER_HALF();
   if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
-    VirtualGlobalCommId::instance().createGlobalId(virtComm);
+    grant_ggid(virtComm);
     *newcomm = virtComm;
     active_comms.insert(virtComm);
     LOG_CALL(restoreComms, Comm_split, comm, color, key, *newcomm);
@@ -655,7 +655,7 @@ USER_DEFINED_WRAPPER(int, Comm_dup, (MPI_Comm) comm, (MPI_Comm *) newcomm)
   RETURN_TO_UPPER_HALF();
   if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
-    VirtualGlobalCommId::instance().createGlobalId(virtComm);
+    grant_ggid(virtComm);
     *newcomm = virtComm;
     active_comms.insert(virtComm);
     LOG_CALL(restoreComms, Comm_dup, comm, *newcomm);

--- a/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
@@ -128,16 +128,9 @@ USER_DEFINED_WRAPPER(int, Comm_create, (MPI_Comm) comm, (MPI_Group) group,
     RETURN_TO_UPPER_HALF();
     if (retval == MPI_SUCCESS && MPI_LOGGING()) {
       MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
-      unsigned int gid = VirtualGlobalCommId::instance()
-        .createGlobalId(virtComm);
+      grant_ggid(virtComm);
       *newcomm = virtComm;
       active_comms.insert(virtComm);
-      std::map<unsigned int, unsigned long>::iterator it =
-        seq_num.find(gid);
-      if (it == seq_num.end()) {
-        seq_num[gid] = 0;
-        target[gid] = 0;
-      }
       LOG_CALL(restoreComms, Comm_create, comm, group, virtComm);
     }
     DMTCP_PLUGIN_ENABLE_CKPT();
@@ -213,10 +206,6 @@ USER_DEFINED_WRAPPER(int, Comm_free, (MPI_Comm *) comm)
     // realComm = REMOVE_OLD_COMM(*comm);
     // CLEAR_COMM_LOGS(*comm);
     active_comms.erase(*comm);
-    unsigned int gid = VirtualGlobalCommId::instance().getGlobalId(*comm);
-#if 0 
-    seq_num.erase(gid);
-#endif
     LOG_CALL(restoreComms, Comm_free, *comm);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
@@ -355,7 +344,7 @@ USER_DEFINED_WRAPPER(int, Comm_split_type, (MPI_Comm) comm, (int) split_type,
   RETURN_TO_UPPER_HALF();
   if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
-    VirtualGlobalCommId::instance().createGlobalId(virtComm);
+    grant_ggid(virtComm);
     *newcomm = virtComm;
     active_comms.insert(virtComm);
     LOG_CALL(restoreComms, Comm_split_type, comm,
@@ -486,7 +475,7 @@ USER_DEFINED_WRAPPER(int, Comm_create_group, (MPI_Comm) comm,
     int retval = MPI_Comm_create_group_internal(comm, group, tag, newcomm);
     if (retval == MPI_SUCCESS && MPI_LOGGING()) {
       MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
-      VirtualGlobalCommId::instance().createGlobalId(virtComm);
+      grant_ggid(virtComm);
       *newcomm = virtComm;
       active_comms.insert(virtComm);
       LOG_CALL(restoreComms, Comm_create_group, comm, group, tag, virtComm);

--- a/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
@@ -203,8 +203,10 @@ USER_DEFINED_WRAPPER(int, Comm_free, (MPI_Comm *) comm)
     // we'll need to replay this call to reconstruct any other comms that
     // might have been created using this comm.
     //
-    // realComm = REMOVE_OLD_COMM(*comm);
-    // CLEAR_COMM_LOGS(*comm);
+    //
+    // FIXME: Now, we remove it. O(1) decode-recode changes this.
+    realComm = REMOVE_OLD_COMM(*comm);
+    CLEAR_COMM_LOGS(*comm);
     active_comms.erase(*comm);
     LOG_CALL(restoreComms, Comm_free, *comm);
   }

--- a/mpi-proxy-split/mpi-wrappers/mpi_file_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_file_wrappers.cpp
@@ -150,6 +150,10 @@ USER_DEFINED_WRAPPER(int, File_set_view, (MPI_File) fh, (MPI_Offset) disp,
   return retval;
 }
 
+// FIXME: This is the only wrapper function in the entirety of MANA that uses
+// REAL_TO_VIRTUAL. O(1) real-to-virtual translation was a goal of the vid
+// refactoring, but we need to think more carefully about this. Maybe
+// REAL_TO_VIRTUAL could be eliminated, if it's only used once.
 USER_DEFINED_WRAPPER(int, File_get_view, (MPI_File) fh, (MPI_Offset*) disp,
                      (MPI_Datatype*) etype, (MPI_Datatype*) filetype,
                      (char*) datarep)
@@ -163,8 +167,8 @@ USER_DEFINED_WRAPPER(int, File_get_view, (MPI_File) fh, (MPI_Offset*) disp,
   retval = NEXT_FUNC(File_get_view)(realFile, disp, &realEtype, &realFtype,
                                     datarep);
   RETURN_TO_UPPER_HALF();
-  *etype = REAL_TO_VIRTUAL_TYPE(realEtype);
-  *filetype = REAL_TO_VIRTUAL_TYPE(realFtype);
+  // *etype = REAL_TO_VIRTUAL_TYPE(realEtype);
+  // *filetype = REAL_TO_VIRTUAL_TYPE(realFtype);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }

--- a/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
@@ -101,8 +101,9 @@ USER_DEFINED_WRAPPER(int, Group_free, (MPI_Group *) group)
     // to replay this call to reconstruct any comms that might
     // have been created using this group.
     //
-    // realGroup = REMOVE_OLD_GROUP(*group);
-    // CLEAR_GROUP_LOGS(*group);
+    // FIXME: See comment in Comm_free wrapper.
+    realGroup = REMOVE_OLD_GROUP(*group);
+    CLEAR_GROUP_LOGS(*group);
     LOG_CALL(restoreGroups, Group_free, *group);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();

--- a/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
@@ -73,7 +73,8 @@ USER_DEFINED_WRAPPER(int, Op_free, (MPI_Op*) op)
     // to replay this call to reconstruct any new op that might
     // have been created using this op.
     //
-    // realOp = REMOVE_OLD_OP(*op);
+    // FIXME: See comment in Comm_free wrapper.
+    realOp = REMOVE_OLD_OP(*op);
     LOG_CALL(restoreOps, Op_free, *op);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();

--- a/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
@@ -44,6 +44,12 @@ USER_DEFINED_WRAPPER(int, Op_create,
   RETURN_TO_UPPER_HALF();
   if (retval == MPI_SUCCESS && MPI_LOGGING()) {
     MPI_Op virtOp = ADD_NEW_OP(*op);
+    // FIXME HACK: Since MPI does not provide any functions To deserialize an
+    // operator, we get the data at creation time.
+    //
+    // FIXME: Do we also have to reconstruct the MPI_User_function?
+    op_desc_t* desc = VIRTUAL_TO_DESC_OP(virtOp);
+    update_op_desc_t(desc, user_fn, commute);
     *op = virtOp;
     LOG_CALL(restoreOps, Op_create, user_fn, commute, virtOp);
   }

--- a/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
@@ -57,7 +57,9 @@ USER_DEFINED_WRAPPER(int, Type_free, (MPI_Datatype *) type)
     // to replay this call to reconstruct any new type that might
     // have been created using this type.
     //
-    // realType = REMOVE_OLD_TYPE(*type);
+    // FIXME: Now, we remove this type. Otherwise, if we try to decode a type
+    // that has been freed in the lower half, MPI will be upset.
+    realType = REMOVE_OLD_TYPE(*type);
     LOG_CALL(restoreTypes, Type_free, *type);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();

--- a/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
@@ -74,6 +74,7 @@ USER_DEFINED_WRAPPER(int, Init, (int *) argc, (char ***) argv) {
 
   recordPostMpiInitMaps();
 
+  init_comm_world();
   g_world_comm = ADD_NEW_COMM(g_world_comm);
   LOG_CALL(restoreComms, Comm_dup, MPI_COMM_WORLD, g_world_comm);
   initialize_drain_send_recv();
@@ -99,6 +100,7 @@ USER_DEFINED_WRAPPER(int, Init_thread, (int *) argc, (char ***) argv,
 
   recordPostMpiInitMaps();
 
+  init_comm_world();
   g_world_comm = ADD_NEW_COMM(g_world_comm);
   LOG_CALL(restoreComms, Comm_dup, MPI_COMM_WORLD, g_world_comm);
   initialize_drain_send_recv();

--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -1110,6 +1110,11 @@ mpi_plugin_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
     }
 
     case DMTCP_EVENT_PRECHECKPOINT: {
+      // FIXME: We want update_descriptors to capture all userland descriptors,
+      // but not any internal descriptors. A function here was creating an
+      // errant descriptor, but that should be fixed by PR #348.
+      update_descriptors();
+      dmtcp_global_barrier("MPI:recordMpiInitMaps");
       recordMpiInitMaps();
       recordOpenFds();
       dmtcp_local_barrier("MPI:GetLocalLhMmapList");
@@ -1171,9 +1176,12 @@ mpi_plugin_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
       // record-replay.cpp
       setCartesianCommunicator(lh_info.getCartesianCommunicatorFptr);
 #endif
-      dmtcp_global_barrier("MPI:restoreMpiLogState");
-      restoreMpiLogState(); // record-replay.cpp
-      dmtcp_global_barrier("MPI:record-replay.cpp-void");
+      dmtcp_global_barrier("MPI:reconstruct_with_descriptors");
+      // restoreMpiLogState(); // record-replay.cpp
+      reconstruct_with_descriptors();
+      // FIXME: I place reconstruct_with_descriptors in the analogous place to
+      // restoreMpiLogState.
+      dmtcp_global_barrier("MPI:virtual-ids.cpp-void");
       replayMpiP2pOnRestart(); // p2p_log_replay.cpp
       dmtcp_local_barrier("MPI:p2p_log_replay.cpp-void");
       seq_num_reset(RESTART);

--- a/mpi-proxy-split/seq_num.cpp
+++ b/mpi-proxy-split/seq_num.cpp
@@ -125,7 +125,8 @@ int twoPhaseCommit(MPI_Comm comm,
 }
 
 void seq_num_broadcast(MPI_Comm comm, unsigned long new_target) {
-  ggid_desc_t* comm_ggid_desc = VIRTUAL_TO_DESC_COMM(comm)->ggid_desc;
+  comm_desc_t* comm_desc = VIRTUAL_TO_DESC_COMM(comm);
+  ggid_desc_t* comm_ggid_desc = comm_desc->ggid_desc;
   unsigned int comm_ggid = comm_ggid_desc->ggid;
   unsigned long msg[2] = {comm_ggid, new_target};
   int comm_size;
@@ -134,7 +135,7 @@ void seq_num_broadcast(MPI_Comm comm, unsigned long new_target) {
   MPI_Comm_size(comm, &comm_size);
   MPI_Comm_rank(comm, &comm_rank);
   MPI_Group world_group, local_group;
-  MPI_Comm real_local_comm = VIRTUAL_TO_REAL_COMM(comm);
+  MPI_Comm real_local_comm = comm_desc->real_id;
   MPI_Comm real_world_comm = VIRTUAL_TO_REAL_COMM(g_world_comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   NEXT_FUNC(Comm_group)(real_world_comm, &world_group);

--- a/mpi-proxy-split/seq_num.cpp
+++ b/mpi-proxy-split/seq_num.cpp
@@ -177,14 +177,14 @@ void commit_begin(MPI_Comm comm, bool passthrough) {
           status.MPI_SOURCE, status.MPI_TAG, real_world_comm,
           MPI_STATUS_IGNORE);
       RETURN_TO_UPPER_HALF();
-      unsigned int updated_comm = (unsigned int) new_target[0];
-      ggid_desc_t* updated_ggid_desc = VIRTUAL_TO_DESC_COMM(updated_comm)->ggid_desc;
+      unsigned int updated_comm_ggid = (unsigned int) new_target[0];
+      ggid_desc_iterator it = ggidDescriptorTable.find(updated_comm_ggid);
       unsigned long updated_target = new_target[1];
-      if (updated_ggid_desc != NULL && updated_ggid_desc->target_num < updated_target) {
-	updated_ggid_desc->target_num = updated_target;
+      if (it != ggidDescriptorTable.end() && it->second->target_num < updated_target) {
+	it->second->target_num = updated_target;
 #ifdef DEBUG_SEQ_NUM
         printf("rank %d received new target comm %u seq %lu target %lu\n",
-            g_world_rank, updated_comm, updated_ggid_desc->seq_num, updated_target);
+            g_world_rank, updated_comm_ggid, it->second->seq_num, updated_target);
         fflush(stdout);
 #endif
       }
@@ -224,16 +224,14 @@ void commit_finish(MPI_Comm comm, bool passthrough) {
           status.MPI_SOURCE, status.MPI_TAG, real_world_comm,
           MPI_STATUS_IGNORE);
       RETURN_TO_UPPER_HALF();
-      unsigned int updated_comm = (unsigned int) new_target[0];
+      unsigned int updated_comm_ggid = (unsigned int) new_target[0];
       unsigned long updated_target = new_target[1];
-      ggid_desc_t* updated_ggid_desc = VIRTUAL_TO_DESC_COMM(updated_comm)->ggid_desc;
-      // std::map<unsigned int, unsigned long>::iterator it =
-        // target.find(updated_comm);
-      if (updated_ggid_desc != NULL && updated_ggid_desc->target_num < updated_target) {
-	updated_ggid_desc->target_num = updated_target;
+      ggid_desc_iterator it = ggidDescriptorTable.find(updated_comm_ggid);
+      if (it != ggidDescriptorTable.end() && it->second->target_num < updated_target) {
+	it->second->target_num = updated_target;
 #ifdef DEBUG_SEQ_NUM
         printf("rank %d received new target comm %u seq %lu target %lu\n",
-            g_world_rank, updated_comm, updated_ggid_desc->seq_num, updated_target);
+            g_world_rank, updated_comm_ggid, it->second->seq_num, updated_target);
         fflush(stdout);
 #endif
       }

--- a/mpi-proxy-split/seq_num.h
+++ b/mpi-proxy-split/seq_num.h
@@ -4,6 +4,7 @@
 #include <mpi.h>
 #include <pthread.h>
 #include <functional>
+#include "virtual-ids.h"
 
 typedef enum _reset_type_t {
   RESUME,
@@ -44,16 +45,13 @@ typedef struct __rank_state_t
 // Global communicator for MANA internal use
 extern MPI_Comm g_world_comm;
 
-extern std::map<unsigned int, unsigned long> seq_num;
-extern std::map<unsigned int, unsigned long> target;
-
 // The main functions of the sequence number algorithm for MPI collectives
 void commit_begin(MPI_Comm comm, bool passthrough);
 void commit_finish(MPI_Comm comm, bool passthrough);
 
 int twoPhaseCommit(MPI_Comm comm, std::function<int(void)>doRealCollectiveComm);
 void drain_mpi_collective();
-void share_seq_nums(std::map<unsigned int, unsigned long> &target);
+void share_seq_nums(std::map<unsigned int, ggid_desc_t*> &ggidDescriptorTable);
 int check_seq_nums(bool exclusive);
 int print_seq_nums();
 void seq_num_init();

--- a/mpi-proxy-split/virtual-ids.cpp
+++ b/mpi-proxy-split/virtual-ids.cpp
@@ -128,6 +128,11 @@ void grant_ggid(MPI_Comm virtualComm) {
   } else {
     ggid_desc_t* gd = ((ggid_desc_t *) malloc(sizeof(ggid_desc_t)));
     gd->ggid = ggid;
+
+    // FIXME: In the old system, using VirtualGlobalCommId, These were only
+    // initiatialized in the wrapper function for Comm_create, (but not
+    // Comm_split, etc.)
+    // So, what is correct?
     gd->target_num = 0;
     gd->seq_num = 0;
     ggidDescriptorTable[ggid] = gd;
@@ -141,10 +146,12 @@ void grant_ggid(MPI_Comm virtualComm) {
   return;
 }
 
-// HACK See notes in virtual-ids.h about the reference counting.
 void destroy_comm_desc_t(comm_desc_t* desc) {
   free(desc->global_ranks);
-  // We DO NOT free the ggid_desc. Need to think about how to do it correctly.
+  // FIXME: We DO NOT free the ggid_desc, because it is aliased, and as such
+  // shouldn't always be removed. We could do a form of reference counting, but
+  // we would need to make sure that it is thread-safe. Need to think about how
+  // to do it correctly in the MANA architecture.
   free(desc);
 }
 
@@ -254,6 +261,7 @@ void init_comm_world() {
   comm_world->ggid_desc = comm_world_ggid;
   // The upper-half one.
   comm_world_ggid->ggid = MPI_COMM_WORLD;
+
   comm_world_ggid->seq_num = 0;
   comm_world_ggid->target_num = 0;
 

--- a/mpi-proxy-split/virtual-ids.cpp
+++ b/mpi-proxy-split/virtual-ids.cpp
@@ -1,0 +1,179 @@
+/****************************************************************************
+ *   Copyright (C) 2019-2021 by Gene Cooperman, Rohan Garg, Yao Xu          *
+ *   gene@ccs.neu.edu, rohgarg@ccs.neu.edu, xu.yao1@northeastern.edu        *
+ *                                                                          *
+ *   Edited 2023 by Leonid Belyaev                                          *
+ *   belyaev.l@northeastern.edu                                             *
+ *                                                                          *
+ *  This file is part of DMTCP.                                             *
+ *                                                                          *
+ *  DMTCP is free software: you can redistribute it and/or                  *
+ *  modify it under the terms of the GNU Lesser General Public License as   *
+ *  published by the Free Software Foundation, either version 3 of the      *
+ *  License, or (at your option) any later version.                         *
+ *                                                                          *
+ *  DMTCP is distributed in the hope that it will be useful,                *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ *  GNU Lesser General Public License for more details.                     *
+ *                                                                          *
+ *  You should have received a copy of the GNU Lesser General Public        *
+ *  License in the files COPYING and COPYING.LESSER.  If not, see           *
+ *  <http://www.gnu.org/licenses/>.                                         *
+ ****************************************************************************/
+#include <map>
+#include <vector>
+
+#include <mpi.h>
+#include <stdlib.h>
+
+#include "dmtcp.h"
+
+#include "jassert.h"
+#include "jconvert.h"
+#include "split_process.h"
+#include "lower_half_api.h"
+#include "virtual-ids.h"
+#include "mpi_nextfunc.h"
+
+#define MAX_VIRTUAL_ID 999
+
+// #define DEBUG_VIDS
+
+// TODO I use an explicitly integer virtual id, which under macro
+// reinterpretation will fit into an int64 pointer.  This should be
+// fine if no real MPI Type is smaller than an int32.
+typedef typename std::map<int, id_desc_t*>::iterator id_desc_iterator;
+
+// Per Yao Xu, MANA does not require the thread safety offered by
+// DMTCP's VirtualIdTable. We use std::map.
+
+// int vId -> id_desc_t*, which contains rId.
+std::map<int, id_desc_t*> idDescriptorTable; 
+
+// dead-simple vid generation mechanism.
+int base = 1;
+int nextvId = base;
+
+// This is a descriptor initializer. Its job is to write an initial
+// descriptor for a real MPI Communicator.
+
+comm_desc_t* init_comm_desc_t(MPI_Comm realComm) {
+  comm_desc_t* desc = ((comm_desc_t*)malloc(sizeof(comm_desc_t)));
+  desc->real_id = realComm;
+  desc->ranks = NULL;
+  return desc;
+}
+
+void destroy_comm_desc_t(comm_desc_t* desc) {
+  free(desc->ranks);
+  free(desc);
+}
+
+group_desc_t* init_group_desc_t(MPI_Group realGroup) {
+  group_desc_t* desc = ((group_desc_t*)malloc(sizeof(group_desc_t)));
+  desc->real_id = realGroup;
+  desc->ranks = NULL;
+  desc->size = 0;
+  return desc;
+}
+
+void destroy_group_desc_t(group_desc_t* group) {
+  free(group->ranks);
+  free(group);
+}
+
+request_desc_t* init_request_desc_t(MPI_Request realReq) {
+  request_desc_t* desc = ((request_desc_t*)malloc(sizeof(request_desc_t))); // FIXME
+  desc->real_id = realReq;
+  return desc;
+}
+
+void destroy_request_desc_t(request_desc_t* request) {
+  free(request);
+}
+
+op_desc_t* init_op_desc_t(MPI_Op realOp) {
+  op_desc_t* desc = ((op_desc_t*)malloc(sizeof(op_desc_t)));
+  desc->real_id = realOp;
+  desc->user_fn = NULL;
+  return desc;
+}
+
+void destroy_op_desc_t(op_desc_t* op) {
+    free(op);
+}
+
+datatype_desc_t* init_datatype_desc_t(MPI_Datatype realType) {
+    datatype_desc_t* desc = ((datatype_desc_t*)malloc(sizeof(datatype_desc_t)));
+    desc->real_id = realType;
+
+    desc->num_integers = 0;
+    desc->integers = NULL;
+
+    desc->num_addresses = 0;
+    desc->addresses = NULL;
+
+    // TODO this was in Yao's spec sheet, but I haven't seen it used
+    // in any of the relevant functions. Why is this here?
+    desc->num_large_counts = 0;
+    desc->large_counts = NULL;
+
+    desc->num_datatypes = 0;
+    desc->datatypes = NULL;
+
+    desc->combiner = 0;
+    desc->is_freed = false;
+    return desc;
+}
+
+void destroy_datatype_desc_t(datatype_desc_t* datatype) {
+  free(datatype->integers);
+  free(datatype->addresses);
+  free(datatype->large_counts);
+  free(datatype->datatypes);
+  free(datatype);
+}
+
+file_desc_t* init_file_desc_t(MPI_File realFile) {
+  file_desc_t* desc = ((file_desc_t*)malloc(sizeof(file_desc_t)));
+  desc->real_id = realFile;
+  return desc;
+}
+
+void destroy_file_desc_t(file_desc_t* file) {
+  free(file);
+}
+
+void print_id_descriptors() {
+  printf("Printing %u id_descriptors:\n", idDescriptorTable.size());
+  fflush(stdout);
+  for (id_desc_pair pair : idDescriptorTable) {
+    printf("%x\n", pair.first);
+    fflush(stdout);
+  }
+}
+
+// Given int virtualid, return the contained id_desc_t if it exists.
+// Otherwise return NULL
+id_desc_t* virtualToDescriptor(int virtId) {
+#ifdef DEBUG_VIDS
+  // print_id_descriptors();
+#endif
+  id_desc_iterator it = idDescriptorTable.find(virtId);
+  if (it != idDescriptorTable.end()) {
+    return it->second;
+  }
+  return NULL;
+}
+
+// We need to preemptively virtualize MPI_COMM_WORLD.
+void init_comm_world() {
+  comm_desc_t* comm_world = ((comm_desc_t*)malloc(sizeof(comm_desc_t)));
+
+  // FIXME: This WILL NOT WORK when moving to OpenMPI, ExaMPI, as written.
+  // Yao, Twinkle, should apply their lh_constants_map strategy here.
+  comm_world->real_id = 0x84000000;
+
+  idDescriptorTable[MPI_COMM_WORLD] = ((union id_desc_t*)comm_world);
+}

--- a/mpi-proxy-split/virtual-ids.h
+++ b/mpi-proxy-split/virtual-ids.h
@@ -1,44 +1,35 @@
-/****************************************************************************
- *   Copyright (C) 2019-2021 by Gene Cooperman, Rohan Garg, Yao Xu          *
- *   gene@ccs.neu.edu, rohgarg@ccs.neu.edu, xu.yao1@northeastern.edu        *
- *                                                                          *
- *  This file is part of DMTCP.                                             *
- *                                                                          *
- *  DMTCP is free software: you can redistribute it and/or                  *
- *  modify it under the terms of the GNU Lesser General Public License as   *
- *  published by the Free Software Foundation, either version 3 of the      *
- *  License, or (at your option) any later version.                         *
- *                                                                          *
- *  DMTCP is distributed in the hope that it will be useful,                *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of          *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
- *  GNU Lesser General Public License for more details.                     *
- *                                                                          *
- *  You should have received a copy of the GNU Lesser General Public        *
- *  License in the files COPYING and COPYING.LESSER.  If not, see           *
- *  <http://www.gnu.org/licenses/>.                                         *
- ****************************************************************************/
-
 #pragma once
 #ifndef MPI_VIRTUAL_IDS_H
 #define MPI_VIRTUAL_IDS_H
 
 #include <mpi.h>
-
 #include "virtualidtable.h"
 #include "jassert.h"
 #include "jconvert.h"
 #include "split_process.h"
 #include "dmtcp.h"
 
-// Convenience macros
-#define MpiCommList  dmtcp_mpi::MpiVirtualization<MPI_Comm>
-#define MpiGroupList dmtcp_mpi::MpiVirtualization<MPI_Group>
-#define MpiTypeList  dmtcp_mpi::MpiVirtualization<MPI_Datatype>
-#define MpiOpList    dmtcp_mpi::MpiVirtualization<MPI_Op>
-#define MpiFileList  dmtcp_mpi::MpiVirtualization<MPI_File>
-#define MpiCommKeyvalList    dmtcp_mpi::MpiVirtualization<int>
-#define MpiRequestList    dmtcp_mpi::MpiVirtualization<MPI_Request>
+#define CONCAT(a,b) a ## b
+
+// num - type - VID MASK
+// 0 - undefined - 0x00000000
+// 1 - communicator - 0x01000000
+// 2 - group - 0x02000000
+// 3 - request - 0x03000000
+// 4 - op - 0x04000000
+// 5 - datatype - 0x05000000
+// 6 - file - 0x06000000
+// 7 - comm_keyval - 0x07000000
+
+#define UNDEFINED_MASK 0x00000000
+#define COMM_MASK 0x01000000
+#define GROUP_MASK 0x02000000
+#define REQUEST_MASK 0x03000000
+#define OP_MASK 0x04000000
+#define DATATYPE_MASK 0x05000000
+#define FILE_MASK 0x06000000
+#define COMM_KEYVAL_MASK 0x07000000
+
 #ifndef NEXT_FUNC
 # define NEXT_FUNC(func)                                                       \
   ({                                                                           \
@@ -50,243 +41,305 @@
     _real_MPI_ ## func;                                                        \
   })
 #endif // ifndef NEXT_FUNC
-#define REAL_TO_VIRTUAL_FILE(id) \
-  MpiFileList::instance("MpiFile", MPI_FILE_NULL).realToVirtual(id)
+
+
+#define DESC_TO_VIRTUAL(desc, null, real_type)		\
+  ({ \
+    real_type _DTV_vId = (desc == NULL) ? null : desc->handle; \
+   _DTV_vId; \
+  })
+
+#define VIRTUAL_TO_DESC(virtual_id, null, desc_type)					\
+  (virtual_id == null) ? NULL : ((desc_type*) virtualToDescriptor( *((int*)(&virtual_id)) ))
+
+#define VIRTUAL_TO_REAL(id, null, real_id_type, desc_type)    \
+    ({                                              \
+      desc_type* _VTR_tmp = VIRTUAL_TO_DESC(id, null, desc_type);			\
+       real_id_type _VTR_id = (_VTR_tmp == NULL) ? id : _VTR_tmp->real_id; \
+       _VTR_id; \
+     })
+
+// FIXME: Looping through every real id is /very/ inefficient for a large
+// program, but we don't have any way to loop through only the real ids of a
+// particular type yet. That would change with a two-level table approach.
+#define ADD_NEW(given_real_id, null, real_id_type, descriptor_type, vid_mask)	\
+  ({ \
+    real_id_type _AD_retval; \
+    descriptor_type* _AD_desc; \
+    if (given_real_id != null) { \
+        bool real_id_exists = false; \
+        for (id_desc_pair pair : idDescriptorTable) { \
+          if ((vid_mask & pair.first) == vid_mask && ((descriptor_type*)pair.second)->real_id == given_real_id) { \
+	    real_id_exists = true; \
+	    _AD_retval = *((real_id_type*)&pair.first); \
+	    break; \
+	  } \
+        } \
+	if (!real_id_exists) { \
+          _AD_desc = CONCAT(init_,descriptor_type)(given_real_id);	\
+          int _AD_vId = nextvId++; \
+	  _AD_vId = _AD_vId | vid_mask; \
+          _AD_desc->handle = _AD_vId; \
+          idDescriptorTable[_AD_vId] = ((union id_desc_t*) _AD_desc);	\
+          _AD_retval = *((real_id_type*)&_AD_vId);						\
+	} \
+    } else { \
+      _AD_retval = null; \
+    } \
+    _AD_retval; \
+  })
+
+#define REMOVE_OLD(virtual_id, null, descriptor_type, real_type)	\
+  ({ \
+    real_type _RO_retval; \
+    if (virtual_id == null) { \
+      _RO_retval = null; \
+    } else { \
+      descriptor_type* _RO_torem; \
+      id_desc_iterator it = idDescriptorTable.find( *((int*)&virtual_id) ); \
+      if (it != idDescriptorTable.end()) { \
+	_RO_torem = ((descriptor_type*)it->second);	   \
+        idDescriptorTable.erase(*((int*)&virtual_id)); \
+        _RO_retval = _RO_torem->real_id; \
+        CONCAT(destroy_,descriptor_type)(_RO_torem); \
+      } else { \
+        _RO_retval = null; \
+      } \
+    }  \
+    _RO_retval; \
+  })
+
+// FIXME: this cannot easily have precisely the same semantics as ADD_NEW: the []
+// operator inserts when the argument is not yet present.  If the usage in the
+// code is indicative of the "update" name despite this, then it's not a
+// problem.
+// I just checked every usage of UPDATE_MAP to see if those semantics of [] are employed --
+// They are not, with the exception of MPI_COMM_WORLD, so we previrtualize it.
+#define UPDATE_MAP(virtual_id, to_update, null, descriptor_type, to_update_type)	\
+  ({ \
+    to_update_type _UM_retval; \
+    if (virtual_id == null) { \
+      _UM_retval = null; \
+    } else { \
+      id_desc_iterator _UM_it = idDescriptorTable.find(*((int*)(&virtual_id))); \
+      if (_UM_it != idDescriptorTable.end()) { \
+        descriptor_type* desc = ((descriptor_type*)_UM_it->second); \
+        desc->real_id = to_update; \
+        _UM_retval = virtual_id; \
+      } else { 		     \
+        _UM_retval = null; \
+      } \
+    } \
+  _UM_retval; \
+})
+
+#define DESC_TO_VIRTUAL_FILE(desc) \
+  DESC_TO_VIRTUAL(desc, MPI_FILE_NULL, MPI_File) 
+#define VIRTUAL_TO_DESC_FILE(id) \
+  VIRTUAL_TO_DESC(id, MPI_FILE_NULL, file_desc_t)
 #define VIRTUAL_TO_REAL_FILE(id) \
-  MpiFileList::instance("MpiFile", MPI_FILE_NULL).virtualToReal(id)
+  VIRTUAL_TO_REAL(id, MPI_FILE_NULL, MPI_File, file_desc_t)
 #define ADD_NEW_FILE(id) \
-  MpiFileList::instance("MpiFile", MPI_FILE_NULL).onCreate(id)
+  ADD_NEW(id, MPI_FILE_NULL, MPI_File, file_desc_t, FILE_MASK)
 #define REMOVE_OLD_FILE(id) \
-  MpiFileList::instance("MpiFile", MPI_FILE_NULL).onRemove(id)
+  REMOVE_OLD(id, MPI_FILE_NULL, file_desc_t, MPI_File)
 #define UPDATE_FILE_MAP(v, r) \
-  MpiFileList::instance("MpiFile", MPI_FILE_NULL).updateMapping(v, r)
+  UPDATE_MAP(v, r, MPI_FILE_NULL, file_desc_t, MPI_File)
 
-#define REAL_TO_VIRTUAL_COMM(id) \
-  MpiCommList::instance("MpiComm", MPI_COMM_NULL).realToVirtual(id)
+#define DESC_TO_VIRTUAL_COMM(desc) \
+  DESC_TO_VIRTUAL(desc, MPI_COMM_NULL, MPI_Comm) 
+#define VIRTUAL_TO_DESC_COMM(id) \
+  VIRTUAL_TO_DESC(id, MPI_COMM_NULL, comm_desc_t)
 #define VIRTUAL_TO_REAL_COMM(id) \
-  MpiCommList::instance("MpiComm", MPI_COMM_NULL).virtualToReal(id)
+  VIRTUAL_TO_REAL(id, MPI_COMM_NULL, MPI_Comm, comm_desc_t)
 #define ADD_NEW_COMM(id) \
-  MpiCommList::instance("MpiComm", MPI_COMM_NULL).onCreate(id)
+  ADD_NEW(id, MPI_COMM_NULL, MPI_Comm, comm_desc_t, COMM_MASK)
 #define REMOVE_OLD_COMM(id) \
-  MpiCommList::instance("MpiComm", MPI_COMM_NULL).onRemove(id)
+  REMOVE_OLD(id, MPI_COMM_NULL, comm_desc_t, MPI_Comm)
 #define UPDATE_COMM_MAP(v, r) \
-  MpiCommList::instance("MpiComm", MPI_COMM_NULL).updateMapping(v, r)
+  UPDATE_MAP(v, r, MPI_COMM_NULL, comm_desc_t, MPI_Comm)
 
-#define REAL_TO_VIRTUAL_GROUP(id) \
-  MpiGroupList::instance("MpiGroup", MPI_GROUP_NULL).realToVirtual(id)
+#define DESC_TO_VIRTUAL_GROUP(desc) \
+  DESC_TO_VIRTUAL(desc, MPI_GROUP_NULL, MPI_Group) 
+#define VIRTUAL_TO_DESC_GROUP(id) \
+  VIRTUAL_TO_DESC(id, MPI_GROUP_NULL, group_desc_t)
 #define VIRTUAL_TO_REAL_GROUP(id) \
-  MpiGroupList::instance("MpiGroup", MPI_GROUP_NULL).virtualToReal(id)
+  VIRTUAL_TO_REAL(id, MPI_GROUP_NULL, MPI_Group, group_desc_t)
 #define ADD_NEW_GROUP(id) \
-  MpiGroupList::instance("MpiGroup", MPI_GROUP_NULL).onCreate(id)
+  ADD_NEW(id, MPI_GROUP_NULL, MPI_Group, group_desc_t, GROUP_MASK)
 #define REMOVE_OLD_GROUP(id) \
-  MpiGroupList::instance("MpiGroup", MPI_GROUP_NULL).onRemove(id)
+  REMOVE_OLD(id, MPI_GROUP_NULL, group_desc_t, MPI_Group)
 #define UPDATE_GROUP_MAP(v, r) \
-  MpiGroupList::instance("MpiGroup", MPI_GROUP_NULL).updateMapping(v, r)
+  UPDATE_MAP(v, r, MPI_GROUP_NULL, group_desc_t, MPI_Group)
 
-#define REAL_TO_VIRTUAL_TYPE(id) \
-  MpiTypeList::instance("MpiType", MPI_DATATYPE_NULL).realToVirtual(id)
+#define DESC_TO_VIRTUAL_TYPE(desc) \
+  DESC_TO_VIRTUAL(desc, MPI_DATATYPE_NULL, MPI_Datatype) 
+#define VIRTUAL_TO_DESC_TYPE(id) \
+  VIRTUAL_TO_DESC(id, MPI_DATATYPE_NULL, datatype_desc_t)
 #define VIRTUAL_TO_REAL_TYPE(id) \
-  MpiTypeList::instance("MpiType", MPI_DATATYPE_NULL).virtualToReal(id)
+  VIRTUAL_TO_REAL(id, MPI_DATATYPE_NULL, MPI_Datatype, datatype_desc_t)
 #define ADD_NEW_TYPE(id) \
-  MpiTypeList::instance("MpiType", MPI_DATATYPE_NULL).onCreate(id)
+  ADD_NEW(id, MPI_DATATYPE_NULL, MPI_Datatype, datatype_desc_t, DATATYPE_MASK)
 #define REMOVE_OLD_TYPE(id) \
-  MpiTypeList::instance("MpiType", MPI_DATATYPE_NULL).onRemove(id)
+  REMOVE_OLD(id, MPI_DATATYPE_NULL, datatype_desc_t, MPI_Datatype)
 #define UPDATE_TYPE_MAP(v, r) \
-  MpiTypeList::instance("MpiType", MPI_DATATYPE_NULL).updateMapping(v, r)
+  UPDATE_MAP(v, r, MPI_DATATYPE_NULL, datatype_desc_t, MPI_Datatype)
 
-#define REAL_TO_VIRTUAL_OP(id) \
-  MpiOpList::instance("MpiOp", MPI_OP_NULL).realToVirtual(id)
+#define DESC_TO_VIRTUAL_OP(desc) \
+  DESC_TO_VIRTUAL(desc, MPI_OP_NULL, MPI_Op) 
+#define VIRTUAL_TO_DESC_OP(id) \
+  VIRTUAL_TO_DESC(id, MPI_OP_NULL, op_desc_t)
 #define VIRTUAL_TO_REAL_OP(id) \
-  MpiOpList::instance("MpiOp", MPI_OP_NULL).virtualToReal(id)
+  VIRTUAL_TO_REAL(id, MPI_OP_NULL, MPI_Op, op_desc_t)
 #define ADD_NEW_OP(id) \
-  MpiOpList::instance("MpiOp", MPI_OP_NULL).onCreate(id)
+  ADD_NEW(id, MPI_OP_NULL, MPI_Op, op_desc_t, OP_MASK)
 #define REMOVE_OLD_OP(id) \
-  MpiOpList::instance("MpiOp", MPI_OP_NULL).onRemove(id)
+  REMOVE_OLD(id, MPI_OP_NULL, op_desc_t, MPI_Op)
 #define UPDATE_OP_MAP(v, r) \
-  MpiOpList::instance("MpiOp", MPI_OP_NULL).updateMapping(v, r)
+  UPDATE_MAP(v, r, MPI_OP_NULL, op_desc_t, MPI_Op)
 
-#define REAL_TO_VIRTUAL_COMM_KEYVAL(id) \
-  MpiOpList::instance("MpiCommKeyval", 0).realToVirtual(id)
+// FIXME: Earlier, I was under the impression that we didn't need to virtualize
+// communicator keyvals anymore, but without these, VASP5 DBG will not run. So,
+// what is the case?
+#define DESC_TO_VIRTUAL_COMM_KEYVAL(desc) \
+  DESC_TO_VIRTUAL(desc, 0, int) 
+#define VIRTUAL_TO_DESC_COMM_KEYVAL(id) \
+  VIRTUAL_TO_DESC(id, 0, comm_keyval_desc_t)
 #define VIRTUAL_TO_REAL_COMM_KEYVAL(id) \
-  MpiOpList::instance("MpiCommKeyval", 0).virtualToReal(id)
+  VIRTUAL_TO_REAL(id, 0, int, comm_keyval_desc_t)
 #define ADD_NEW_COMM_KEYVAL(id) \
-  MpiOpList::instance("MpiCommKeyval", 0).onCreate(id)
+  ADD_NEW(id, 0, int, comm_keyval_desc_t, COMM_KEYVAL_MASK)
 #define REMOVE_OLD_COMM_KEYVAL(id) \
-  MpiOpList::instance("MpiCommKeyval", 0).onRemove(id)
+  REMOVE_OLD(id, 0, comm_keyval_desc_t, int)
 #define UPDATE_COMM_KEYVAL_MAP(v, r) \
-  MpiOpList::instance("MpiCommKeyval", 0).updateMapping(v, r)
+  UPDATE_MAP(v, r, 0, comm_keyval_desc_t, int)
 
-#if 1
-#define REAL_TO_VIRTUAL_REQUEST(id) \
-  MpiRequestList::instance("MpiRequest", MPI_REQUEST_NULL).realToVirtual(id)
+#define DESC_TO_VIRTUAL_REQUEST(desc) \
+  DESC_TO_VIRTUAL(desc, MPI_REQUEST_NULL, MPI_Request) 
+#define VIRTUAL_TO_DESC_REQUEST(id) \
+  VIRTUAL_TO_DESC(id, MPI_REQUEST_NULL, request_desc_t)
 #define VIRTUAL_TO_REAL_REQUEST(id) \
-  MpiRequestList::instance("MpiRequest", MPI_REQUEST_NULL).virtualToReal(id)
+  VIRTUAL_TO_REAL(id, MPI_REQUEST_NULL, MPI_Request, request_desc_t)
 #define ADD_NEW_REQUEST(id) \
-  MpiRequestList::instance("MpiRequest", MPI_REQUEST_NULL).onCreate(id)
+  ADD_NEW(id, MPI_REQUEST_NULL, MPI_Request, request_desc_t, REQUEST_MASK)
 #define REMOVE_OLD_REQUEST(id) \
-  MpiRequestList::instance("MpiRequest", MPI_REQUEST_NULL).onRemove(id)
+  REMOVE_OLD(id, MPI_REQUEST_NULL, request_desc_t, MPI_Request)
 #define UPDATE_REQUEST_MAP(v, r) \
-  MpiRequestList::instance("MpiRequest", MPI_REQUEST_NULL).updateMapping(v, r)
-#else
-#define VIRTUAL_TO_REAL_REQUEST(id) id
-#define ADD_NEW_REQUEST(id) id
-#define UPDATE_REQUEST_MAP(v, r) r
-#endif
+  UPDATE_MAP(v, r, MPI_REQUEST_NULL, request_desc_t, MPI_Request)
+
+struct comm_desc_t {
+    MPI_Comm real_id; // Real MPI communicator in the lower-half
+    int handle; // A copy of the int type handle generated from the address of this struct
+    int size; // Size of this communicator
+    int local_rank; // local rank number of this communicator
+    int *ranks; // list of ranks of the group.
+
+    // struct virt_group_t *group; // Or should this field be a pointer to virt_group_t?
+};
+
+struct group_desc_t {
+    MPI_Group real_id; // Real MPI group in the lower-half
+    int handle; // A copy of the int type handle generated from the address of this struct
+    int size; // The size of this group in ranks.
+    int *ranks; // list of ranks of the group.
+    // unsigned int ggid; // Global Group ID
+};
+
+enum mpi_request_kind {
+  COLLECTIVE,
+  PEER_TO_PEER
+};
+
+struct request_desc_t {
+    MPI_Request real_id; // Real MPI request in the lower-half
+    int handle; // A copy of the int type handle generated from the address of this struct
+    mpi_request_kind request_kind; // P2P request or collective request
+    MPI_Status* status; // Real MPI status in the lower-half
+};
+
+struct op_desc_t {
+    MPI_Op real_id; // Real MPI operator in the lower-half
+    int handle; // A copy of the int type handle generated from the address of this struct
+    MPI_User_function *user_fn; // Function pointer to the user defined op function
+    int commute; // True if op is commutative.
+};
+
+struct datatype_desc_t {
+    MPI_Datatype real_id; // Real MPI type in the lower-half
+    int handle; // A copy of the int type handle generated from the address of this struct
+    // Components of user-defined datatype.
+    int num_integers;
+    int *integers;
+    int num_addresses;
+    MPI_Aint *addresses;
+    int num_large_counts;
+    int *large_counts;
+    int num_datatypes;
+    MPI_Datatype *datatypes; // hmmm.. hierarchical restore?
+    int combiner;
+    // if is_freed is true, then we should not update the descriptor on a checkpoint.
+    bool is_freed;
+};
+
+struct file_desc_t {
+  MPI_File real_id;
+  int handle;
+};
+
+struct comm_keyval_desc_t {
+  int real_id;
+  int handle;
+};
+
+// FIXME: Some of these structs (request_desc_t, file_desc_t,
+// comm_keyval_desc_t) Are just very thin wrappers around a real id, with no
+// other information. So, should these be virtualized after all? In an "#else"
+// branch of an "#if 1" in the main code, VIRTUAL_TO_REAL_REQUEST(id) is
+// defined as just id, for instance.
+union id_desc_t {
+    comm_desc_t comm;
+    group_desc_t group;
+    request_desc_t request;
+    op_desc_t op;
+    datatype_desc_t datatype;
+    file_desc_t file;
+    comm_keyval_desc_t comm_keyval;
+
+  operator comm_desc_t () const { return comm; }
+  operator group_desc_t () const { return group; }
+  operator request_desc_t () const { return request; }
+  operator op_desc_t () const { return op; }
+  operator datatype_desc_t () const { return datatype; }
+  operator file_desc_t () const { return file; }
+  operator comm_keyval_desc_t () const { return comm_keyval; }
+};
+
+extern std::map<int, id_desc_t*> idDescriptorTable;
+extern int base;
+extern int nextvId;
+typedef typename std::map<int, id_desc_t*>::iterator id_desc_iterator;
+typedef std::pair<int, id_desc_t*> id_desc_pair;
+
+id_desc_t* virtualToDescriptor(int virtId);
+
+datatype_desc_t* init_datatype_desc_t(MPI_Datatype realType);
+op_desc_t* init_op_desc_t(MPI_Op realOp);
+request_desc_t* init_request_desc_t(MPI_Request realReq);
+group_desc_t* init_group_desc_t(MPI_Group realGroup);
+comm_desc_t* init_comm_desc_t(MPI_Comm realComm);
+file_desc_t* init_file_desc_t(MPI_File realFile);
+
+void destroy_datatype_desc_t(datatype_desc_t* datatype);
+void destroy_op_desc_t(op_desc_t* op);
+void destroy_request_desc_t(request_desc_t* request);
+void destroy_group_desc_t(group_desc_t* group);
+void destroy_comm_desc_t(comm_desc_t* comm);
+void destroy_file_desc_t(file_desc_t* file);
+
+void init_comm_world();
 
 namespace dmtcp_mpi
 {
-
-  template<typename T>
-  class MpiVirtualization
-  {
-    public:
-#ifdef JALIB_ALLOCATOR
-      static void* operator new(size_t nbytes, void* p) { return p; }
-      static void* operator new(size_t nbytes) { JALLOC_HELPER_NEW(nbytes); }
-      static void  operator delete(void* p) { JALLOC_HELPER_DELETE(p); }
-#endif
-      static MpiVirtualization& instance(const char *name, T nullId)
-      {
-	// FIXME:
-	// dmtcp_mpi::MpiVirtualization::instance("MpiGroup", 1)
-	//                                       ._vIdTable.printMaps(true)
-	// to access _virTableMpiGroup in GDB.
-	// We need a cleaner way to access it.
-	if (strcmp(name, "MpiOp") == 0) {
-	  static MpiVirtualization<T> _virTableMpiOp(name, nullId);
-	  return _virTableMpiOp;
-	} else if (strcmp(name, "MpiComm") == 0) {
-	  static MpiVirtualization<T> _virTableMpiComm(name, nullId);
-	  return _virTableMpiComm;
-	} else if (strcmp(name, "MpiGroup") == 0) {
-	  static MpiVirtualization<T> _virTableMpiGroup(name, nullId);
-	  return _virTableMpiGroup;
-	} else if (strcmp(name, "MpiType") == 0) {
-	  static MpiVirtualization<T> _virTableMpiType(name, nullId);
-	  return _virTableMpiType;
-	} else if (strcmp(name, "MpiCommKeyval") == 0) {
-	  static MpiVirtualization _virTableMpiCommKeyval(name, nullId);
-	  return _virTableMpiCommKeyval;
-	} else if (strcmp(name, "MpiRequest") == 0) {
-	  static MpiVirtualization _virTableMpiRequest(name, nullId);
-	  return _virTableMpiRequest;
-	} else if (strcmp(name, "MpiFile") == 0) {
-	  static MpiVirtualization _virTableMpiFile(name, nullId);
-	  return _virTableMpiFile;
-	}
-	JWARNING(false)(name)(nullId).Text("Unhandled type");
-	static MpiVirtualization _virTableNoSuchObject(name, nullId);
-	return _virTableNoSuchObject;
-      }
-
-      T virtualToReal(T virt)
-      {
-        // Don't need to virtualize the null id
-        if (virt == _nullId) {
-          return virt;
-        }
-        // DMTCP virtual id table already does the lock around the table.
-        // FIXME: Even with an empty map, we are seeing 1 microsecond overhead.
-        return _vIdTable.virtualToReal(virt);
-      }
-
-      T realToVirtual(T real)
-      {
-        // Don't need to virtualize the null id
-        if (real == _nullId) {
-          return real;
-        }
-        // DMTCP virtual id table already does the lock around the table.
-        return _vIdTable.realToVirtual(real);
-      }
-
-      // Adds the given real id to the virtual id table and creates a new
-      // corresponding virtual id.
-      // Returns the new virtual id on success, null id otherwise.
-      T onCreate(T real)
-      {
-        T vId = _nullId;
-        // Don't need to virtualize the null id
-        if (real == _nullId) {
-          return vId;
-        }
-        // DMTCP virtual id table already does the lock around the table.
-        if (_vIdTable.realIdExists(real)) {
-          // Adding a existing real id is a legal operation and
-          // we should not report warning/error.
-          // For example, MPI_Comm_group accesses the group associated with
-          // given communicator. It can be called multiple times from
-          // different localtions. They should get the same virtual id and
-          // real id of the same group.
-          // JWARNING(false)(real)(_vIdTable.getTypeStr())
-          //         (_vIdTable.realToVirtual(real))
-          //         .Text("Real id exists. Will overwrite existing mapping");
-          vId = _vIdTable.realToVirtual(real);
-        } else {
-          if (!_vIdTable.getNewVirtualId(&vId)) {
-            JWARNING(false)(real)(_vIdTable.getTypeStr())
-              .Text("Failed to create a new vId");
-          } else {
-            _vIdTable.updateMapping(vId, real);
-          }
-        }
-        return vId;
-      }
-
-      // Removes virtual id from table and returns the real id corresponding
-      // to the virtual id; if the virtual id does not exist in the table,
-      // returns null id.
-      T onRemove(T virt)
-      {
-        T realId = _nullId;
-        // Don't need to virtualize the null id
-        if (virt == _nullId) {
-          return realId;
-        }
-        // DMTCP virtual id table already does the lock around the table.
-        if (_vIdTable.virtualIdExists(virt)) {
-          realId = _vIdTable.virtualToReal(virt);
-          _vIdTable.erase(virt);
-        } else {
-          JWARNING(false)(virt)(_vIdTable.getTypeStr())
-                  .Text("Cannot delete non-existent virtual id");
-        }
-        return realId;
-      }
-
-      // Updates the mapping for the given virtual id to the given real id.
-      // Returns virtual id on success, null-id otherwise
-      T updateMapping(T virt, T real)
-      {
-        // If the virt is the null id, then return it directly.
-        // Don't need to virtualize the null id
-        if (virt == _nullId) {
-          return _nullId;
-        }
-        // DMTCP virtual id table already does the lock around the table.
-        if (!_vIdTable.virtualIdExists(virt)) {
-          JWARNING(false)(virt)(real)(_vIdTable.getTypeStr())
-                  (_vIdTable.realToVirtual(real))
-                  .Text("Cannot update mapping for a non-existent virt. id");
-          return _nullId;
-        }
-        _vIdTable.updateMapping(virt, real);
-        return virt;
-      }
-
-    private:
-      // Pvt. constructor
-      MpiVirtualization(const char *name, T nullId)
-        : _vIdTable(name, (T)0, (size_t)999999),
-          _nullId(nullId)
-      {
-      }
-
-      // Virtual Ids Table
-      dmtcp::VirtualIdTable<T> _vIdTable;
-      // Default "NULL" value for id
-      T _nullId;
-  }; // class MpiId
 
   // FIXME: The new name should be: GlobalIdOfSimiliarComm
   class VirtualGlobalCommId {
@@ -393,5 +446,7 @@ namespace dmtcp_mpi
       std::map<MPI_Comm, unsigned int> globalIdTable;
   };
 };  // namespace dmtcp_mpi
+
+
 
 #endif // ifndef MPI_VIRTUAL_IDS_H

--- a/mpi-proxy-split/virtual-ids.h
+++ b/mpi-proxy-split/virtual-ids.h
@@ -328,6 +328,7 @@ extern std::map<int, id_desc_t*> idDescriptorTable;
 extern std::map<unsigned int, ggid_desc_t*> ggidDescriptorTable; 
 extern int base;
 extern int nextvId;
+extern MPI_Group g_world_group;
 typedef typename std::map<int, id_desc_t*>::iterator id_desc_iterator;
 typedef std::pair<int, id_desc_t*> id_desc_pair;
 typedef typename std::map<unsigned int, ggid_desc_t*>::iterator ggid_desc_iterator;
@@ -354,5 +355,25 @@ void destroy_file_desc_t(file_desc_t* file);
 
 void init_comm_world();
 void grant_ggid(MPI_Comm virtualComm);
+
+void update_datatype_desc_t(datatype_desc_t* datatype);
+void update_op_desc_t(op_desc_t* op, MPI_User_function* user_fn, int commute);
+void update_request_desc_t(request_desc_t* request);
+void update_group_desc_t(group_desc_t* group);
+void update_comm_desc_t(comm_desc_t* comm);
+void update_file_desc_t(file_desc_t* file);
+
+void reconstruct_with_datatype_desc_t(datatype_desc_t* datatype);
+void reconstruct_with_op_desc_t(op_desc_t* op);
+void reconstruct_with_request_desc_t(request_desc_t* request);
+void reconstruct_with_group_desc_t(group_desc_t* group);
+void reconstruct_with_comm_desc_t(comm_desc_t* comm);
+void reconstruct_with_file_desc_t(file_desc_t* file);
+
+void update_descriptors();
+void reconstruct_with_descriptors();
+
+void destroy_g_world_group();
+void write_g_world_group();
 
 #endif // ifndef MPI_VIRTUAL_IDS_H


### PR DESCRIPTION
# Intro

This is a branch of the `dev/gc00/improve-virtualids` code intended for longer-term maintainability, review, and integration into main MANA. It is also intended to be the base for OpenMPI, ExaMPI, etc. development.

When cleaning up my code, I observed two problems, changed in this branch from `dev/gc00/improve-virtualids`:
1. ggids are no longer granted unconditionally. This caused problems when we created an internal communicator and it was granted a ggid (PRESUSPEND bug). I had solved the problem with a hack `get_vcomm_internal` before, this is a better solution. See `grant_ggid` and its usages.
2. ADD_NEW did not have precisely the same semantics as in main, because the equivalent of `realIdExists(real_id)` would be hacky to write. I've written up how this `realIdExists` functionality might look like, but without a two-level table, it is **very bad** for big apps, because we cannot iterate through only the descriptors of a single type. Please look at this part, @xuyao0127 . If we cannot develop and perfect a two-level table like this by camera-ready for SC23, we could revert to the old behavior. I don't think it caused problems, but it is different. Alternatively, as a workaround we could maintain several maps for the different types as before (but do away with string comparison and template class still).

Please, read over the FIXME comments I have written in reviewing, they contain points of interest and important questions/concerns.

I observe that this code does not pass the MemVerge C.I. 
If there was a way to view the results of this integration, and why it is not passing, that would be great.

# Contrib

Unfortunately, this is a pretty big PR. I tried to organize the commits so it is clear what commit is in which phase.

This PR does three main things:
### 1. Replace the old virtualid machinery 

(map from ints to ints, written in a C++ template and using dmtcp's `virtualidtable.h`) to a mapping from int to struct pointer, with each struct pointer containing both the Real ID for a some Virtual ID, and any metadata information required. I tried to write this part in a C-style. The ugliest part has to be the macros, but I thought that this was the cleanest way to write the code which depends on the particular MPI types, because they are not defined the same way even in the same implementation. For instance, `MPI_File` is a pointer even in MPICH. It also integrates well with the existing macros. Like @xuyao0127 says, the definition and usage of these macros are kind of strange and obtuse, or at least poorly documented (VIRTUAL_TO_REAL(real) == real). However, changing their behavior would mean changing them literally everywhere, making this PR even bigger. It could be a later project.  

The struct pointer architecture enables objectives 2 and 3 of the PR. It's also the part that enables portability between MPI implementations (with the exception of one FIXME comment in `init_comm_world`: @xuyao0127 , @JainTwinkle , I would appreciate your feedback/work here. I think it would be great if the MANA codebase was truly 100% the same between ExaMPI, OpenMPI, MPICH. Therefore, we need to integrate the `lh_constants_map` into every version.

If we only want to demonstrate the capability of checkpoint-restart with multiple MPI (without also improving performance in points 2, 3 and really flexing struct VIDs) this is all we have to test and enhance, just the first commit here. 

### 2. Integrate the old ggid machinery into the system in point 1. 
This means that we don't have to look up the same virtual id multiple times. An optimization.

### 3. Replace the log-replay architecture with a decode-recode architecture. 

This works readily for communicators, groups, and operators, because they can all be constructed in one go, when given the proper arguments. It is more difficult for datatypes, because datatypes cannot be "fully deserialized" in the same way. While operators also cannot be deserialized, it is not a problem because there is only way to create a new operator, and operators are not recursively defined, so it is trivial to just hook into operator creation. Datatypes that are "doubly-derived", i.e., user datatypes built using other user datatypes, do not immediately break down into MPI primitives. 

One way to solve this problem would be to maintain a dependency tree of datatypes: every wrapper that creates a datatype can record the virtual id, and mark that it is a dependency. Another way may be to implement our own full-deserialization, but this is probably technically difficult. Yet another is to preserve the log-replay system for datatypes exclusively. Either way, the point of this part is to enable faster runtime (we don't need to record MPI calls), faster restart (we don't have to replay MPI calls) at the cost of making checkpoint time slightly slower (we have to record the information for everything that's alive at checkpoint time).

# Future

Where to go from here:

* Resolve the FIXME
* Implement the two-level table
* Integrate `lh_constants_map`
* Rip out all of the LOG_CALL when we think decon-recon is good. (right now, restoreMpiLogState is disabled, but logging itself is not)
* Whatever else the reviewers think is fit.