### PR TITLE
UCX library constructor fix (open source)

### DIFF
--- a/bin/mpicc_mana
+++ b/bin/mpicc_mana
@@ -52,6 +52,8 @@ for arg in "$@" ; do
       interlib_deps=no
       static_mpi=yes
       addarg=no
+      echo "Does not support Static Library"
+      exit 0
     ;;
     -show)
       addarg=no
@@ -78,8 +80,8 @@ for arg in "$@" ; do
       fi
     ;;
     -help)
-      echo "Usage: mpicc_mana [Options] <source files?"
-      exit 0;
+      echo "Usage: mpicc_mana [Options] <source files>"
+      exit 0
     ;;
   esac
 done

--- a/bin/mpicc_mana
+++ b/bin/mpicc_mana
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# This is a custom mpicc wrapper to link against libmpistub.so
+#   This is mostly useful when the upper-half (user MPI application)
+#   is compiled with MPI libraries using constructors, which conflict with MANA's
+#   kernel loader approach used in lower-half.
+
+# set custom MPI paths 
+prefix=$(dirname "$(dirname "$(realpath "$0")")")
+libdir=$prefix/lib/dmtcp
+CC="gcc -std=gnu99"
+
+# linker flag to pass through compiler
+wl="-Wl,"
+
+# static library suffix
+libext="a"
+
+# shared library suffix
+shlibext="so"
+
+# naming covention for library names
+libname_spec="lib\$name"
+
+# Flag to hardcode $libdir into a binary during linking.
+# This must work even if $libdir does not exist.
+hardcode_libdir_flag_spec="\${wl}-rpath \${wl}\$libdir"
+
+# ensure command line arguments are provided 
+if [ $# -lt 1 ]; then
+  echo "Error: Command line argument is needed!"
+  "$0" -help
+  exit 1
+fi
+
+# processing command line argumnets
+linking=yes
+allargs=("$@")
+argno=0
+interlib_deps=yes
+static_mpi=no
+showinfo=""
+
+
+for arg in "$@" ; do
+  addarg=yes
+  case "$arg" in
+    -c|-S|-E|-M|-MM)
+      linking=no
+    ;;
+    -static)
+      interlib_deps=no
+      static_mpi=yes
+      addarg=no
+    ;;
+    -show)
+      addarg=no
+      Show=echo
+    ;;
+    -show-link-info)
+      addarg=no
+      Show=echo
+      show_info=link
+    ;;
+    -show-comile-info)
+      addarg=no
+      Show=echo
+      show_info=compile
+    ;;
+    -cc=*)
+      CC=`echo A$arg | sed -e 's/A-cc=//g'`
+      addarg=no
+    ;;
+    -v)
+      echo "Custom mpicc for MANA"
+      if [ "$#" -eq "1" ] ; then
+        linking=no
+      fi
+    ;;
+    -help)
+      echo "Usage: mpicc_mana [Options] <source files?"
+      exit 0;
+    ;;
+  esac
+done
+
+# prevent recursive execution
+if [ -n "$MANA_MPICC_RECURSION_CHECK" ] ; then
+  echo "This script ($0) is being called resursively."
+  exit 1
+fi
+
+MANA_MPICC_RECURSION_CHECK=1
+export MANA_MPICC_RECURSION_CHECK
+
+# Constructing Compilation and Linking Commands
+$Show $CC "${allargs[@]}" -L$libdir -lmpistub 
+

--- a/mpi-proxy-split/test/Makefile
+++ b/mpi-proxy-split/test/Makefile
@@ -169,7 +169,7 @@ check-integrated_dmtcp_text: tidy integrated_dmtcp_test
 	 $(MPICC) -o $@ $< ${MPI_LDFLAGS}
 
 %.mana.exe: %.o
-	 $(MPICC) -o $@ $< ${MPI_LDFLAGS} ${LDFLAGS_DUMMY}
+	 $(CC) -o $@ $< ${MPI_LDFLAGS} ${LDFLAGS_DUMMY}
 
 %.exe: %.cpp
 	$(MPICXX) -g3 -O0 -o $@ $< $(MPI_CXXFLAGS)


### PR DESCRIPTION
Network libraries(for example intel's implementation of ucx library used for InfiniBand) that use constructor functions to run before ``main`` of Upper-Half MPI applications, caused crash under MANA. 
This PR aims to fix that by providing a solution for open-source upper-half MPI-applications by the help of following commits:
* `Updated correct compiler flag in test dir Makefile`: Compiler for MPI applications  linked to **_mpistub_** library now set to compile with  **_gcc_** instead of **_mpicc_**.  
* `Update LD_LIBRARY_PATH with libmpistub for UH`: Added code to update **LD_LIBRARY_PATH** for upper-half by prepending path to file **libmpistub.so**.
* `Added custom mpicc_mana compiler in bin dir`:  For open-source MPI applications, this commit provides a custom compiler.  This compiler is to be used on systems that provide **_mpicc_** implementation dependent on libraries with constructor functions. This custom compiler `mpicc_mana` will compile source code with libmpistub library, instead of system MPI libraries, making it suitable to run under MANA checkpointing and restart software.
* `Fixed mpicc_mana to only support dynamic libraries`:  mpicc_mana only supports libmpistub.so, which is a dynamic library. This commit makes mpicc_mana to exit after printing an error message for static linking requests.