### PR TITLE
Fix for Discovery machine (CentOS 7)

### DIFF
--- a/bin/mana_launch.py
+++ b/bin/mana_launch.py
@@ -15,6 +15,7 @@ dmtcp_options = ["-i", "--interval", "-h", "--coord-host",
                  "--ckpt-signal", "--with-plugin",
                  "--tmpdir", "--coord-logfile"]
 verbose = False
+gdb = False
 mana_root_path = os.path.dirname(os.path.realpath(__file__)) + "/../"
 
 # if no arguments provided, print the help message
@@ -42,6 +43,9 @@ if not target_app[0]:
   sys.exit(1)
 
 # Special arguments
+if "--gdb" in dmtcp_flags:
+  gdb = True
+  dmtcp_flags.remove("--gdb")
 if "--help" in dmtcp_flags:
   print(help_msg)
   sys.exit(1)
@@ -108,11 +112,15 @@ if coordinator_found != 0:
 # Build the command line to be executed
 if not verbose:
   dmtcp_flags.insert(0, "-q -q")
-cmd_line = mana_root_path + "bin/dmtcp_launch --mpi" + host_flag + port_flag + \
-           "--no-gzip --join-coordinator --disable-dl-plugin" + \
-           " --with-plugin " + mana_root_path + "lib/dmtcp/libmana.so " + \
-           " ".join(dmtcp_flags) + " " + mana_root_path + "bin/kernel-loader " + \
-           " " .join(target_app)
+if gdb:
+  cmd_line = shutil.which("gdb") + " --args "
+else:
+  cmd_line = ""
+cmd_line += mana_root_path + "bin/dmtcp_launch --mpi" + host_flag + port_flag + \
+            "--no-gzip --join-coordinator --disable-dl-plugin" + \
+            " --with-plugin " + mana_root_path + "lib/dmtcp/libmana.so " + \
+            " ".join(dmtcp_flags) + " " + mana_root_path + "bin/kernel-loader " + \
+            " " .join(target_app)
 if verbose:
   print(cmd_line)
 

