### PR TITLE
Added wrapper support for MPI_Type_get_name

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_stub_wrappers.txt
+++ b/mpi-proxy-split/mpi-wrappers/mpi_stub_wrappers.txt
@@ -318,7 +318,6 @@ int MPI_Type_get_contents(MPI_Datatype mtype, int max_integers, int max_addresse
 int MPI_Type_get_envelope(MPI_Datatype type, int *num_integers, int *num_addresses, int *num_datatypes, int *combiner);
 int MPI_Type_get_extent(MPI_Datatype type, MPI_Aint *lb, MPI_Aint *extent);
 int MPI_Type_get_extent_x(MPI_Datatype type, MPI_Count *lb, MPI_Count *extent);
-int MPI_Type_get_name(MPI_Datatype type, char *type_name, int *resultlen);
 int MPI_Type_get_true_extent(MPI_Datatype datatype, MPI_Aint *true_lb, MPI_Aint *true_extent);
 int MPI_Type_get_true_extent_x(MPI_Datatype datatype, MPI_Count *true_lb, MPI_Count *true_extent);
 int MPI_Type_hindexed(int count, const int array_of_blocklengths[], const MPI_Aint array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);

--- a/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
@@ -406,6 +406,19 @@ USER_DEFINED_WRAPPER(int, Pack, (const void*) inbuf, (int) incount,
   return retval;
 }
 
+USER_DEFINED_WRAPPER(int, Type_get_name, (MPI_Datatype) datatype, 
+                      (char*) type_name, (int*) resultlen)
+{
+   int retval;
+   DMTCP_PLUGIN_DISABLE_CKPT();
+   MPI_Datatype real_datatype = get_real_id({.datatype = datatype}).datatype;
+   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
+   retval = NEXT_FUNC(Type_get_name)(real_datatype, type_name, resultlen);
+   RETURN_TO_UPPER_HALF(); 
+   DMTCP_PLUGIN_ENABLE_CKPT();
+   return retval;
+}
+
 DEFINE_FNC(int, Type_size_x, (MPI_Datatype) type, (MPI_Count *) size);
 
 PMPI_IMPL(int, MPI_Type_size, MPI_Datatype datatype, int *size)

--- a/mpi-proxy-split/mpi-wrappers/mpi_unimplemented_wrappers.txt
+++ b/mpi-proxy-split/mpi-wrappers/mpi_unimplemented_wrappers.txt
@@ -233,7 +233,6 @@ int MPI_Type_get_attr(MPI_Datatype type, int type_keyval, void *attribute_val, i
 int MPI_Type_get_contents(MPI_Datatype mtype, int max_integers, int max_addresses, int max_datatypes, int array_of_integers[], MPI_Aint array_of_addresses[], MPI_Datatype array_of_datatypes[]);
 int MPI_Type_get_envelope(MPI_Datatype type, int *num_integers, int *num_addresses, int *num_datatypes, int *combiner);
 int MPI_Type_get_extent_x(MPI_Datatype type, MPI_Count *lb, MPI_Count *extent);
-int MPI_Type_get_name(MPI_Datatype type, char *type_name, int *resultlen);
 int MPI_Type_get_true_extent(MPI_Datatype datatype, MPI_Aint *true_lb, MPI_Aint *true_extent);
 int MPI_Type_get_true_extent_x(MPI_Datatype datatype, MPI_Count *true_lb, MPI_Count *true_extent);
 int MPI_Type_lb(MPI_Datatype type, MPI_Aint *lb);


### PR DESCRIPTION
`Added wrapper support for MPI_Type_get_name`:
 * Added MPI wrapper support for MPI_Type_get_name function call, a requirement of osu_multi_lat (pt2pt) benchmark.
 * Removed function definition from unimplemented and wrapper-stub files. 
