### PR TITLE
Fix compiler warning about MPI_Fnc_strings unused

### DIFF
--- a/mpi-proxy-split/lower-half/lower-half-api.h
+++ b/mpi-proxy-split/lower-half/lower-half-api.h
@@ -542,11 +542,13 @@ enum MPI_Fncs {
   FOREACH_FNC(GENERATE_ENUM)
   MPI_Fnc_Invalid,
 };
+#ifdef USES_MPI_Fnc_strings
 static const char *MPI_Fnc_strings[] = {
   "MPI_Fnc_NULL",
   FOREACH_FNC(GENERATE_FNC_STRING)
   "MPI_Fnc_Invalid"
 };
+#endif
 
 void* lh_dlsym(enum MPI_Fncs fnc);
 typedef void* (*proxyDlsym_t)(enum MPI_Fncs fnc);

--- a/mpi-proxy-split/record-replay.cpp
+++ b/mpi-proxy-split/record-replay.cpp
@@ -28,6 +28,7 @@
 #include "jassert.h"
 #include "jconvert.h"
 
+#define USES_MPI_Fnc_strings
 #include "record-replay.h"
 #include "virtual_id.h"
 #include "p2p_log_replay.h"


### PR DESCRIPTION
Fix a compiler warning about MPI_Fnc_strings unused.
If it's used in a .cpp file, then we set:
> `#define USES_MPI_Fnc_strings`

before
> `#include "lower-half-api.h"`