### PR TITLE
Fix second restart

### DIFF
--- a/bin/mana_launch
+++ b/bin/mana_launch
@@ -47,6 +47,10 @@ while [ -n "$1" ]; do
     options="$options $1 $2"
     shift
   else
+    if [ "$1" == --quiet ] || [ "$!" == "-q" ]; then
+      export MANA_QUIET=1
+      # And --quiet is also a flag for DMTCP. Continue from here.
+    fi
     # other flags, options, and target_app executable
     options="$options $1"
     # The last word will be the target_app.

--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -19,23 +19,23 @@
  *  <http://www.gnu.org/licenses/>.                                         *
  ****************************************************************************/
 
-#ifdef SINGLE_CART_REORDER
+#include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
-#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/personality.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#ifdef SINGLE_CART_REORDER
 #include "cartesian.h"
 #endif
 
 #include <cxxabi.h>  /* For backtrace() */
 #include <execinfo.h>  /* For backtrace() */
-#include <fcntl.h>
-
-#include <signal.h>
-#include <sys/personality.h>
-#include <sys/mman.h>
 
 #include <regex>
 
@@ -458,7 +458,8 @@ dmtcp_skip_truncate_file_at_restart(const char* path)
 
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   snprintf(p2p_log_name, sizeof(p2p_log_name) - 1, P2P_LOG_MSG, rank);
-  snprintf(p2p_log_request_name, sizeof(p2p_log_request_name)-1, P2P_LOG_REQUEST, rank);
+  snprintf(p2p_log_request_name, sizeof(p2p_log_request_name)-1,
+           P2P_LOG_REQUEST, rank);
 
   if (strstr(path, p2p_log_name) ||
       strstr(path, p2p_log_request_name)) {
@@ -852,6 +853,26 @@ computeUnionOfCkptImageAddresses()
   dmtcp_add_to_ckpt_header("MANA_MinLibsStart", minLibsStartStr.c_str());
   dmtcp_add_to_ckpt_header("MANA_MaxLibsEnd", maxLibsEndStr.c_str());
   dmtcp_add_to_ckpt_header("MANA_MinHighMemStart", minHighMemStartStr.c_str());
+
+  if (!getenv("MANA_QUIET")) {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank == 0) {
+      char time_string[30];
+      time_t t = time(NULL);
+      strftime(time_string, sizeof(time_string), "%H:%M:%S", localtime(&t));
+      fprintf(stderr,
+              "%s: *** MANA: Checkpointing; MANA info saved for restart:\n"
+             "%*c      (Set env var MANA_QUIET to silence this.)\n",
+              time_string, (int)strlen(time_string), ' ');
+      fprintf(stderr, "  %s: %s\n",
+                      "MANA_MinLibsStart", minLibsStartStr.c_str());
+      fprintf(stderr, "  %s: %s\n",
+                      "MANA_MaxLibsEnd", maxLibsEndStr.c_str());
+      fprintf(stderr, "%s: %s\n",
+                      "  MANA_MinHighMemStart", minHighMemStartStr.c_str());
+    }
+  }
 }
 
 const char *


### PR DESCRIPTION
_The right solution for the second commit is to modify DMTCP so that it will automatically munmap mtcp_restart for its text/data/heap memory after restart.  Then MANA doesn't have to worry about it.  Until then, this PR should solve the problem, and allow MANA to handle ckpt-restart-ckpt-restart._

This fixes ~~two~~ one  bug that occurred in ckpt-restart-ckpt.  Please read carefully the commit messages of the two commits (one to fix the bug, and one to print debugging information during MANA ckpt.)

1. ~~In DMTCP, jalib::XToString seems to have a bug in it.  On a second ckpt for wave_mpi.mana.exe, we're saving the address of maxLibsEnd, instead of its value.  (See below.)~~
2. In MANA, we save the mtcp_restart in the checkpoint image, even though DMTCP can avoid doing this.  Then, on the second restart, we try to restore mtcp_restart from the ckpt image on top of the current mtcp_restart, and it fails.  This happens because mtcp_restart is always loaded starting at 0x11200000 

[ I was wrong about Point 1.  Working too late at night.   I read GDB wrong, and wrongly attributed the issues to C++.  :-( ]

@karya0 ,
    I think this intersect with the design of DMTCP.   Could it be that normal DMTCP removes mtcp_restart just fine before a second ckpt-restart, but maybe the restart-plugin feature fails to remove mtcp_restart?  Could you check this?
    It seems to me that the last commit should be something automatically done by DMTCP, and should not rely on MANA.
Thanks.