### PR TITLE
bin/mana_*: Use $HOME/.mana-slurm-$SLURM_JOB_ID.rc

### DIFF
--- a/bin/mana_coordinator
+++ b/bin/mana_coordinator
@@ -53,18 +53,31 @@ if [ "$verbose" == 1 ]; then
 fi
 
 coordinator_found=0
-$dir/dmtcp_coordinator $options --write-kv-data --exit-on-last -q --daemon --status-file $HOME/.mana && coordinator_found=1
+
+if [ ! -z "$SLURM_JOB_ID" ]; then
+  MANA_RC=$HOME/.mana-slurm-$SLURM_JOB_ID.rc
+else
+  MANA_RC=$HOME/.mana.rc
+fi
+
+$dir/dmtcp_coordinator $options --write-kv-data --exit-on-last -q --daemon --status-file $MANA_RC && coordinator_found=1
 set +x
 if [ $coordinator_found -eq 0 ]; then
   exit 3
 fi
 
-if [ "$SITE" = "nersc" ]; then
-  if [ -e $HOME/.mana ]; then
-    echo "SLURM_JOB_ID: $SLURM_JOB_ID" >> $HOME/.mana
+if [ ! -z "$SLURM_JOB_ID" ]; then
+  if [ -e "$MANA_RC" ]; then
+    echo "SLURM_JOB_ID: $SLURM_JOB_ID" >> $MANA_RC
+  else
+    echo '*** MANA problem: Running in Slurm job ' \
+         "$SLURM_JOB_ID; $MANA_RC not found"
   fi
 fi
-echo '*** '"Coordinator/job information written to $HOME/.mana"
+echo '' >> $MANA_RC
+echo '# This is a temporary file for communication between' >> $MANA_RC
+echo '#   mana_coordinator and mana_launch/mana_restart.' >> $MANA_RC
+echo '*** '"Coordinator/job information written to $MANA_RC"
 
 # srun -n1 -c1 --cpu-bind=cores bin/dmtcp_launch  -i10 -h `hostname` --no-gzip --join --disable-dl-plugin --with-plugin $PWD/lib/dmtcp/libmana.so contrib/mpi-proxy-split/test/mpi_hello_world.mana.exe
 

--- a/bin/mana_launch
+++ b/bin/mana_launch
@@ -47,6 +47,10 @@ while [ -n "$1" ]; do
     options="$options $1 $2"
     shift
   else
+    if [ "$1" == --quiet ] || [ "$!" == "-q" ]; then
+      export MANA_QUIET=1
+      # And --quiet is also a flag for DMTCP. Continue from here.
+    fi
     # other flags, options, and target_app executable
     options="$options $1"
     # The last word will be the target_app.
@@ -93,9 +97,15 @@ if ls -d ckpt_rank_* 2>/dev/null 1>&2; then
   exit 4
 fi
 
+if [ ! -z "$SLURM_JOB_ID" ]; then
+  MANA_RC=$HOME/.mana-slurm-$SLURM_JOB_ID.rc
+else
+  MANA_RC=$HOME/.mana.rc
+fi
+
 host=`hostname`
-submissionHost=`grep Host: $HOME/.mana | sed -e 's%Host: %%'|sed -e 's% .*$%%'`
-submissionPort=`grep Port: $HOME/.mana | sed -e 's%Port: %%'|sed -e 's% .*$%%'`
+submissionHost=`grep Host: $MANA_RC | sed -e 's%Host: %%'|sed -e 's% .*$%%'`
+submissionPort=`grep Port: $MANA_RC | sed -e 's%Port: %%'|sed -e 's% .*$%%'`
 
 coordinator_found=0
 $dir/dmtcp_command -s -h $submissionHost -p $submissionPort 1>/dev/null \
@@ -177,6 +187,9 @@ if [ "$verbose" == 1 ]; then
   set -x
 fi
 
+# Remove old ~/.mana_*.rc files from a week ago or more.
+find $HOME/.mana*.rc -ignore_readdir_race -maxdepth 0 -mtime +7 -type f -delete
+
 # TEMPORARY WORKAROUND:  set MPICH_SMP_SINGLE_COPY_OFF=1
 #   As MANA matures, these environment variable settings will not longer
 #   be needed.  Use these only if you have mysterious segfaults due
@@ -193,7 +206,7 @@ fi
 #   needs to send/receive a large message.
 
 exec env LD_LIBRARY_PATH="$libdir:$LD_LIBRARY_PATH" \
-    $dir/dmtcp_launch --coord-host $submissionHost \
+    $dir/dmtcp_launch --mpi --coord-host $submissionHost \
           --coord-port $submissionPort --no-gzip \
           --join-coordinator --disable-dl-plugin \
           --with-plugin $libdir/libmana.so $options

--- a/bin/mana_restart
+++ b/bin/mana_restart
@@ -25,10 +25,16 @@ if [ "$1" == "--help" -o "$1" == -h ] && [ -z "$2" ]; then
   exit 1
 fi
 
+if [ ! -z "$SLURM_JOB_ID" ]; then
+  MANA_RC=$HOME/.mana-slurm-$SLURM_JOB_ID.rc
+else
+  MANA_RC=$HOME/.mana.rc
+fi
+
 dir=`dirname $0`
 host=`hostname`
-submissionHost=`grep Host: $HOME/.mana | sed -e 's%Host: %%'|sed -e 's% .*$%%'`
-submissionPort=`grep Port: $HOME/.mana | sed -e 's%Port: %%'|sed -e 's% .*$%%'`
+submissionHost=`grep Host: $MANA_RC | sed -e 's%Host: %%'|sed -e 's% .*$%%'`
+submissionPort=`grep Port: $MANA_RC | sed -e 's%Port: %%'|sed -e 's% .*$%%'`
 
 options=""
 restartdir=""

--- a/bin/mana_status
+++ b/bin/mana_status
@@ -12,10 +12,16 @@
 #   exit 1
 # fi
 
+if [ ! -z "$SLURM_JOB_ID" ]; then
+  MANA_RC=$HOME/.mana-slurm-$SLURM_JOB_ID.rc
+else
+  MANA_RC=$HOME/.mana.rc
+fi
+
 dir=`dirname $0`
 host=`hostname`
-submissionHost=`grep Host: $HOME/.mana | sed -e 's%Host: %%'|sed -e 's% .*$%%'`
-submissionPort=`grep Port: $HOME/.mana | sed -e 's%Port: %%'|sed -e 's% .*$%%'`
+submissionHost=`grep Host: $MANA_RC | sed -e 's%Host: %%'|sed -e 's% .*$%%'`
+submissionPort=`grep Port: $MANA_RC | sed -e 's%Port: %%'|sed -e 's% .*$%%'`
 
 options=""
 verbose=0


### PR DESCRIPTION
This adds the SLURM_JOB_ID to the bin/mana_* scripts.  This allows multiple SLURM jobs to run safely.

Otherwise, two jobs could both call `bin/mana_coordinator` simultaneously, overwriting the `.mana` file with a single file.  This later causes two independent jobs to use a single `.mana` file when running `bin/mana_launch` or `bin/mana_restart`.