### PR TITLE
Reduce the MAX_DRAIN_ROUNDS for collectives to 200

### DIFF
--- a/mpi-proxy-split/seq_num.cpp
+++ b/mpi-proxy-split/seq_num.cpp
@@ -18,7 +18,7 @@ using dmtcp::kvdb::KVDBResponse;
 
 // #define DEBUG_SEQ_NUM
 
-constexpr int MAX_DRAIN_ROUNDS = 1000;
+constexpr int MAX_DRAIN_ROUNDS = 200;
 
 extern int g_world_rank;
 extern int g_world_size;


### PR DESCRIPTION
Reduce the threshold used in PR#395 to reduce the freezing time.