### PR TITLE
Add an internal barrier to MPI_Finalize wrapper

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
@@ -133,6 +133,10 @@ USER_DEFINED_WRAPPER(int, Finalize, (void))
   // The workaround here is to simply return success to the caller without
   // calling into the real Finalize function in the lower half. This way
   // the application can proceed to exit without getting blocked forever.
+
+  // Prevent other ranks from blowing through MPI_Finalize early, causing
+  // shutdown of the MPI runtime
+  MPI_Barrier(MPI_COMM_WORLD);
   return MPI_SUCCESS;
 }
 


### PR DESCRIPTION
A pattern some applications have is:

1. `INITIALIZE`
2. `WHILE(X); WORK`
3. `IF RANK == 0; PRINT_FINAL_INFO()`
4. `MPI_Finalize()`
5. Program exit, return 0; etc

This can be problematic when running under MANA, because while rank 0 is busy doing `PRINT_FINAL_INFO()`, ranks 1, 2, 3, 4 etc. blow through `MPI_Finalize` and go into program exit. Then, the MPI runtime can decide to kill rank 0. The result is that `PRINT_FINAL_INFO` never finishes.
It appears that this fix also enables programs to print all of their output. Sometimes, applications would print their output only in chunks of 4097~ characters, and are killed before they can finish the next chunk. 

Basic testing suggests that this works.
But the FIXME comment suggests that MPI_Finalize is a complicated issue and might even be MPI-dependent. It should be looked at thoroughly. 

I also looked at https://www.mpi-forum.org/docs/mpi-2.0/mpi-20-html/node32.htm . They write:

> Advice to implementors.

>An implementation may need to delay the return from MPI_FINALIZE until all potential future message cancellations have been processed. One possible solution is to place a barrier inside MPI_FINALIZE ( End of advice to implementors.) 

So, this idea is not without precedent.

