### PR TITLE
CoMD debug

### DIFF
--- a/mpi-proxy-split/test/MPI_Double_Int_test.c
+++ b/mpi-proxy-split/test/MPI_Double_Int_test.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <mpi.h>
+
+int main(int argc, char** argv) {
+  MPI_Init(&argc, &argv);
+
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+  struct {double value; int rank;} local_data, global_data;
+
+  // assign a value (eg: some computational result)
+  local_data.value = rank * 1.5;    // different value for each rank
+  local_data.rank = rank;
+/*
+  volatile int dummy = 1;
+  printf("Dummy Hit!\n");
+  while(dummy);
+  */
+  MPI_Allreduce(&local_data, &global_data, 1, MPI_DOUBLE_INT, MPI_MAXLOC, MPI_COMM_WORLD);
+
+  // print result
+  printf("[Rank %d]: Max value = %f from rank %d\n", rank, global_data.value, global_data.rank);
+
+  MPI_Finalize();
+  return 0;
+
+}
+

--- a/mpi-proxy-split/test/MPI_Double_Int_test.c
+++ b/mpi-proxy-split/test/MPI_Double_Int_test.c
@@ -1,6 +1,18 @@
 #include <stdio.h>
 #include <mpi.h>
 
+/*
+ * MPICH treats MPI_DOUBLE_INT  as a negative 32-bit integer, 
+ * signifying its 'struct' nature.
+ * MANA has defined look-up table for pre-defined MPI_Datatypes as 
+ * map<int64_t, int64_t> to accomodate for OpenMPI library.
+ *
+ * But, When handeling negative 64-bit value in MPICh with int32_t MPI_Datatypes, 
+ * conversion back to 64-bit results in loss of upper-bits, violating integrity of argument passed.
+ *
+ * This tests for a possible regression.
+ */
+
 int main(int argc, char** argv) {
   MPI_Init(&argc, &argv);
 


### PR DESCRIPTION
**`This PR includes the following commits`**:
* `New test for MPI_Double_Int datatype with MPI_Allreduce`: MANA fails to resolve MPI_Double_Int for a call to  MPI_Allreduce  CoMD software. This commit adds a small and faster toy program to MANA's test directory for quickly filtering similar failures in future.
* `Fixed upper_to_lower_constants lookup for special(negative) Datatypes`: Special Datatypes are defined in MPI library for 'struct' type datatypes, defined as negative constant values. This commit aims to maintain  integrity of these special(negative) datatype when passed in function calls. 