### PR TITLE
Add page after heap and change sbrk wrapper to return -1 for mtcp_restart, lh_proxy, upper half; after libc_start_main

### DIFF
--- a/mpi-proxy-split/lower-half/libproxy.c
+++ b/mpi-proxy-split/lower-half/libproxy.c
@@ -338,6 +338,7 @@ void first_constructor()
     lh_info.startText = (void*)start;
     lh_info.endText = (void*)end;
     lh_info.endOfHeap = (void*)heap.endAddr;
+    lh_info.endOfHeapFrozenAddr = &endOfHeapFrozen;
     lh_info.libc_start_main = &__libc_start_main;
     lh_info.main = &main;
     lh_info.libc_csu_init = &__libc_csu_init;

--- a/mpi-proxy-split/lower-half/libproxy.c
+++ b/mpi-proxy-split/lower-half/libproxy.c
@@ -32,6 +32,7 @@
 #include <dlfcn.h>
 #include <link.h>
 #include <assert.h>
+#include <sys/mman.h>
 #include <sys/syscall.h>
 #include <asm/prctl.h>
 #include <sys/prctl.h>
@@ -49,7 +50,7 @@
 extern int MPI_MANA_Internal(char *dummy);
 
 #include "libproxy.h"
-#include "mmap_internal.h"  // included for definition of ROUND_UP
+#include "mmap_internal.h"  // included for definition of ROUND_UP, LH_MMAP_CALL
 #include "mpi_copybits.h"
 #include "procmapsutils.h"
 #include "lower_half_api.h"

--- a/mpi-proxy-split/lower-half/lower_half_api.h
+++ b/mpi-proxy-split/lower-half/lower_half_api.h
@@ -62,6 +62,7 @@ typedef struct _LowerHalfInfo
   void *startText; // Start address of text segment (R-X) of lower half
   void *endText;   // End address of text segmeent (R-X) of lower half
   void *endOfHeap; // Pointer to the end of heap segment of lower half
+  int *endOfHeapFrozenAddr; // Pointer to boolean; Stopextending heap
   void *libc_start_main; // Pointer to libc's __libc_start_main function in statically-linked lower half
   void *main;      // Pointer to the main() function in statically-linked lower half
   void *libc_csu_init; // Pointer to libc's __libc_csu_init() function in statically-linked lower half

--- a/mpi-proxy-split/lower-half/mmap64.c
+++ b/mpi-proxy-split/lower-half/mmap64.c
@@ -50,33 +50,11 @@
 
 #define HAS_MAP_FIXED_NOREPLACE LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
 
-#ifdef __NR_mmap2
-# define LH_MMAP_CALL(addr, len, prot, flags, fd, offset) \
-           (void *)MMAP_CALL(mmap2, addr, len, prot, flags, fd, \
-                                    (off_t) (offset / MMAP2_PAGE_UNIT))
-#else
-# define LH_MMAP_CALL(addr, len, prot, flags, fd, offset) \
-           (void *)MMAP_CALL(mmap, addr, len, prot, flags, fd, offset)
-#endif
-
 // We write this into our rserved lh_memRange memory, to see if anyone
 //   modified our memory.
 // FIXME:  We don't restore CANARY_BYTE when we munmap memory.  But it's not
 //         a current problem.  We add mmap regions only at end of lh_memRange
 #define CANARY_BYTE ((char)0b10101010)
-
-#ifndef __set_errno
-# define __set_errno(Val) errno = (Val)
-#endif
-
-/* Set error number and return -1.  A target may choose to return the
-   internal function, __syscall_error, which sets errno and returns -1.
-   We use -1l, instead of -1, so that it can be casted to (void *).  */
-#define INLINE_SYSCALL_ERROR_RETURN_VALUE(err)  \
-  ({						\
-    __set_errno (err);				\
-    -1l;					\
-  })
 
 /* To avoid silent truncation of offset when using mmap2, do not accept
    offset larger than 1 << (page_shift + off_t bits).  For archictures with

--- a/mpi-proxy-split/lower-half/mmap_internal.h
+++ b/mpi-proxy-split/lower-half/mmap_internal.h
@@ -274,4 +274,6 @@ extern int numRegions;
 extern MmapInfo_t mmaps[MAX_TRACK];
 extern void *nextFreeAddr;
 
+extern int endOfHeapFrozen;
+
 #endif /* MMAP_INTERNAL_LINUX_H  */

--- a/mpi-proxy-split/lower-half/sbrk.c
+++ b/mpi-proxy-split/lower-half/sbrk.c
@@ -15,6 +15,29 @@
    License along with the GNU C Library; if not, see
    <http://www.gnu.org/licenses/>.  */
 
+/****************************************************************************
+ *   Copyright (C) 2019-2023 by Kapil AryaGene Cooperman, Rohan Garg, Yao Xu*
+ *   kapil.arya.17@gmail.com, gene@ccs.neu.edu, rohgarg@ccs.neu.edu,        *
+ *     xu.yao1@northeastern.edu                                             *
+ *                                                                          *
+ *  This file is part of DMTCP.                                             *
+ *                                                                          *
+ *  DMTCP is free software: you can redistribute it and/or                  *
+ *  modify it under the terms of the GNU Lesser General Public License as   *
+ *  published by the Free Software Foundation, either version 3 of the      *
+ *  License, or (at your option) any later version.                         *
+ *                                                                          *
+ *  DMTCP is distributed in the hope that it will be useful,                *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ *  GNU Lesser General Public License for more details.                     *
+ *                                                                          *
+ *  You should have received a copy of the GNU Lesser General Public        *
+ *  License in the files COPYING and COPYING.LESSER.  If not, see           *
+ *  <http://www.gnu.org/licenses/>.                                         *
+ ****************************************************************************/
+
+#include <assert.h>
 #include <errno.h>
 #include <stdint.h>
 #include <unistd.h>
