### PR TITLE
REVERT potential resource leak fix (and added new comments)

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
@@ -50,25 +50,6 @@ USER_DEFINED_WRAPPER(int, Comm_group, (MPI_Comm) comm, (MPI_Group *) group)
   return retval;
 }
 
-// Calls MPI_Comm_group to define a new group for internal purposes.
-// See: p2p_drain_send_recv.cpp
-int
-MPI_Comm_internal_virt_group(MPI_Comm comm, MPI_Group *group)
-{
-  int retval;
-  DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
-  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
-  retval = NEXT_FUNC(Comm_group)(realComm, group);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS) {
-    MPI_Group virtGroup = ADD_NEW_GROUP(*group);
-    *group = virtGroup;
-  }
-  DMTCP_PLUGIN_ENABLE_CKPT();
-  return retval;
-}
-
 USER_DEFINED_WRAPPER(int, Group_size, (MPI_Group) group, (int *) size)
 {
   int retval;


### PR DESCRIPTION
In PR #348 , I wrote code that would remove the MPI_Group `group_world` created in `registerLocalSendsAndRecvs` unconditionally.

But this is problematic because of the semantics of the ADD_NEW macro. See virtual-ids.h, lines 214-223. If the group does not yet exist, this is indeed an extra group. However, if the group already exists (i.e., the application has created the same `group_world`), then there is a collision, and the free can make a restart fail, for it erases a group that the application depends on, or one of the child groups depends on. See `mpi-proxy-split/mpi-wrappers/mpi_group_wrappers`, line 100-105. (This is in some sense fixed by virtual-ids, in that there is no more dependency between groups in this way).

This can cause an extra LOG_CALL and LOG_REPLAY to occur as written, but it is not a huge problem. We are working to remove LOG_CALL and LOG_REPLAY altogether in `virtualids-v2` anyways.

For now, we should probably revert these changes for the main branch. I have done so, and also wrote some commentary to explain the situation.