### PR TITLE
Fix compile-error in 91834d : __wrap_shmat

### DIFF
--- a/mpi-proxy-split/lower-half/shmat.c
+++ b/mpi-proxy-split/lower-half/shmat.c
@@ -22,8 +22,8 @@ __wrap_shmat(int shmid, const void *shmaddr, int shmflg)
     char msg[] = "*** WARNING:  lh shmat called with non-NULL shmaddr\n"
                  "***           This is not currently handled by MANA.\n";
     write(2, msg, sizeof(msg));
-    if (shmflag & SHM_REMAP) {
-      char msg2[] = "*** WARNING:  shmflag had SHM_REMAP set.\n");
+    if (shmflg & SHM_REMAP) {
+      char msg2[] = "*** WARNING:  shmflg had SHM_REMAP set.\n");
       write(2, msg2, sizeof(msg));
     }
   }


### PR DESCRIPTION
 * Apparently, Jenkins CI didn't catch build error: shmflag not declared.
      This fixes the prior commit:  shmflag -> shmflg