### PR TITLE
Fix for commit 1bede81 (PR #379)

### DIFF
--- a/mpi-proxy-split/mpi_plugin.h
+++ b/mpi-proxy-split/mpi_plugin.h
@@ -49,9 +49,6 @@
 #define PMPI_IMPL(ret, func, ...)                               \
   EXTERNC ret P##func(__VA_ARGS__) __attribute__ ((weak, alias (#func)));
 
-extern int *g_numMmaps;
-extern MmapInfo_t *g_list;
-
 bool isUsingCollectiveToP2p();
 void recordPreMpiInitMaps();
 void recordPostMpiInitMaps();

--- a/mpi-proxy-split/p2p_log_replay.cpp
+++ b/mpi-proxy-split/p2p_log_replay.cpp
@@ -77,19 +77,14 @@ updateCkptDirByRank()
   o << baseDir << "/ckpt_rank_" << g_world_rank;
   dmtcp_set_ckpt_dir(o.str().c_str());
 
-  if (!g_list || g_numMmaps == NULL || *g_numMmaps == 0) return;
+#if 0
   o << "/lhregions.dat";
   dmtcp::string fname = o.str();
   int fd = open(fname.c_str(), O_CREAT | O_WRONLY, 0600);
-#if 0
   // g_range (lh_memory_range) was written for debugging here.
   Util::writeAll(fd, g_range, sizeof(*g_range));
-#endif
-  Util::writeAll(fd, g_numMmaps, sizeof(*g_numMmaps));
-  for (int i = 0; i < *g_numMmaps; i++) {
-    Util::writeAll(fd, &g_list[i], sizeof(g_list[i]));
-  }
   close(fd);
+#endif
 }
 
 void


### PR DESCRIPTION
In PR #379, it was supposed to remove all references to `g_list` and `g_numMmaps`.  But it didn't do that.  So, it produce a runtime error, undefined reference to `g_numMmaps`.  This PR fixes that issue by removing the remaining references to `g_list` and `g_numMmaps`.