### PR TITLE
unsynchronized MPI_Finalized  

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
@@ -104,15 +104,6 @@ USER_DEFINED_WRAPPER(double, Wtime, (void))
 
 USER_DEFINED_WRAPPER(int, Finalize, (void))
 {
-  // FIXME: With Cray MPI, for some reason, MPI_Finalize hangs when
-  // running on multiple nodes. The MPI Finalize call tries to pthread_cancel
-  // a polling thread in the lower half and then blocks on join. But,
-  // for some reason, the polling thread never comes out of an ioctl call
-  // and remains blocked.
-  //
-  // The workaround here is to simply return success to the caller without
-  // calling into the real Finalize function in the lower half. This way
-  // the application can proceed to exit without getting blocked forever.
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
   JUMP_TO_LOWER_HALF(lh_info->fsaddr);

--- a/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
@@ -113,7 +113,13 @@ USER_DEFINED_WRAPPER(int, Finalize, (void))
   // The workaround here is to simply return success to the caller without
   // calling into the real Finalize function in the lower half. This way
   // the application can proceed to exit without getting blocked forever.
-  return MPI_SUCCESS;
+  int retval;
+  DMTCP_PLUGIN_DISABLE_CKPT();
+  JUMP_TO_LOWER_HALF(lh_info->fsaddr);
+  retval = NEXT_FUNC(Finalize)();
+  RETURN_TO_UPPER_HALF();
+  DMTCP_PLUGIN_ENABLE_CKPT();
+  return retval;
 }
 
 USER_DEFINED_WRAPPER(int, Get_count,

--- a/mpi-proxy-split/test/Makefile
+++ b/mpi-proxy-split/test/Makefile
@@ -43,11 +43,11 @@ FILES=mpi_hello_world \
       Type_hvector_test Type_vector_test \
       ${FILES_FORTRAN} \
       send_recv_loop large_async_p2p \
-	  	File_read_write_test File_characteristics_test File_size_test \
-	  	File_read_write_all_test \
+      File_read_write_test File_characteristics_test File_size_test \
+      File_read_write_all_test \
       Type_dup_test Type_create_hindexed_test \
-	  	Type_create_resized_test Type_create_hindexed_block_test \
-			unsync_Finalize MPI_Double_Int_test  \
+      Type_create_resized_test Type_create_hindexed_block_test \
+      unsync_Finalize MPI_Double_Int_test  \
 
 OBJS=$(addsuffix .o, ${FILES})
 

--- a/mpi-proxy-split/test/Makefile
+++ b/mpi-proxy-split/test/Makefile
@@ -43,10 +43,11 @@ FILES=mpi_hello_world \
       Type_hvector_test Type_vector_test \
       ${FILES_FORTRAN} \
       send_recv_loop large_async_p2p \
-	  File_read_write_test File_characteristics_test File_size_test \
-	  File_read_write_all_test \
+	  	File_read_write_test File_characteristics_test File_size_test \
+	  	File_read_write_all_test \
       Type_dup_test Type_create_hindexed_test \
-	  Type_create_resized_test Type_create_hindexed_block_test \
+	  	Type_create_resized_test Type_create_hindexed_block_test \
+			unsync_Finalize MPI_Double_Int_test  \
 
 OBJS=$(addsuffix .o, ${FILES})
 

--- a/mpi-proxy-split/test/unsync_Finalize.c
+++ b/mpi-proxy-split/test/unsync_Finalize.c
@@ -1,0 +1,44 @@
+/*
+ * FILE: unsync_Finalize.c 
+ * Description: This test triggers an *unsynchronized call* 
+ *          to `MPI_Finalize` by intentionally delaying 
+ *          the finalize call in rank 0. 
+ *          If correct synchronization mechanism is not employed 
+ *          in MPI_Finalize wrapper, it causes premature termination.
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[]){
+  int rank, size;
+  MPI_Init(&argc, &argv);
+  
+  // get rank and comm size
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+  // requires atleast 2 processes
+  if (size < 2) {
+    printf("ERROR: requires at least 2 processes!\n");
+    return 1;
+  }
+
+  printf("[%d/%d]: Says Hello!\n", rank, size);
+  
+  // wait for all the processes to say hello!
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Rank 0: sleep for 4 sec before saying goodbye
+  if(rank == 0){
+    printf("Rank 0 sleeping for 4 sec\n");
+    sleep(4);
+    printf("Rank %d says: Goodbye!\n", rank);
+  }
+  else{
+    printf("Rank %d says: Goodbye!\n", rank);
+  }
+  
+  MPI_Finalize();
+}


### PR DESCRIPTION
This PR is based on PR#374 created by Leonid Belyaev (@aeblyve). 

**Unsynchronized MPI_Finalize**  call to MANA wrappers causes MPI application to prematurely terminate i.e., it `aborts` any slacking process still computing and the result is lost.
 
This PR fixes this bug with the following commits:
* `Added test for unsynchronized MPI_Finalize call`: Added a test in MANA test directory to detect future regression. A
* `Fix MPI_Finalize wrapper to correctly call MPI_Finalize`:  Added code in MANA wrapper for MPI_Finalize to call MPI_Finalize from lower half instead of returning MPI_SUCESS. This allows all the running processes to finish safely without premature termination.
* `Removed stale comment from MPI_Finalize wrapper`: Stale comment regrading Cray-MPI removed form MPI_Finalize wrapper, since it is no longer relevant. 
* `Corrected indentation in Makefile for test dir`: Fixed layout in Makefile for test directory. 