### PR TITLE
Fix 2nd compile in 91834d: __wrap_shmat (CI broke)

### DIFF
--- a/mpi-proxy-split/lower-half/shmat.c
+++ b/mpi-proxy-split/lower-half/shmat.c
@@ -23,7 +23,7 @@ __wrap_shmat(int shmid, const void *shmaddr, int shmflg)
                  "***           This is not currently handled by MANA.\n";
     write(2, msg, sizeof(msg));
     if (shmflg & SHM_REMAP) {
-      char msg2[] = "*** WARNING:  shmflg had SHM_REMAP set.\n");
+      char msg2[] = "*** WARNING:  shmflg had SHM_REMAP set.\n";
       write(2, msg2, sizeof(msg));
     }
   }


### PR DESCRIPTION
The stupid Jenkins CI is still broken.  Here's another compile file.

Unfortunately, it makes the workflow difficult, because we can't assume that Jenkins is doing the checks.  So, we have to wait until we have an opening in our schedule, so that we can do the work that Jenkins was supposed to have done.  :-(