### PR TITLE
Misc. build-related changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,5 @@ build/
 
 mpi-proxy-split/mpi-wrappers/p2p-deterministic.h
 mpi-proxy-split/mpi-wrappers/mana_p2p_update_logs
-manpages/mana.1.gz 
+restart_plugin/lower_half_api.h
+manpages/mana.1.gz

--- a/Makefile.in
+++ b/Makefile.in
@@ -36,6 +36,9 @@ targetdir = $(top_builddir)
 INSTALL_FLAGS = install
 UNINSTALL_FLAGS = uninstall
 
+# If 'DMTCP_ROOT' env. var. is defined, use that instead of dmtcp submodule.
+DMTCP_ROOT ?= $(top_builddir)/dmtcp
+
 # Macros TEST and XTERM_E used on command line by check1, check2, ...:
 #   make TEST=readline XTERM_E="xterm -e" check-readline
 
@@ -48,9 +51,9 @@ mana: mana_prereqs dmtcp
 	cd mpi-proxy-split && $(MAKE) install && $(MAKE) -j tests
 
 dmtcp: restart_plugin/lower_half_api.h
-	cd dmtcp && $(MAKE)
-	cp -rf dmtcp/bin .
-	cp -rf dmtcp/lib .
+	cd ${DMTCP_ROOT} && $(MAKE)
+	cp -rf ${DMTCP_ROOT}/bin .
+	cp -rf ${DMTCP_ROOT}/lib .
 
 # This could be a symbolic link.  But a full copy seems safer.
 restart_plugin/lower_half_api.h: mpi-proxy-split/lower-half/lower_half_api.h
@@ -65,17 +68,17 @@ create-dirs:
 	$(INSTALL) -d $(DESTDIR)$(mandir)/man1
 
 install: all create-dirs
-	cd dmtcp && make DESTDIR=$(DESTDIR) $(INSTALL_FLAGS)
+	cd ${DMTCP_ROOT} && make DESTDIR=$(DESTDIR) $(INSTALL_FLAGS)
 	cd mpi-proxy-split && make DESTDIR=$(DESTDIR) $(INSTALL_FLAGS)
 	cd manpages && make DESTDIR=$(DESTDIR) $(INSTALL_FLAGS)
 
 uninstall:
-	cd dmtcp && make DESTDIR=$(DESTDIR) $(UNINSTALL_FLAGS)
+	cd ${DMTCP_ROOT} && make DESTDIR=$(DESTDIR) $(UNINSTALL_FLAGS)
 	cd mpi-proxy-split && make DESTDIR=$(DESTDIR) $(UNINSTALL_FLAGS)
 	cd manpages && make DESTDIR=$(DESTDIR) $(UNINSTALL_FLAGS)
 
 distclean: clean
-	- cd dmtcp && $(MAKE) distclean
+	- cd ${DMTCP_ROOT} && $(MAKE) distclean
 	- cd mpi-proxy-split && $(MAKE) distclean
 	- cd manpages && $(MAKE) distclean
 	rm -f Makefile config.log config.status config.status-* config.cache
@@ -89,7 +92,7 @@ tidy:
 	rm -f dmtcp_coordinator_db-*.json
 
 clean: tidy
-	- cd dmtcp && $(MAKE) clean
+	- cd ${DMTCP_ROOT} && $(MAKE) clean
 	- cd mpi-proxy-split && $(MAKE) clean
 
 mana_prereqs:

--- a/mpi-proxy-split/test/Makefile
+++ b/mpi-proxy-split/test/Makefile
@@ -162,8 +162,7 @@ check-integrated_dmtcp_text: tidy integrated_dmtcp_test
 	$(MPIFORTRAN) ${FFLAGS} -g3 -O0 -o $@ $<
 
 %.mana.exe: %.f90
-	$(MPIFORTRAN) ${FFLAGS} -g3 -O0 -o $@ $<
-	  ${LDFLAGS_DUMMY}
+	$(MPIFORTRAN) ${FFLAGS} -g3 -O0 -o $@ $< ${LDFLAGS_DUMMY}
 
 %.exe: %.o
 	 $(MPICC) -o $@ $< ${MPI_LDFLAGS}


### PR DESCRIPTION
Adding DMTCP_ROOT to the Makefile to make it flexible when using an external DMTCP repo instead of the dmtcp submodule. 
