### PR TITLE
Add libnl.a to build MANA

### DIFF
--- a/mpi-proxy-split/lower-half/Makefile
+++ b/mpi-proxy-split/lower-half/Makefile
@@ -68,6 +68,12 @@ endif
 # ***        ./configure --disable-xml2 --disable-libxml2 ...
 # ***        or unless you installed the necessary libaries.
 # ***        See ./README.mpich-static here, for how to install the libaries
+# NOTE:  The static library libnl-3.a must be built specially.  A suggested recipe is:
+# Search for and download libnl3-3.3.0-1.29.src.rpm
+# rpm -i libnl3-3.3.0-1.29.src.rpm
+# rpmbuild -ba ~/rpmbuild/SPECS/libnl3.spec
+# cd ~/rpmbuild/BUILD/libnl-3.3.0/lib/.libs/
+# Build libnl-3.a from lib_libnl_3_la-*.o
 ${PROXY_BIN}: ${PROXY_OBJS} ${LIBPROXY}.a ${STATIC_GETHOSTBYNAME}
 	if ${MPICC} -v 2>&1 | grep -q 'MPICH version'; then \
 	  rm -f tmp.sh; \

--- a/mpi-proxy-split/lower-half/static_libs.txt
+++ b/mpi-proxy-split/lower-half/static_libs.txt
@@ -1,1 +1,1 @@
--lpmi -lpmi2 /opt/cray/libfabric/1.15.2.0/lib64/libfabric.a -lcxi -L/global/homes/z/zz217/local/lib -L/global/cfs/cdirs/cr/pm_dependencies -ljson-c -lcurl  -lssl -lcrypto -lz -latomic -lpthread /opt/cray/pe/pals/1.2.11/lib/libpals.a
+-lpmi -lpmi2 /opt/cray/libfabric/1.15.2.0/lib64/libfabric.a -lcxi -L/global/homes/z/zz217/local/lib -L/global/cfs/cdirs/cr/pm_dependencies -ljson-c -lcurl  -lssl -lcrypto -lz -latomic -lpthread /opt/cray/pe/pals/1.2.11/lib/libpals.a libnl-3.a

--- a/mpi-proxy-split/lower-half/static_libs.txt
+++ b/mpi-proxy-split/lower-half/static_libs.txt
@@ -1,1 +1,1 @@
--lpmi -lpmi2 /opt/cray/libfabric/1.15.2.0/lib64/libfabric.a -lcxi -L/global/homes/z/zz217/local/lib -L/global/cfs/cdirs/cr/pm_dependencies -ljson-c -lcurl  -lssl -lcrypto -lz -latomic -lpthread /opt/cray/pe/pals/1.2.4/lib/libpals.a
+-lpmi -lpmi2 /opt/cray/libfabric/1.15.2.0/lib64/libfabric.a -lcxi -L/global/homes/z/zz217/local/lib -L/global/cfs/cdirs/cr/pm_dependencies -ljson-c -lcurl  -lssl -lcrypto -lz -latomic -lpthread /opt/cray/pe/pals/1.2.11/lib/libpals.a


### PR DESCRIPTION
This change adds libnl-3.a library to build lower-half. It also fixes the lower half makefile to use the right version of libpal.a on Perlmutter. 