@@ -33,31 +56,44 @@ extern int __brk (void *addr);
 static int __libc_multiple_libcs = 0;
 
 void *__endOfHeap = 0;
-int endOfHeapFrozen = 0; // When we set this, sbrk will always return -1.
+int endOfHeapFrozen = 0; // When we set this, sbrk will always return -1
 
 #define PAGE_SIZE 4096
 
 #define ROUND_UP(addr) ((unsigned long)(addr + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1))
 
-#ifndef __set_errno
-# define __set_errno(Val) errno = (Val)
-#endif
-
-#ifdef __NR_mmap2
-# define LH_MMAP_CALL(addr, len, prot, flags, fd, offset) \
-           (void *)MMAP_CALL(mmap2, addr, len, prot, flags, fd, \
-                                    (off_t) (offset / MMAP2_PAGE_UNIT))
-#else
-# define LH_MMAP_CALL(addr, len, prot, flags, fd, offset) \
-           (void *)MMAP_CALL(mmap, addr, len, prot, flags, fd, offset)
-#endif
-
 /* Extend the process's data space by INCREMENT.
    If INCREMENT is negative, shrink data space by - INCREMENT.
    Return start of new space allocated, or -1 for errors.  */
 void *
-__sbrk (intptr_t increment)
+__sbrk(intptr_t increment)
 {
+  // uh sets lh_info.endOfHeapFrozenAddr after libc_start_main finixhes.
+  if (endOfHeapFrozen) {
+    /* We always return a failure unless the increment is 0 (to ask to current
+     * end-of-break). Malloc libraries handle -1 by initializing new arenas.
+     */
+    static int firstTime = 1;
+    if (firstTime) {
+      firstTime = 0;
+      // Mmap a page at the end of the break in case glibc tries to extend heap
+      // NOTE:  This is needed for mtcp_restart, lh_proxy, and the upper half.
+      // Rationale:  On restart, the end-of-heap is not here, but at
+      //             the end-of-heap for mtcp_restart.  Luckily, glibc
+      //             caches 'sbrk(0)', which is here.  So, glibc should
+      //             detect that there is an mmap'ed region just beyond it,
+      //             thus causing glibc to allocate a second arena elsewhere.
+      assert(MAP_FAILED != LH_MMAP_CALL(__curbrk, 4096, PROT_NONE,
+                                        MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED,
+                                        -1, 0));
+    }
+    if (increment == 0) {
+      return __curbrk;
+    } else {
+      return -1;
+    }
+  }
+
   void *oldbrk;
 
   /* If this is not part of the dynamic library or the library is used
@@ -66,7 +102,7 @@ __sbrk (intptr_t increment)
      instances of __brk and __sbrk can share the heap, returning
      interleaved pieces of it.  */
   if (__curbrk == NULL || __libc_multiple_libcs)
-    if (__brk (0) < 0)		/* Initialize the break.  */
+    if (__brk (0) < 0)		/* Initialize the break, __curbrk.  */
       return (void *) -1;
     else
       __endOfHeap = __curbrk;

--- a/mpi-proxy-split/lower-half/sbrk.c
+++ b/mpi-proxy-split/lower-half/sbrk.c
@@ -33,6 +33,7 @@ extern int __brk (void *addr);
 static int __libc_multiple_libcs = 0;
 
 void *__endOfHeap = 0;
+int endOfHeapFrozen = 0; // When we set this, sbrk will always return -1.
 
 #define PAGE_SIZE 4096
 

--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -1103,6 +1103,18 @@ mpi_plugin_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
 
       heapAddr = sbrk(0);
       JASSERT(heapAddr != nullptr);
+      // FIXME:  If we use PROT_NONE (preferred), then an older DMTCP
+      //         will not restore this memory region.
+      // By creating a memory page just beyond the end of the heap,
+      // this will prevent glibc from extending the main malloc arena.
+      // So, glibc will create a second arena.
+      // NOTE:  This is needed for mtcp_restart, lh_proxy, and the upper half.
+      // Rationale:  On restart, the end-of-heap is not here, but at
+      //             the end-of-heap for mtcp_restart.  Luckily, glibc
+      //             caches 'sbrk(0)', which is here.  So, glibc should
+      //             detect that there is an mmap'ed region just beyond it,
+      //             thus causing glibc to allocate a second arena elsewhere.
+      mmap(heapAddr, 4096, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
 
       break;
     }

--- a/mpi-proxy-split/mtcp_split_process.h
+++ b/mpi-proxy-split/mtcp_split_process.h
@@ -51,6 +51,7 @@ typedef struct LowerHalfInfo
   void *startText;
   void *endText;
   void *endOfHeap;
+  int *endOfHeapFrozenAddr;
   void *libc_start_main;
   void *main;
   void *libc_csu_init;

--- a/restart_plugin/mtcp_split_process.c
+++ b/restart_plugin/mtcp_split_process.c
@@ -416,6 +416,8 @@ initializeLowerHalf(RestoreInfo *rinfo)
     fnc((mainFptr)lh_info_addr->main, argc, argv,
         (mainFptr)lh_info_addr->libc_csu_init,
         (finiFptr)lh_info_addr->libc_csu_fini, 0, stack_end);
+    // Prevent lh malloc from extending main heap; Also, sbrk returns -1 in lh
+    *lh_info_addr->endOfHeapFrozenAddr = 1;
   }
   DPRINTF("After getcontext");
   patchAuxv(auxvec, 0, 0, 0);


### PR DESCRIPTION
Without this fix, the restart or upper half can crash with libc:sysmalloc on stack when sysmalloc tries to call libc:morecore, which tries to call sbrk to extend the main (original) heap.