--- a/bin/mana_restart.py
+++ b/bin/mana_restart.py
@@ -11,11 +11,15 @@ help_msg = '''
 
 # dmtcp options that requires a value
 verbose = False
+gdb = True
 mana_root_path = os.path.dirname(os.path.realpath(__file__)) + "/../"
 
 dmtcp_flags = sys.argv[1:]
 
 # Special arguments
+if "--gdb" in dmtcp_flags:
+  gdb = True
+  dmtcp_flags.remove("--gdb")
 if "--help" in dmtcp_flags:
   print(help_msg)
   sys.exit(1)
@@ -89,6 +93,10 @@ if coordinator_found != 0:
 # Build the command line to be executed
 if not verbose:
   dmtcp_flags.insert(0, "-q -q")
+if gdb:
+  cmd_line = shutil.which("gdb") + " --args "
+else:
+  cmd_line = ""
 cmd_line = mana_root_path + "bin/kernel-loader -j --restore " + " ".join(dmtcp_flags)
 if verbose:
   print(cmd_line)

--- a/mpi-proxy-split/lower-half/Makefile
+++ b/mpi-proxy-split/lower-half/Makefile
@@ -41,7 +41,7 @@ default: kernel-loader
 .c.o:
 	${MPICXX} ${CFLAGS} -c -o $@ $<
 
-kernel-loader: get_symbol_offset.o copy_stack.o patch_trampoline.o lh_func_ptr.o mem_wrapper.o switch_context.o kernel_loader.o ${DMTCP_DEPS}
+kernel-loader: get_symbol_offset.o copy_stack.o patch_trampoline.o lh_func_ptr.o mem_wrapper.o switch_context.o kernel_loader.o mmap-fixed-noreplace.o ${DMTCP_DEPS}
 	${MPICXX} -g3 ${TEXTSEG_ADDR_FLAG} ${CXXFLAGS} -o $@ $^ -lpthread -ldl
 
 install: kernel-loader

--- a/mpi-proxy-split/lower-half/Makefile
+++ b/mpi-proxy-split/lower-half/Makefile
@@ -41,8 +41,11 @@ default: kernel-loader
 .c.o:
 	${MPICXX} ${CFLAGS} -c -o $@ $<
 
+# Normally, gcc (or clang) will automatically link with libatomic.so.
+# However, for come MPICXX it's hard to know if they cover it.
+# So this is good as a safety measure.
 kernel-loader: get_symbol_offset.o copy_stack.o patch_trampoline.o lh_func_ptr.o mem_wrapper.o switch_context.o kernel_loader.o mmap-fixed-noreplace.o ${DMTCP_DEPS}
-	${MPICXX} -g3 ${TEXTSEG_ADDR_FLAG} ${CXXFLAGS} -o $@ $^ -lpthread -ldl
+	${MPICXX} -g3 ${TEXTSEG_ADDR_FLAG} ${CXXFLAGS} -o $@ $^ -lpthread -ldl -latomic
 
 install: kernel-loader
 	cp -f $^ ${MANA_ROOT}/bin/

--- a/mpi-proxy-split/lower-half/copy_stack.c
+++ b/mpi-proxy-split/lower-half/copy_stack.c
@@ -79,12 +79,16 @@ char *deepCopyStack(int argc, char **argv, char *argc_ptr, char *argv_ptr,
 
   char *top_of_stack = (char *)&argv[-1];
   assert( (auxv_size + env_ptr_size) % 8 == 0);
+  // The fnc _start() may copy 'argc', but this is its original address.
+  char *argc_ptr_original = argv_ptr - sizeof(char *);
+  // This shows that for current stack (not the copied one), _start copied argc.
+  assert(*(long int *)argc_ptr_original == *(long int *)argc_ptr);
   int dest_stack_size = sizeof(NULL) /* end marker */ +
                         env_strings_size + argv_strings_size +
                         32 /* max.  padding is 32 for x86_64 */ +
                         auxv_size + env_ptr_size + argv_ptr_size +
                         (auxv_size + env_ptr_size) % 16 /* 16-byte aligned */ +
-                        (argc_ptr - argv_ptr);
+                        (argv_ptr - argc_ptr_original);
 
   char *dest_top_of_stack =
     (char *)ROUND_UP((unsigned long)dest_stack + dest_stack_size);

--- a/mpi-proxy-split/lower-half/kernel_loader.cpp
+++ b/mpi-proxy-split/lower-half/kernel_loader.cpp
@@ -25,11 +25,6 @@
 #include "jconvert.h"
 #include "jfilesystem.h"
 #include "util.h"
-#if 0
-#include "mtcp_sys.h"
-#include "mtcp_restart.h"
-#include "mtcp_util.h"
-#endif
 
 // Uses ELF Format.  For background, read both of:
 //  * http://www.skyfree.org/linux/references/ELF_Format.pdf
@@ -59,6 +54,8 @@
 
 #define MAX_ELF_INTERP_SZ 256
 
+void *mmap_fixed_noreplace(void *addr, size_t length, int prot, int flags,
+                           int fd, off_t offset);
 int write_lh_info_to_file();
 void get_elf_interpreter(int fd, Elf64_Addr *cmd_entry,
                          char get_elf_interpreter[], void *ld_so_addr);
@@ -119,22 +116,6 @@ int main(int argc, char *argv[], char *envp[]) {
   memset(lh_info, 0, sizeof(LowerHalfInfo_t));
   lh_info->fsaddr = (void*)fsaddr;
  
-  // Create new heap region to be used by RTLD
-  void *lh_brk = sbrk(0);
-  const uint64_t heapSize = 0x1000;
-  void *heap_addr = mmap_wrapper(lh_brk, heapSize, PROT_NONE,
-                         MAP_PRIVATE | MAP_ANONYMOUS |
-                         MAP_NORESERVE | MAP_FIXED_NOREPLACE ,
-                         -1, 0);
-  if (heap_addr == MAP_FAILED) {
-    DLOG(ERROR, "Failed to mmap region. Error: %s\n",
-         strerror(errno));
-    exit(1);
-  }
-  // Add a guard page before the start of heap; this protects
-  // the heap from getting merged with a "previous" region.
-  mprotect(heap_addr, heapSize, PROT_NONE);
-
   // Initialize MPI in advance
   int rank;
   MPI_Init(&argc, &argv);
@@ -293,7 +274,6 @@ int main(int argc, char *argv[], char *envp[]) {
     off_t ckpt_file_pos = 0;
     ckpt_file_pos = lseek(t->fd(), 0, SEEK_CUR);
     // Reserve space for memory areas saved in the ckpt image file.
-    munmap_wrapper(heap_addr, heapSize);
     while(1) {
       off_t cur_pos = ckpt_file_pos;
       int rc = read(t->fd(), &area, sizeof area);
@@ -303,9 +283,9 @@ int main(int argc, char *argv[], char *envp[]) {
         break;
       }
       if ((area.properties & DMTCP_ZERO_PAGE_CHILD_HEADER) == 0) {
-        void *mmapedat = mmap(area.addr, area.size, PROT_NONE,
-                              MAP_PRIVATE | MAP_ANONYMOUS,
-                              0, 0);
+        void *mmapedat = mmap_fixed_noreplace(area.addr, area.size, PROT_NONE,
+                                              MAP_PRIVATE | MAP_ANONYMOUS,
+                                              0, 0);
         if (mmapedat == MAP_FAILED) {
           fprintf(stderr, "restore failed area.addr: %p, area.endAddr%p\n", area.addr, area.endAddr);
           volatile int dummy = 1;

--- a/mpi-proxy-split/lower-half/mmap-fixed-noreplace.c
+++ b/mpi-proxy-split/lower-half/mmap-fixed-noreplace.c
@@ -1,0 +1,89 @@
+#include <assert.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+void *mmap_fixed_noreplace(void *addr, size_t length, int prot, int flags,
+                           int fd, off_t offset) {
+#ifdef MAP_FIXED_NOREPLACE
+  static int has_map_fixed_noreplace = -1;
+#else
+  static int has_map_fixed_noreplace = 0; // macro undefined; we don't have it
+# define MAP_FIXED_NOREPLACE (-1) // Stop compiler from complaining.
+#endif
+
+  if (has_map_fixed_noreplace == -1) {
+    long pagesize = sysconf(_SC_PAGESIZE); 
+    int test_flag = MAP_PRIVATE | MAP_ANONYMOUS;
+    void *addr = mmap(NULL, pagesize, 0, test_flag, -1, 0); // No clobber memory
+    if (addr == MAP_FAILED) { return addr; }
+    void *addr2 = mmap(addr, pagesize, 0, test_flag | MAP_FIXED_NOREPLACE,
+                       -1, 0);
+    if (addr2 == MAP_FAILED && errno == EEXIST) {
+      has_map_fixed_noreplace = 1;
+    } else {
+      assert(addr2 == MAP_FAILED);
+      has_map_fixed_noreplace = 0;
+    }
+    assert(munmap(addr, pagesize) == 0); // We now have our answer; unmap it.
+  }
+
+  if (flags & MAP_FIXED) {flags ^= MAP_FIXED;} // Don't clobber memory.
+  if (has_map_fixed_noreplace) {
+    flags |= MAP_FIXED_NOREPLACE;
+    return mmap(addr, length, prot, flags, fd, offset);
+  } else {
+    assert(has_map_fixed_noreplace == 0);
+#if MAP_FIXED_NOREPLACE != -1
+    if (flags & MAP_FIXED_NOREPLACE) {flags ^= MAP_FIXED_NOREPLACE;}
+#endif
+    void *addr2 = mmap(addr, length, prot, flags, fd, offset);
+
+    if (addr2 == addr) {
+      return addr; // Success!
+    } else if (addr2 != MAP_FAILED) { // The memory region already exists.
+      assert(addr2 != addr);
+      assert(munmap(addr2, length) == 0);
+      errno = EEXIST;
+      return MAP_FAILED;
+    } else { // The mmap really did fail.  Keep the errno for caller.
+      assert(addr2 == MAP_FAILED);
+      return MAP_FAILED;
+    }
+  }
+}
+
+#ifdef STANDALONE
+// Returns on success; asserts on error.
+int main() {
+  long pagesize = sysconf(_SC_PAGESIZE); 
+  errno = 0;
+  int test_flag = MAP_PRIVATE | MAP_ANONYMOUS;
+  void *addr = mmap(NULL, pagesize, 0, test_flag, -1, 0); // No clobber memory
+  assert(addr != MAP_FAILED);
+
+  void *addr2 = mmap_fixed_noreplace(addr, pagesize, 0, test_flag, -1, 0);
+  assert(addr2 == MAP_FAILED && errno == EEXIST);
+
+  addr2 = mmap(addr, pagesize, 0, test_flag, -1, 0); // Test internals of fnc
+  assert(addr2 != MAP_FAILED && addr2 != addr); // memory region already exists
+  assert(munmap(addr, pagesize) == 0);
+  assert(munmap(addr2, pagesize) == 0);
+
+  addr2 = mmap_fixed_noreplace(addr, pagesize, 0, test_flag, -1, 0);
+  assert(addr2 != MAP_FAILED && addr2 == addr);
+  assert(munmap(addr, pagesize) == 0);
+
+#if MAP_FIXED_NOREPLACE != -1
+  addr2 = mmap_fixed_noreplace(addr, pagesize, 0,
+                               test_flag | MAP_FIXED_NOREPLACE, -1, 0);
+  assert(addr2 != MAP_FAILED && addr2 == addr);
+  addr2 = mmap_fixed_noreplace(addr, pagesize, 0,
+                               test_flag | MAP_FIXED_NOREPLACE, -1, 0);
+  assert(addr2 == MAP_FAILED && errno == EEXIST);
+  assert(munmap(addr, pagesize) == 0);
+#endif
+
+  return 0;
+}
+#endif

--- a/mpi-proxy-split/mpi-wrappers/p2p-deterministic.py
+++ b/mpi-proxy-split/mpi-wrappers/p2p-deterministic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import sys
 import os
 

--- a/mpi-proxy-split/test/Makefile
+++ b/mpi-proxy-split/test/Makefile
@@ -47,7 +47,6 @@ FILES=mpi_hello_world \
 	  File_read_write_all_test \
       Type_dup_test Type_create_hindexed_test \
 	  Type_create_resized_test Type_create_hindexed_block_test \
-	  comm_reconstruct_test
 
 OBJS=$(addsuffix .o, ${FILES})
 

--- a/mpi-proxy-split/uh_wrappers.cpp
+++ b/mpi-proxy-split/uh_wrappers.cpp
@@ -96,7 +96,17 @@ int munmap(void *addr, size_t length) {
 static void readLhInfoAddr() {
   char filename[100] = "./lh_info_";
   gethostname(filename + strlen(filename), 100 - strlen(filename));
-  snprintf(filename + strlen(filename), 100 - strlen(filename), "_%d", dmtcp_get_real_pid());
+  filename[strlen(filename)] = '_';
+  // Convert real pid to char* without calling snprintf
+  // During process startup, avoid directly or indirectly
+  // calling a libc function that is a DMTCP wrapper.
+  int real_pid = dmtcp_get_real_pid();
+  static char buf[32] = {0};
+  int i = 30;
+  for(; real_pid && i ; --i, real_pid /= 10) {
+    buf[i] = "0123456789"[real_pid % 10];
+  }
+  memcpy(filename + strlen(filename), &buf[i+1], strlen(&buf[i+1]));
   int fd = open(filename, O_RDONLY);
   if (fd < 0) {
     printf("Could not open %s for reading.\n", filename);


### PR DESCRIPTION
This PR fixes multiple issues on the Discovery cluster.
1. Provide an alternative function on machines that don't support MAP_FIXED_NOREPLACE.
2. Remove unused test cases.
3. Fix how some Python script finds python3.
4. Remove unused wrapper functions.
5. Fix building errors.
6. Fix a bug in the kernel loader (wrong stack size for copying).
7. Add a feature for mana_launch.py and mana_restart.py scripts. The added --gdb option allows users to launch their program and MANA under gdb.