### PR TITLE
Disable "passthrough" mode for coll. comm.

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -86,7 +86,7 @@ USER_DEFINED_WRAPPER(int, Bcast,
                      (void *) buffer, (int) count, (MPI_Datatype) datatype,
                      (int) root, (MPI_Comm) comm)
 {
-  bool passthrough = true;
+  bool passthrough = false;
   commit_begin(comm, passthrough);
   int retval;
 #if 0 // for debugging
@@ -287,7 +287,7 @@ USER_DEFINED_WRAPPER(int, Reduce,
                      (MPI_Datatype) datatype, (MPI_Op) op,
                      (int) root, (MPI_Comm) comm)
 {
-  bool passthrough = true;
+  bool passthrough = false;
   commit_begin(comm, passthrough);
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -343,7 +343,7 @@ USER_DEFINED_WRAPPER(int, Reduce_scatter,
                      (const int) recvcounts[], (MPI_Datatype) datatype,
                      (MPI_Op) op, (MPI_Comm) comm)
 {
-  bool passthrough = true;
+  bool passthrough = false;
   commit_begin(comm, passthrough);
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -514,7 +514,7 @@ USER_DEFINED_WRAPPER(int, Gather, (const void *) sendbuf, (int) sendcount,
                      (MPI_Datatype) sendtype, (void *) recvbuf, (int) recvcount,
                      (MPI_Datatype) recvtype, (int) root, (MPI_Comm) comm)
 {
-  bool passthrough = true;
+  bool passthrough = false;
   commit_begin(comm, passthrough);
   int retval;
   // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
@@ -544,7 +544,7 @@ USER_DEFINED_WRAPPER(int, Gatherv, (const void *) sendbuf, (int) sendcount,
                      (const int*) recvcounts, (const int*) displs,
                      (MPI_Datatype) recvtype, (int) root, (MPI_Comm) comm)
 {
-  bool passthrough = true;
+  bool passthrough = false;
   commit_begin(comm, passthrough);
   int retval;
   // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
@@ -569,7 +569,7 @@ USER_DEFINED_WRAPPER(int, Scatter, (const void *) sendbuf, (int) sendcount,
                      (MPI_Datatype) sendtype, (void *) recvbuf, (int) recvcount,
                      (MPI_Datatype) recvtype, (int) root, (MPI_Comm) comm)
 {
-  bool passthrough = true;
+  bool passthrough = false;
   commit_begin(comm, passthrough);
   int retval;
   // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
@@ -595,7 +595,7 @@ USER_DEFINED_WRAPPER(int, Scatterv, (const void *) sendbuf,
                      (MPI_Datatype) sendtype, (void *) recvbuf, (int) recvcount,
                      (MPI_Datatype) recvtype, (int) root, (MPI_Comm) comm)
 {
-  bool passthrough = true;
+  bool passthrough = false;
   commit_begin(comm, passthrough);
   int retval;
   // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
@@ -671,7 +671,7 @@ USER_DEFINED_WRAPPER(int, Scan, (const void *) sendbuf, (void *) recvbuf,
                      (int) count, (MPI_Datatype) datatype,
                      (MPI_Op) op, (MPI_Comm) comm)
 {
-  bool passthrough = true;
+  bool passthrough = false;
   commit_begin(comm, passthrough);
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();

--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -86,7 +86,7 @@ USER_DEFINED_WRAPPER(int, Bcast,
                      (void *) buffer, (int) count, (MPI_Datatype) datatype,
                      (int) root, (MPI_Comm) comm)
 {
-  bool passthrough = false;
+  bool passthrough = false; // See PR#394
   commit_begin(comm, passthrough);
   int retval;
 #if 0 // for debugging
@@ -287,7 +287,7 @@ USER_DEFINED_WRAPPER(int, Reduce,
                      (MPI_Datatype) datatype, (MPI_Op) op,
                      (int) root, (MPI_Comm) comm)
 {
-  bool passthrough = false;
+  bool passthrough = false; // See PR#394
   commit_begin(comm, passthrough);
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -343,7 +343,7 @@ USER_DEFINED_WRAPPER(int, Reduce_scatter,
                      (const int) recvcounts[], (MPI_Datatype) datatype,
                      (MPI_Op) op, (MPI_Comm) comm)
 {
-  bool passthrough = false;
+  bool passthrough = false; // See PR#394
   commit_begin(comm, passthrough);
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -514,7 +514,7 @@ USER_DEFINED_WRAPPER(int, Gather, (const void *) sendbuf, (int) sendcount,
                      (MPI_Datatype) sendtype, (void *) recvbuf, (int) recvcount,
                      (MPI_Datatype) recvtype, (int) root, (MPI_Comm) comm)
 {
-  bool passthrough = false;
+  bool passthrough = false; // See PR#394
   commit_begin(comm, passthrough);
   int retval;
   // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
@@ -544,7 +544,7 @@ USER_DEFINED_WRAPPER(int, Gatherv, (const void *) sendbuf, (int) sendcount,
                      (const int*) recvcounts, (const int*) displs,
                      (MPI_Datatype) recvtype, (int) root, (MPI_Comm) comm)
 {
-  bool passthrough = false;
+  bool passthrough = false; // See PR#394
   commit_begin(comm, passthrough);
   int retval;
   // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
@@ -569,7 +569,7 @@ USER_DEFINED_WRAPPER(int, Scatter, (const void *) sendbuf, (int) sendcount,
                      (MPI_Datatype) sendtype, (void *) recvbuf, (int) recvcount,
                      (MPI_Datatype) recvtype, (int) root, (MPI_Comm) comm)
 {
-  bool passthrough = false;
+  bool passthrough = false; // See PR#394
   commit_begin(comm, passthrough);
   int retval;
   // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
@@ -595,7 +595,7 @@ USER_DEFINED_WRAPPER(int, Scatterv, (const void *) sendbuf,
                      (MPI_Datatype) sendtype, (void *) recvbuf, (int) recvcount,
                      (MPI_Datatype) recvtype, (int) root, (MPI_Comm) comm)
 {
-  bool passthrough = false;
+  bool passthrough = false; // See PR#394
   commit_begin(comm, passthrough);
   int retval;
   // FIXME: Ideally, check FORTRAN_MPI_IN_PLACE only in the Fortran wrapper.
@@ -671,7 +671,7 @@ USER_DEFINED_WRAPPER(int, Scan, (const void *) sendbuf, (void *) recvbuf,
                      (int) count, (MPI_Datatype) datatype,
                      (MPI_Op) op, (MPI_Comm) comm)
 {
-  bool passthrough = false;
+  bool passthrough = false; // See PR#394
   commit_begin(comm, passthrough);
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();


### PR DESCRIPTION
  The "passthrough" mode in the seq num algorithm was designed to avoid a
  potential deadlock when mixing collective communications and point-to-point
  communications. One example provided by Tony Skjellum is as follows:
```
    if (rank == 1) {
      MPI_Recv(buf, 10, MPI_INT, MPI_ANY_SOURCE, 0, MPI_COMM_WORLD,
               MPI_STATUS_IGNORE);
      MPI_Bcast(buf, 10, MPI_INT, root, MPI_COMM_WORLD);
    } else if (rank == root) {
      MPI_Bcast(buf, 10, MPI_INT, root, MPI_COMM_WORLD);
      MPI_Send(buf, 10, MPI_INT, 1, 0, MPI_COMM_WORLD);
    }
```
  The behavior of this code is implementation-dependent. It was valid
  with cray-mpich years ago on Cori. But with the current version of
  cray-mpich (8.1.25) on Perlmutter, the program is no longer valid.  It hangs.
  So, MPI_Bcast used to be non-synchronizing for Cray MPI and it currently
  is synchronizing.

 The original passthrough mode allowed us to pass through and increment
 the sequence number at checkpoint time for MPI_Bcast and certain other
 blocking collective calls that may or may not be synchronizing.

  A portabla MPI application code should assume that an MPI library may
  implement MPI_Bcast as synchronizing, and so avoid code examples like
  the one above.  So we don't need the passthrough mode.

  We want to turn off the passthrough mode because it tended to
  cause MPI_Test to block, even though MPI_Test is supposed to be non-blocking.

With cray-mpich (8.1.25), we found a case that a process is calling MPI_Test, while
other processes are calling MPI_Bcast. The MPI_Test calls the MPI progress engine,
which calls a blocking function `MPIDI_anysrc_try_cancel_partner`. The backtrace is:
```
#0  0x00000000103a45f0 in ofi_mutex_unlock_noop () at src/common.c:996
#1  0x00000000103e5955 in ofi_genlock_unlock (lock=0x10ae8790) at ./include/ofi_lock.h:364
#2  ofi_cq_readfrom (cq_fid=0x10ae8720, buf=<optimized out>, count=8, src_addr=0x0) at prov/util/src/util_cq.c:231
#3  0x0000000010322e3b in MPIDI_anysrc_try_cancel_partner ()
#4  0x000000001033981f in MPIDIG_send_target_msg_cb ()
#5  0x000000001010af96 in MPIDI_SHMI_progress ()
#6  0x000000000ebafee9 in MPIR_Test_impl ()
#7  0x000000000ebd8c95 in MPIR_Test ()
#8  0x000000000ebd9446 in PMPI_Test ()
```
According to the issue [https://github.com/pmodels/mpich/issues/5980](https://github.com/pmodels/mpich/issues/5980) in MPICH's repo. The function `MPIDI_anysrc_try_cancel_partner` is blocking in this case. So we believe our passthrough mode has a conflict
with MPICH/cray-mpich's implementation. Hence, we want to disable the passthrough mode to follow the
sementic of the MPI standard.