### PR TITLE
end2 value now tracks start2 value

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
@@ -50,25 +50,6 @@ USER_DEFINED_WRAPPER(int, Comm_group, (MPI_Comm) comm, (MPI_Group *) group)
   return retval;
 }
 
-// Calls MPI_Comm_group to define a new group for internal purposes.
-// See: p2p_drain_send_recv.cpp
-int
-MPI_Comm_internal_virt_group(MPI_Comm comm, MPI_Group *group)
-{
-  int retval;
-  DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
-  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
-  retval = NEXT_FUNC(Comm_group)(realComm, group);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS) {
-    MPI_Group virtGroup = ADD_NEW_GROUP(*group);
-    *group = virtGroup;
-  }
-  DMTCP_PLUGIN_ENABLE_CKPT();
-  return retval;
-}
-
 USER_DEFINED_WRAPPER(int, Group_size, (MPI_Group) group, (int *) size)
 {
   int retval;

--- a/restart_plugin/mtcp_restart_plugin.c
+++ b/restart_plugin/mtcp_restart_plugin.c
@@ -599,7 +599,7 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
     // Reserve 8MB above min high memory region. That should include space for
     // stack, argv, env, auxvec.
     start2 = rinfo->pluginInfo.minHighMemStart - 1 * GB; // Allow for stack to grow
-    end2 = rinfo->pluginInfo.minHighMemStart + 8 * MB;
+    end2 = start2 + 8 * MB;
     // Ignore region start2:end2 if it is overlapped with region start1:end1
     if (is_overlap(start1, end1, start2, end2)) {
       if (end1 < end2) { end1 = end2; }
@@ -811,7 +811,7 @@ mtcp_plugin_hook(RestoreInfo *rinfo)
     // Reserve 8MB above min high memory region. That should include space for
     // stack, argv, env, auxvec.
     start2 = rinfo->pluginInfo.minHighMemStart - 1 * GB; // Allow for stack to grow
-    end2 = rinfo->pluginInfo.minHighMemStart + 8 * MB;
+    end2 = start2 + 8 * MB;
     // Ignore region start2:end2 if it is overlapped with region start1:end1
     if (is_overlap(start1, end1, start2, end2)) {
       if (end1 < end2) { end1 = end2; }


### PR DESCRIPTION
Simple two-liner fix. This appears to be relevant to restarting correctly on Discovery.