### PR TITLE
Fix compiler warnings

### DIFF
--- a/mpi-proxy-split/lower-half/copy-stack.c
+++ b/mpi-proxy-split/lower-half/copy-stack.c
@@ -48,7 +48,7 @@ char *deepCopyStack(int argc, char **argv, char *argc_ptr, char *argv_ptr,
       " This violates x86_64 ABI; needed for Intel SSE support.\n");
     exit(1);
   }
-  assert((unsigned long)(argv[-1]) == argc);
+  assert((long int)(argv[-1]) == argc);
   // $sp should be pointing to &(argv[-1])
   char *start_stack = (char *)&(argv[-1]);
   int i;
@@ -254,6 +254,8 @@ printf("\nDEBUGGING:\ndest_mem_addr (top of stack): %p;\n"
   return dest_curr_stack;
 }
 
+// FIXME:  This was copied into lower-half.cpp, and is unused here.
+//         Why didn't we simply remove the 'static' declaration?
 // Given a pointer to auxvector, parses the aux vector and patches the AT_PHDR,
 // AT_ENTRY, and AT_PHNUM entries.
 static void

--- a/mpi-proxy-split/lower-half/get-symbol-offset.c
+++ b/mpi-proxy-split/lower-half/get-symbol-offset.c
@@ -15,7 +15,7 @@ static int readElfSection(int , int , const Elf64_Ehdr* ,
 static int expandDebugFile(char *debugLibName,
                            const char *dir, const char *debugName);
 
-off_t get_symbol_offset(char *pathname, char *symbol) {
+off_t get_symbol_offset(const char *pathname, const char *symbol) {
   unsigned char e_ident[EI_NIDENT];
   int rc;
   int symtab_found = 0;

--- a/mpi-proxy-split/lower-half/lower-half-api.h
+++ b/mpi-proxy-split/lower-half/lower-half-api.h
@@ -54,8 +54,8 @@ typedef struct _LowerHalfInfo
   void *munmap;
   void *mmap_list_fptr;
   void *lh_dlsym;
-  void *uh_stack_start;
-  void *uh_stack_end;
+  char *uh_stack_start;
+  char *uh_stack_end;
 
   // MPI Constants
   MPI_Group MANA_GROUP_NULL;

--- a/mpi-proxy-split/lower-half/mem-wrapper.cpp
+++ b/mpi-proxy-split/lower-half/mem-wrapper.cpp
@@ -268,60 +268,60 @@ void addRegionTommaps(char * addr, size_t length) {
 void updateMmaps(char *addr, size_t length) {
   // traverse through the mmap'ed list and check whether to remove the whole
   // entry or update the address and length
-  char *unmaped_start_addr = addr;
-  char *unmaped_end_addr = addr + length;
+  char *unmapped_start_addr = addr;
+  char *unmapped_end_addr = addr + length;
   // sort the mmaps list by address
   std::sort(mmaps.begin(), mmaps.end(), compare);
   // iterate over the list
   for (auto it = mmaps.begin(); it != mmaps.end(); it++) {
     char *start_addr = it->addr;
     char *end_addr = start_addr + it->len;
-    // if unmaped start address is same as mmaped start address
-    if (start_addr == unmaped_start_addr) {
-      if (unmaped_end_addr == end_addr) {
+    // if unmapped start address is same as mmaped start address
+    if (start_addr == unmapped_start_addr) {
+      if (unmapped_end_addr == end_addr) {
         // remove full entry
         mmaps.erase(it);
         return;
-      } else if (end_addr > unmaped_end_addr) {
-          it->addr = unmaped_end_addr;
+      } else if (end_addr > unmapped_end_addr) {
+          it->addr = unmapped_end_addr;
           it->len = it->len - length;
           return;
         } else {
-        // if the unmaped region is going beyond the len
-        unmaped_start_addr = end_addr;
+        // if the unmapped region is going beyond the len
+        unmapped_start_addr = end_addr;
         length -= it->len;
         mmaps.erase(it);
         it--;
       }
-    } else if ((unmaped_start_addr < start_addr) && (unmaped_end_addr > start_addr)) {
-      if (unmaped_end_addr ==  end_addr) {
+    } else if ((unmapped_start_addr < start_addr) && (unmapped_end_addr > start_addr)) {
+      if (unmapped_end_addr ==  end_addr) {
         mmaps.erase(it);
         return;
-      } else if (end_addr > unmaped_end_addr) {
-          it->addr = unmaped_end_addr;
-          it->len = end_addr - unmaped_end_addr;
+      } else if (end_addr > unmapped_end_addr) {
+          it->addr = unmapped_end_addr;
+          it->len = end_addr - unmapped_end_addr;
           return;
         } else {
-        // if the unmaped region is going beyond the len
-        length -= length - (end_addr - unmaped_start_addr);
-        unmaped_start_addr = end_addr;
+        // if the unmapped region is going beyond the len
+        length -= length - (end_addr - unmapped_start_addr);
+        unmapped_start_addr = end_addr;
         mmaps.erase(it);
         it--;
       }
-    } else if ((unmaped_start_addr > start_addr) && (unmaped_start_addr <= end_addr)) {
-        it->len = unmaped_start_addr - start_addr;
-        if (unmaped_end_addr ==  end_addr) {
+    } else if ((unmapped_start_addr > start_addr) && (unmapped_start_addr <= end_addr)) {
+        it->len = unmapped_start_addr - start_addr;
+        if (unmapped_end_addr ==  end_addr) {
           return;
-        } else if (end_addr > unmaped_end_addr) {
+        } else if (end_addr > unmapped_end_addr) {
           MmapInfo_t new_entry;
-          new_entry.addr = unmaped_end_addr;
-          new_entry.len = end_addr - unmaped_end_addr;
+          new_entry.addr = unmapped_end_addr;
+          new_entry.len = end_addr - unmapped_end_addr;
           mmaps.push_back(new_entry);
           return;
         } else {
-          // if the unmaped region is going beyond the len
-          length = length - (end_addr - unmaped_start_addr);
-          unmaped_start_addr = end_addr;
+          // if the unmapped region is going beyond the len
+          length = length - (end_addr - unmapped_start_addr);
+          unmapped_start_addr = end_addr;
         }
     }
   }

--- a/mpi-proxy-split/lower-half/switch-context.h
+++ b/mpi-proxy-split/lower-half/switch-context.h
@@ -87,8 +87,8 @@ class SwitchContext
 //   (similar to define's in lower-half/mmap_internal.h)
 #define PAGE_SIZE              0x1000
 #define HUGE_PAGE              0x200000
-#define ROUND_UP(addr, size) (((unsigned long)addr + size - 1) & ~(size - 1))
-#define ROUND_DOWN(addr, size) ((unsigned long)addr & ~(size - 1))
+#define ROUND_UP(addr, size) (((unsigned long)(addr) + size - 1) & ~(size - 1))
+#define ROUND_DOWN(addr, size) ((unsigned long)(addr) & ~(size - 1))
 
 #ifdef __clang__
 # define NO_OPTIMIZE __attribute__((optnone))

--- a/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
@@ -52,7 +52,7 @@ static const char collective_p2p_string[] =
 ManaHeader g_mana_header = { .init_flag = MPI_INIT_NO_THREAD };
 
 USER_DEFINED_WRAPPER(int, Init, (int *) argc, (char ***) argv) {
-  int retval;
+  int retval = MPI_SUCCESS;
   if (isUsingCollectiveToP2p()) {
     fprintf(stderr, collective_p2p_string);
   }
@@ -70,7 +70,7 @@ USER_DEFINED_WRAPPER(int, Init, (int *) argc, (char ***) argv) {
 }
 USER_DEFINED_WRAPPER(int, Init_thread, (int *) argc, (char ***) argv,
                      (int) required, (int *) provided) {
-  int retval;
+  int retval = MPI_SUCCESS;
   if (isUsingCollectiveToP2p()) {
     fprintf(stderr, collective_p2p_string);
   }

--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -109,8 +109,8 @@ static bool isLhDevice(const ProcMapsArea *area);
 
 void *old_brk;
 void *old_end_of_brk;
-void *uh_stack_start;
-void *uh_stack_end;
+char *uh_stack_start;
+char *uh_stack_end;
 
 // Check if haystack region contains needle region.
 static inline int


### PR DESCRIPTION
We had a huge number of compiler warnings in lower-half dir (and some elsewhere).
I got bored with fixing the any warnings, but this fixes some of the worst of them.  This would be embarrassing for our release.

(See the first commit msg for an analysis of the many warnings.)

This is ready for review now.