### PR TITLE
A temporary MPI_Alltoall workaround to hanging programs

### DIFF
--- a/bin/mana_launch
+++ b/bin/mana_launch
@@ -19,8 +19,8 @@
 dir=`dirname $0`
 
 if [ -z "$1" ]; then
-  echo "USAGE:  $0 [--verbose] [DMTCP_OPTIONS ...] [--ckptdir DIR]" \\
-  echo "                                                       MANA_EXECUTABLE"
+  echo "USAGE: $0 [--verbose] [--timing] [DMTCP_OPTIONS ...]" \\
+  echo "                                       [--ckptdir DIR] MANA_EXECUTABLE"
   echo "        For DMTCP options, do: $0 --help"
   echo "  NOTE: MANA_EXECUTABLE must be compiled with libmpistub.so"
   echo "        See $dir/../contrib/mpi-proxy-split/test/ for examples."
@@ -35,6 +35,8 @@ srun_sbatch_found=0
 while [ -n "$1" ]; do
   if [ "$1" == --verbose ]; then
     verbose=1
+  elif [ "$1" == --timing ]; then
+    export MANA_TIMING=1
   elif [ "$1" == --help ]; then
     help=1
   elif [ "$1" == srun ] || [ "$1" == sbatch ]; then
@@ -60,6 +62,13 @@ while [ -n "$1" ]; do
 done
 
 if [ "$help" -eq 1 ]; then
+  echo 'MANA OPTIONS:'
+  echo '--verbose:  Display the underlying DMTCP command and DMTCP_OPTIONS used'
+  echo '            and other info.'
+  echo '--timing:  Print times to stderr for INIT, EXIT,' \
+                  'and ckkpt-restart events'
+  echo '           (stays active during both mana_launch and mana_restart)'
+  echo ''
   $dir/dmtcp_launch --help $options
   exit 0
 fi

--- a/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
@@ -50,25 +50,6 @@ USER_DEFINED_WRAPPER(int, Comm_group, (MPI_Comm) comm, (MPI_Group *) group)
   return retval;
 }
 
-// Calls MPI_Comm_group to define a new group for internal purposes.
-// See: p2p_drain_send_recv.cpp
-int
-MPI_Comm_internal_virt_group(MPI_Comm comm, MPI_Group *group)
-{
-  int retval;
-  DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
-  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
-  retval = NEXT_FUNC(Comm_group)(realComm, group);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS) {
-    MPI_Group virtGroup = ADD_NEW_GROUP(*group);
-    *group = virtGroup;
-  }
-  DMTCP_PLUGIN_ENABLE_CKPT();
-  return retval;
-}
-
 USER_DEFINED_WRAPPER(int, Group_size, (MPI_Group) group, (int *) size)
 {
   int retval;


### PR DESCRIPTION
This commit is to work around a hanging issue during launch surfaced during testing a series of workloads including VASP5/PdO4, VASP6/Si256 etc...