### PR TITLE
Fix mana restart

### DIFF
--- a/bin/mana_restart.py
+++ b/bin/mana_restart.py
@@ -11,7 +11,7 @@ help_msg = '''
 
 # dmtcp options that requires a value
 verbose = False
-gdb = True
+gdb = False
 mana_root_path = os.path.dirname(os.path.realpath(__file__)) + "/../"
 
 dmtcp_flags = sys.argv[1:]
@@ -97,7 +97,7 @@ if gdb:
   cmd_line = shutil.which("gdb") + " --args "
 else:
   cmd_line = ""
-cmd_line = mana_root_path + "bin/kernel-loader -j --restore " + " ".join(dmtcp_flags)
+cmd_line += mana_root_path + "bin/kernel-loader -j --restore " + " ".join(dmtcp_flags)
 if verbose:
   print(cmd_line)
 

--- a/bin/mana_restart.py
+++ b/bin/mana_restart.py
@@ -30,7 +30,7 @@ if "--timing" in dmtcp_flags:
   os.environ["MANA_TIMING"] = "1"
   dmtcp_flags.remove("--timing")
 if "--restartdir" in dmtcp_flags:
-  ckptdir_path = dmtcp_flags[dmtcp_flags.index("--restart") + 1]
+  ckptdir_path = dmtcp_flags[dmtcp_flags.index("--restartdir") + 1]
   if not os.path.exists(ckptdir_path):
     print("mana_restart: --restartdir " + ckptdir_path + ": Restart directory doesn't exist")
     sys.exit(1)

--- a/mpi-proxy-split/lower-half/kernel-loader.cpp
+++ b/mpi-proxy-split/lower-half/kernel-loader.cpp
@@ -102,8 +102,6 @@ void set_addr_no_randomize(char *argv[]) {
 }
 
 int main(int argc, char *argv[], char *envp[]) {
-  
-
   set_addr_no_randomize(argv);
   int i;
   int restore_mode = 0;
@@ -410,7 +408,6 @@ int main(int argc, char *argv[], char *envp[]) {
 
   // Open the elf interpreter (ldso)
   ld_so_fd = open(elf_interpreter, O_RDONLY);
-  
   char *interp_base_address =
     load_elf_interpreter(ld_so_fd, elf_interpreter, ld_so_addr, &ld_so_elf_hdr);
   ld_so_entry = interp_base_address  + ld_so_elf_hdr.e_entry;
@@ -446,7 +443,6 @@ int main(int argc, char *argv[], char *envp[]) {
   // FIXME:
   //   Should add check that interp_base_address + 0x400000 not already mapped
   //   Or else, could use newer MAP_FIXED_NOREPLACE in mmap of deepCopyStack
-  
   char *dest_stack = deepCopyStack(argc, argv, (char *)&argc, (char *)&argv[0],
                                    cmd_argc+1, cmd_argv2,
                                    interp_base_address + rlim.rlim_cur + LOADER_SIZE_LIMIT,

--- a/mpi-proxy-split/mpi-wrappers/mpi_file_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_file_wrappers.cpp
@@ -77,7 +77,7 @@ USER_DEFINED_WRAPPER(int, File_get_atomicity, (MPI_File) fh, (int*) flag)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_get_atomicity)(real_file, flag);
   RETURN_TO_UPPER_HALF();
@@ -89,7 +89,7 @@ USER_DEFINED_WRAPPER(int, File_set_atomicity, (MPI_File) fh, (int) flag)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_set_atomicity)(real_file, flag);
   RETURN_TO_UPPER_HALF();
@@ -101,7 +101,7 @@ USER_DEFINED_WRAPPER(int, File_set_size, (MPI_File) fh, (MPI_Offset) size)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_set_size)(real_file, size);
   RETURN_TO_UPPER_HALF();
@@ -113,7 +113,7 @@ USER_DEFINED_WRAPPER(int, File_get_size, (MPI_File) fh, (MPI_Offset *) size)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_get_size)(real_file, size);
   RETURN_TO_UPPER_HALF();
@@ -127,7 +127,7 @@ USER_DEFINED_WRAPPER(int, File_set_view, (MPI_File) fh, (MPI_Offset) disp,
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   MPI_Datatype realEtype = get_real_id({.datatype = etype}).datatype;
   MPI_Datatype realFtype = get_real_id({.datatype = filetype}).datatype;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
@@ -177,7 +177,7 @@ USER_DEFINED_WRAPPER(int, File_read, (MPI_File) fh, (void*) buf, (int) count,
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   MPI_Datatype real_datatype = get_real_id({.datatype = datatype}).datatype;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_read)(real_file, buf, count, real_datatype, status);
@@ -192,7 +192,7 @@ USER_DEFINED_WRAPPER(int, File_read_at, (MPI_File) fh, (MPI_Offset) offset,
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   MPI_Datatype real_datatype = get_real_id({.datatype = datatype}).datatype;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_read_at)(real_file, offset, buf, count, real_datatype,
@@ -213,7 +213,7 @@ USER_DEFINED_WRAPPER(int, File_read_at_all, (MPI_File) fh, (MPI_Offset) offset,
   // add commit_begin() and commit_finish() to the start/end of this wrapper.
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   MPI_Datatype real_datatype = get_real_id({.datatype = datatype}).datatype;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_read_at_all)(real_file, offset, buf, count, real_datatype,
@@ -233,7 +233,7 @@ USER_DEFINED_WRAPPER(int, File_read_all, (MPI_File) fh, (void*) buf,
   // add commit_begin() and commit_finish() to the start/end of this wrapper.
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   MPI_Datatype real_datatype = get_real_id({.datatype = datatype}).datatype;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_read_all)(real_file, buf, count, real_datatype, status);
@@ -247,7 +247,7 @@ USER_DEFINED_WRAPPER(int, File_write, (MPI_File) fh, (const void*) buf,
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   MPI_Datatype real_datatype = get_real_id({.datatype = datatype}).datatype;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_write)(real_file, buf, count, real_datatype, status);
@@ -262,7 +262,7 @@ USER_DEFINED_WRAPPER(int, File_write_at, (MPI_File) fh, (MPI_Offset) offset,
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   MPI_Datatype real_datatype = get_real_id({.datatype = datatype}).datatype;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_write_at)(real_file, offset, buf, count, real_datatype,
@@ -279,7 +279,7 @@ USER_DEFINED_WRAPPER(int, File_write_at_all, (MPI_File) fh, (MPI_Offset) offset,
   // FIXME: See File_read_at_all (the same applies here)
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   MPI_Datatype real_datatype = get_real_id({.datatype = datatype}).datatype;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_write_at_all)(real_file, offset, buf, count,
@@ -295,7 +295,7 @@ USER_DEFINED_WRAPPER(int, File_write_all, (MPI_File) fh, (const void*) buf,
   // FIXME: See File_read_all (the same applies here)
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   MPI_Datatype real_datatype = get_real_id({.datatype = datatype}).datatype;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_write_all)(real_file, buf, count, real_datatype, status);
@@ -308,7 +308,7 @@ USER_DEFINED_WRAPPER(int, File_sync, (MPI_File) fh)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_sync)(real_file);
   RETURN_TO_UPPER_HALF();
@@ -321,7 +321,7 @@ USER_DEFINED_WRAPPER(int, File_get_position, (MPI_File) fh,
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_get_position)(real_file, offset);
   RETURN_TO_UPPER_HALF();
@@ -334,7 +334,7 @@ USER_DEFINED_WRAPPER(int, File_seek, (MPI_File) fh, (MPI_Offset) offset,
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = fh}).file;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_seek)(real_file, offset, whence);
   RETURN_TO_UPPER_HALF();
@@ -346,7 +346,7 @@ USER_DEFINED_WRAPPER(int, File_close, (MPI_File*) fh)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = *fh}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = *fh}).file;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_close)(&real_file);
   RETURN_TO_UPPER_HALF();
@@ -388,7 +388,7 @@ USER_DEFINED_WRAPPER(int, File_set_errhandler, (MPI_File) file,
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = file}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = file}).file;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_set_errhandler)(real_file, errhandler);
   RETURN_TO_UPPER_HALF();
@@ -401,7 +401,7 @@ USER_DEFINED_WRAPPER(int, File_get_errhandler, (MPI_File) file,
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_File real_file = get_real_id({.file = file}).file;
+  MPI_File real_file = get_real_id((mana_handle){.file = file}).file;
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
   retval = NEXT_FUNC(File_get_errhandler)(real_file, errhandler);
   RETURN_TO_UPPER_HALF();

--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -690,7 +690,7 @@ restore_mpi_files(const char *filename)
     JASSERT(retval == 0).Text("Restoration of MPI_File_open failed");
 
     // Update virtual mapping with newly created file
-    update_virt_id({.file = itr->first}, {.file = fh});
+    update_virt_id((mana_handle){.file = itr->first}, (mana_handle){.file = fh});
 
     // Restore file characteristics that are universal to the entire file
     // These are characteristics that do not have to be replayed in order,

--- a/mpi-proxy-split/test/Makefile
+++ b/mpi-proxy-split/test/Makefile
@@ -26,7 +26,7 @@ DEMO_PORT=7787
 # Several tests are excluded from this Makefile because they are redundant:
 # multi_send_recv, send_recv, send_recv_many
 # Comment out FILES_FORTRAN if you don't have an mmpifort compiler.
-FILES_FORTRAN= f_ibarrier wave_mpi day1_mpi quad_mpi poisson_nonblock_mpi
+#FILES_FORTRAN= f_ibarrier day1_mpi quad_mpi poisson_nonblock_mpi wave_mpi
 FILES=mpi_hello_world \
       hello_mpi_init_thread Sendrecv_test Gatherv_test \
       keyval_test file_test Scatterv_test Gather_test \

--- a/mpi-proxy-split/virtual_id.cpp
+++ b/mpi-proxy-split/virtual_id.cpp
@@ -119,7 +119,7 @@ MPI_Datatype new_virt_datatype(MPI_Datatype real_datatype) {
 
 MPI_File new_virt_file(MPI_File real_file) {
   mana_handle virt_id;
-  virt_id = add_virt_id({.file = real_file}, NULL, MANA_FILE_KIND);
+  virt_id = add_virt_id((mana_handle){.file = real_file}, NULL, MANA_FILE_KIND);
   return virt_id.file;
 }
 


### PR DESCRIPTION
1.` Fixed --restartdir <dir> flag option in mana_restart.py` :  Fixed mana_restart.py code to be able to load targeted restart dir path using --restartdir flag.
2. `FIXED inline --gdb flag crashing bug in mana_restart.py` : Fixed freezing error caused when inline call to gdb using --gdb flag is used.