### PR TITLE
UH stack clash

### DIFF
--- a/mpi-proxy-split/lower-half/kernel-loader.cpp
+++ b/mpi-proxy-split/lower-half/kernel-loader.cpp
@@ -57,7 +57,7 @@
 #endif
 
 #define MAX_ELF_INTERP_SZ 256
-#define LOADER_SIZE_LIMIT 0x40000
+#define LOADER_SIZE_LIMIT 0x2000000
 
 void *mmap_fixed_noreplace(void *addr, size_t length, int prot, int flags,
                            int fd, off_t offset);

--- a/mpi-proxy-split/lower-half/kernel-loader.cpp
+++ b/mpi-proxy-split/lower-half/kernel-loader.cpp
@@ -433,8 +433,10 @@ int main(int argc, char *argv[], char *envp[]) {
   // Check for the edge case where soft limit for rlimit stack is 
   // set to RLIM_INFINITY (which is -1) failing the 16-bit layout check.  
   if(rlim.rlim_cur == RLIM_INFINITY){
-    // FIXME: putting in a placeholder value for now as 32MB
-    rlim.rlim_cur = 0x2000000;
+    // FIXME: putting in a placeholder value for now as 16MB
+    // This size is chosen to provide good distance between 
+    //  library segments and red zone, as well as red zone and UH-stack.
+    rlim.rlim_cur = 0x1000000;
   }
 
   // FIXME:


### PR DESCRIPTION
Upper-half(UH) Stack clash with ld.so library caused inconsistent launch of target applications in UH. 
The following commits resolve this:
* `Increased LOADER_SIZE_LIMIT to create UH-stack at higher address` :  This commit increasing UH stack size, so that stack block can be created at a higher memory range than before. This ample gap between stack and ld.so library segment decreases the collision risk. 
* `Added red zone for UH stack clash detection`: To detect similar UH stack clashes with libraries, a red-block is added on top of stack. 
* `Updated code in RLIM_INFINITY check for UH stack`: Since first commit already increased UH application's usable stack space, rlim_cur value is reduced to 16MB, for the case where system stack size limit is equal to RLIM_INFINITY. This resolves overshooting of red-zone to ld.so library space.
*  `Comments on deepCopy(ing) UH-stack beyond rlimit_cur`:  Added comments on deepCopyingStack to explain the increase in LOADER_SIZE_LIMIT, as well as why kernel-error is not seen when mmap(ing) UH-stack bigger than rlim_cur allowed.