### PR TITLE
Add FI_MR_CACHE_MONITOR=memhooks in mana_restart

### DIFF
--- a/bin/mana_restart
+++ b/bin/mana_restart
@@ -63,6 +63,10 @@ if [ "$help" -eq 1 ]; then
   exit 0
 fi
 
+# On Perlmutter, on August 16, 2023, an update made FI_MR_CACHE_MONITOR
+# necessary.  See https://docs.nersc.gov/systems/perlmutter/timeline/
+# for details.
+
 SITE=unknown
 if [ "$NERSC_HOST" = "cori" ]; then
   SITE=nersc
@@ -70,6 +74,7 @@ elif [ "$NERSC_HOST" = "gerty" ]; then
   SITE=nersc
 elif [ "$NERSC_HOST" = "perlmutter" -o "$LMOD_SYSTEM_NAME" = "perlmutter" ]; then
   SITE=nersc
+  export FI_MR_CACHE_MONITOR=memhooks
 fi
 
 if [ "$restartdir" = "" ]; then


### PR DESCRIPTION
We also need the `FI_MR_CACHE_MONITOR=memhooks` environment variable in the mana_restart script for Perlmutter.  This was done for Perlmutter in the mana_launch script in commit 823aef0.