### PR TITLE
Simplified wrappers

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
@@ -41,7 +41,8 @@ using namespace dmtcp_mpi;
 
 extern "C" {
 
-int MPI_Cart_coords(MPI_Comm comm, int rank, int maxdims, int *coords)
+#pragma weak MPI_Cart_coords = PMPI_Cart_coords
+int PMPI_Cart_coords(MPI_Comm comm, int rank, int maxdims, int *coords)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -53,7 +54,8 @@ int MPI_Cart_coords(MPI_Comm comm, int rank, int maxdims, int *coords)
   return retval;
 }
 
-int MPI_Cart_get(MPI_Comm comm, int maxdims, int *dims, int *periods, int *coords)
+#pragma weak MPI_Cart_get = PMPI_Cart_get
+int PMPI_Cart_get(MPI_Comm comm, int maxdims, int *dims, int *periods, int *coords)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -65,7 +67,8 @@ int MPI_Cart_get(MPI_Comm comm, int maxdims, int *dims, int *periods, int *coord
   return retval;
 }
 
-int MPI_Cart_map(MPI_Comm comm, int ndims, const int *dims, const int *periods,
+#pragma weak MPI_Cart_map = PMPI_Cart_map
+int PMPI_Cart_map(MPI_Comm comm, int ndims, const int *dims, const int *periods,
                  int  *newrank)
 {
   int retval;
@@ -84,7 +87,8 @@ int MPI_Cart_map(MPI_Comm comm, int ndims, const int *dims, const int *periods,
   return retval;
 }
 
-int MPI_Cart_rank(MPI_Comm comm, const int *coords, int *rank)
+#pragma weak MPI_Cart_rank = PMPI_Cart_rank
+int PMPI_Cart_rank(MPI_Comm comm, const int *coords, int *rank)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -96,7 +100,8 @@ int MPI_Cart_rank(MPI_Comm comm, const int *coords, int *rank)
   return retval;
 }
 
-int MPI_Cart_shift(MPI_Comm comm, int direction, int disp, int *rank_source,
+#pragma weak MPI_Cart_shift = PMPI_Cart_shift
+int PMPI_Cart_shift(MPI_Comm comm, int direction, int disp, int *rank_source,
                    int *rank_dest)
 {
   int retval;
@@ -114,7 +119,8 @@ int MPI_Cart_shift(MPI_Comm comm, int direction, int disp, int *rank_source,
   return retval;
 }
 
-int MPI_Cart_sub(MPI_Comm comm, const int *remain_dims, MPI_Comm *new_comm)
+#pragma weak MPI_Cart_sub = PMPI_Cart_sub
+int PMPI_Cart_sub(MPI_Comm comm, const int *remain_dims, MPI_Comm *new_comm)
 {
   int retval;
 
@@ -132,7 +138,8 @@ int MPI_Cart_sub(MPI_Comm comm, const int *remain_dims, MPI_Comm *new_comm)
   return retval;
 }
 
-int MPI_Cartdim_get(MPI_Comm comm, int *ndims)
+#pragma weak MPI_Cartdim_get = PMPI_Cartdim_get
+int PMPI_Cartdim_get(MPI_Comm comm, int *ndims)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -144,7 +151,8 @@ int MPI_Cartdim_get(MPI_Comm comm, int *ndims)
   return retval;
 }
 
-int Dims_create(int nnodes, int ndims, int *dims)
+#pragma weak MPI_Dims_create = PMPI_Dims_create
+int PMPI_Dims_create(int nnodes, int ndims, int *dims)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -163,7 +171,8 @@ CartesianProperties g_cartesian_properties = { .comm_old_size = -1,
                                                .comm_old_rank = -1,
                                                .comm_cart_rank = -1 };
 
-int MPI_Cart_create(MPI_Comm old_comm, int ndims,
+#pragma weak MPI_Cart_create = PMPI_Cart_create
+int PMPI_Cart_create(MPI_Comm old_comm, int ndims,
                     const int *dims, const int *periods, int reorder,
                     MPI_Comm *comm_cart)
 {
@@ -203,7 +212,8 @@ int MPI_Cart_create(MPI_Comm old_comm, int ndims,
 }
 #else
 
-int MPI_Cart_create(MPI_Comm old_comm, int ndims,
+#pragma weak MPI_Cart_create = PMPI_Cart_create
+int PMPI_Cart_create(MPI_Comm old_comm, int ndims,
                     const int *dims, const int *periods, int reorder,
                     MPI_Comm *comm_cart)
 {
@@ -242,4 +252,5 @@ int MPI_Cart_create(MPI_Comm old_comm, int ndims,
 }
 
 #endif
+
 } // end of: extern "C"

--- a/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
@@ -1,22 +1,22 @@
 /****************************************************************************
- *   Copyright (C) 2019-2021 by Gene Cooperman, Rohan Garg, Yao Xu          *
- *   gene@ccs.neu.edu, rohgarg@ccs.neu.edu, xu.yao1@northeastern.edu        *
- *                                                                          *
- *  This file is part of DMTCP.                                             *
- *                                                                          *
- *  DMTCP is free software: you can redistribute it and/or                  *
- *  modify it under the terms of the GNU Lesser General Public License as   *
- *  published by the Free Software Foundation, either version 3 of the      *
- *  License, or (at your option) any later version.                         *
- *                                                                          *
- *  DMTCP is distributed in the hope that it will be useful,                *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of          *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
- *  GNU Lesser General Public License for more details.                     *
- *                                                                          *
- *  You should have received a copy of the GNU Lesser General Public        *
- *  License in the files COPYING and COPYING.LESSER.  If not, see           *
- *  <http://www.gnu.org/licenses/>.                                         *
+  *  Copyright (C) 2019-2021 by Gene Cooperman, Rohan Garg, Yao Xu          *
+  *  gene@ccs.neu.edu, rohgarg@ccs.neu.edu, xu.yao1@northeastern.edu        *
+  *                                                                         *
+  * This file is part of DMTCP.                                             *
+  *                                                                         *
+  * DMTCP is free software: you can redistribute it and/or                  *
+  * modify it under the terms of the GNU Lesser General Public License as   *
+  * published by the Free Software Foundation, either version 3 of the      *
+  * License, or (at your option) any later version.                         *
+  *                                                                         *
+  * DMTCP is distributed in the hope that it will be useful,                *
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+  * GNU Lesser General Public License for more details.                     *
+  *                                                                         *
+  * You should have received a copy of the GNU Lesser General Public        *
+  * License in the files COPYING and COPYING.LESSER.  If not, see           *
+  * <http://www.gnu.org/licenses/>.                                         *
  ****************************************************************************/
 
 #include "mpi_plugin.h"
@@ -39,8 +39,9 @@
 
 using namespace dmtcp_mpi;
 
-USER_DEFINED_WRAPPER(int, Cart_coords, (MPI_Comm) comm, (int) rank,
-                     (int) maxdims, (int*) coords)
+extern "C" {
+
+int MPI_Cart_coords(MPI_Comm comm, int rank, int maxdims, int *coords)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -52,8 +53,7 @@ USER_DEFINED_WRAPPER(int, Cart_coords, (MPI_Comm) comm, (int) rank,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Cart_get, (MPI_Comm) comm, (int) maxdims,
-                     (int*) dims, (int*) periods, (int*) coords)
+int MPI_Cart_get(MPI_Comm comm, int maxdims, int *dims, int *periods, int *coords)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -65,8 +65,8 @@ USER_DEFINED_WRAPPER(int, Cart_get, (MPI_Comm) comm, (int) maxdims,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Cart_map, (MPI_Comm) comm, (int) ndims,
-                     (const int*) dims, (const int*) periods, (int *) newrank)
+int MPI_Cart_map(MPI_Comm comm, int ndims, const int *dims, const int *periods,
+                 int  *newrank)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -76,16 +76,15 @@ USER_DEFINED_WRAPPER(int, Cart_map, (MPI_Comm) comm, (int) ndims,
   retval = NEXT_FUNC(Cart_map)(realComm, ndims, dims, periods, newrank);
   RETURN_TO_UPPER_HALF();
   if (retval == MPI_SUCCESS && MPI_LOGGING()) {
-    FncArg ds = CREATE_LOG_BUF(dims, ndims * sizeof(int));
-    FncArg ps = CREATE_LOG_BUF(periods, ndims * sizeof(int));
+    FncArg ds = CREATE_LOG_BUF(dims, ndims  *sizeof(int));
+    FncArg ps = CREATE_LOG_BUF(periods, ndims  *sizeof(int));
     LOG_CALL(restoreCarts, Cart_map, comm, ndims, ds, ps, newrank);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Cart_rank, (MPI_Comm) comm,
-                     (const int*) coords, (int *) rank)
+int MPI_Cart_rank(MPI_Comm comm, const int *coords, int *rank)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -97,8 +96,8 @@ USER_DEFINED_WRAPPER(int, Cart_rank, (MPI_Comm) comm,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Cart_shift, (MPI_Comm) comm, (int) direction,
-                     (int) disp, (int *) rank_source, (int *) rank_dest)
+int MPI_Cart_shift(MPI_Comm comm, int direction, int disp, int *rank_source,
+                   int *rank_dest)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -115,8 +114,7 @@ USER_DEFINED_WRAPPER(int, Cart_shift, (MPI_Comm) comm, (int) direction,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Cart_sub, (MPI_Comm) comm,
-                     (const int*) remain_dims, (MPI_Comm *) new_comm)
+int MPI_Cart_sub(MPI_Comm comm, const int *remain_dims, MPI_Comm *new_comm)
 {
   int retval;
 
@@ -134,7 +132,7 @@ USER_DEFINED_WRAPPER(int, Cart_sub, (MPI_Comm) comm,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Cartdim_get, (MPI_Comm) comm, (int *) ndims)
+int MPI_Cartdim_get(MPI_Comm comm, int *ndims)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -146,7 +144,7 @@ USER_DEFINED_WRAPPER(int, Cartdim_get, (MPI_Comm) comm, (int *) ndims)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Dims_create, (int)nnodes, (int)ndims, (int *)dims)
+int Dims_create(int nnodes, int ndims, int *dims)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -165,9 +163,9 @@ CartesianProperties g_cartesian_properties = { .comm_old_size = -1,
                                                .comm_old_rank = -1,
                                                .comm_cart_rank = -1 };
 
-USER_DEFINED_WRAPPER(int, Cart_create, (MPI_Comm)old_comm, (int)ndims,
-                     (const int *)dims, (const int *)periods, (int)reorder,
-                     (MPI_Comm *)comm_cart)
+int MPI_Cart_create(MPI_Comm old_comm, int ndims,
+                    const int *dims, const int *periods, int reorder,
+                    MPI_Comm *comm_cart)
 {
   JWARNING(g_cartesian_properties.comm_old_size == -1)
     .Text("MPI_Cart_create() called more than once. Current implementation "
@@ -205,9 +203,9 @@ USER_DEFINED_WRAPPER(int, Cart_create, (MPI_Comm)old_comm, (int)ndims,
 }
 #else
 
-USER_DEFINED_WRAPPER(int, Cart_create, (MPI_Comm) old_comm, (int) ndims,
-                     (const int*) dims, (const int*) periods, (int) reorder,
-                     (MPI_Comm *) comm_cart)
+int MPI_Cart_create(MPI_Comm old_comm, int ndims,
+                    const int *dims, const int *periods, int reorder,
+                    MPI_Comm *comm_cart)
 {
   int retval;
   // The MPI library assigns the cartesian coordinates naively
@@ -244,21 +242,4 @@ USER_DEFINED_WRAPPER(int, Cart_create, (MPI_Comm) old_comm, (int) ndims,
 }
 
 #endif
-
-PMPI_IMPL(int, MPI_Cart_coords, MPI_Comm comm, int rank,
-          int maxdims, int coords[])
-PMPI_IMPL(int, MPI_Cart_create, MPI_Comm old_comm, int ndims,
-          const int dims[], const int periods[], int reorder,
-          MPI_Comm *comm_cart)
-PMPI_IMPL(int, MPI_Cart_get, MPI_Comm comm, int maxdims,
-          int dims[], int periods[], int coords[])
-PMPI_IMPL(int, MPI_Cart_map, MPI_Comm comm, int ndims,
-          const int dims[], const int periods[], int *newrank)
-PMPI_IMPL(int, MPI_Cart_rank, MPI_Comm comm, const int coords[], int *rank)
-PMPI_IMPL(int, MPI_Cart_shift, MPI_Comm comm, int direction,
-          int disp, int *rank_source, int *rank_dest)
-PMPI_IMPL(int, MPI_Cart_sub, MPI_Comm comm,
-          const int remain_dims[], MPI_Comm *new_comm)
-PMPI_IMPL(int, MPI_Cartdim_get, MPI_Comm comm, int *ndims)
-PMPI_IMPL(int, MPI_Dims_create, int nnodes, int ndims, int *dims)
-
+} // end of: extern "C"

--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_p2p.c
@@ -66,7 +66,8 @@ extern "C" {
 #endif
 
 // MPI standard 3.1:  Section 5.3
-int MPI_Barrier(MPI_Comm comm) {
+#pragma weak MPI_Barrier = PMPI_Barrier
+int PMPI_Barrier(MPI_Comm comm) {
   PROLOG_Comm_rank_size;
   // Does MPI specify that a send/recv count of 0 must be blocking?
   int buffer[1] = {98};
@@ -93,7 +94,8 @@ int MPI_Barrier(MPI_Comm comm) {
 }
 
 // MPI standard 3.1:  Section 5.4
-int MPI_Bcast(void* buffer, int count, MPI_Datatype datatype,
+#pragma weak MPI_Bcast = PMPI_Bcast
+int PMPI_Bcast(void* buffer, int count, MPI_Datatype datatype,
               int root, MPI_Comm comm) {
   PROLOG_Comm_rank_size;
   if (rank == root) {
@@ -110,7 +112,8 @@ int MPI_Bcast(void* buffer, int count, MPI_Datatype datatype,
 }
 
 // MPI standard 3.1:  Section 5.5
-int MPI_Gather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+#pragma weak MPI_Gather = PMPI_Gather
+int PMPI_Gather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                void* recvbuf, int recvcount, MPI_Datatype recvtype,
                int root, MPI_Comm comm) {
   PROLOG_Comm_rank_size;
@@ -141,7 +144,8 @@ int MPI_Gather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
   return MPI_SUCCESS;
 }
 
-int MPI_Gatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+#pragma weak MPI_Gatherv = PMPI_Gatherv
+int PMPI_Gatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                 void* recvbuf, const int recvcounts[], const int displs[],
                 MPI_Datatype recvtype, int root, MPI_Comm comm) {
   PROLOG_Comm_rank_size;
@@ -177,7 +181,8 @@ int MPI_Gatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
 }
 
 // MPI standard 3.1:  Section 5.6
-int MPI_Scatter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+#pragma weak MPI_Scatter = PMPI_Scatter
+int PMPI_Scatter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                 void* recvbuf, int recvcount, MPI_Datatype recvtype,
                 int root, MPI_Comm comm) {
   PROLOG_Comm_rank_size;
@@ -218,7 +223,8 @@ int MPI_Scatter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
   return MPI_SUCCESS;
 }
 
-int MPI_Scatterv(const void* sendbuf, const int sendcounts[],
+#pragma weak MPI_Scatterv = PMPI_Scatterv
+int PMPI_Scatterv(const void* sendbuf, const int sendcounts[],
                  const int displs[], MPI_Datatype sendtype,
                  void* recvbuf, int recvcount, MPI_Datatype recvtype,
                  int root, MPI_Comm comm) {
@@ -252,7 +258,8 @@ int MPI_Scatterv(const void* sendbuf, const int sendcounts[],
 
 // MPI standard 3.1:  Section 5.7
 //   Implementations based on 'man MPI_Allgather' for Open MPI
-int MPI_Allgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+#pragma weak MPI_Allgather = PMPI_Allgather
+int PMPI_Allgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                   void* recvbuf, int recvcount, MPI_Datatype recvtype,
                   MPI_Comm comm) {
   PROLOG_Comm_rank_size;
@@ -265,7 +272,8 @@ int MPI_Allgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
   return MPI_SUCCESS;
 }
 
-int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+#pragma weak MPI_Allgatherv = PMPI_Allgatherv
+int PMPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                    void *recvbuf, const int recvcounts[], const int displs[],
                    MPI_Datatype recvtype, MPI_Comm comm) {
   PROLOG_Comm_rank_size;
@@ -278,7 +286,8 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 }
 
 // MPI standard 3.1:  Section 5.8
-int MPI_Alltoall(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+#pragma weak MPI_Alltoall = PMPI_Alltoall
+int PMPI_Alltoall(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                  void* recvbuf, int recvcount, MPI_Datatype recvtype,
                  MPI_Comm comm) {
   PROLOG_Comm_rank_size;
@@ -328,7 +337,8 @@ int MPI_Alltoall(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
   return MPI_SUCCESS;
 }
 
-int MPI_Alltoallv(const void* sendbuf, const int sendcounts[],
+#pragma weak MPI_Alltoallv = PMPI_Alltoallv
+int PMPI_Alltoallv(const void* sendbuf, const int sendcounts[],
                   const int sdispls[], MPI_Datatype sendtype,
                   void* recvbuf, const int recvcounts[],
                   const int rdispls[], MPI_Datatype recvtype,
@@ -389,7 +399,8 @@ int MPI_Alltoallv(const void* sendbuf, const int sendcounts[],
 }
 
 #ifdef ADD_UNDEFINED
-int MPI_Alltoallw(const void* sendbuf, const int sendcounts[],
+#pragma weak MPI_Alltoallw = PMPI_Alltoallw
+int PMPI_Alltoallw(const void* sendbuf, const int sendcounts[],
                   const int sdispls[], const MPI_Datatype sendtypes[],
                   void* recvbuf, const int recvcounts[], const int rdispls[],
                   const MPI_Datatype recvtypes[], MPI_Comm comm) {
@@ -420,7 +431,8 @@ int MPI_Alltoallw(const void* sendbuf, const int sendcounts[],
  * MPI_MAXLOC
  * MPI_MINLOC
  */
-int MPI_Reduce(const void* sendbuf, void* recvbuf, int count,
+#pragma weak MPI_Reduce = PMPI_Reduce
+int PMPI_Reduce(const void* sendbuf, void* recvbuf, int count,
                MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm) {
   PROLOG_Comm_rank_size;
   MPI_Aint lower_bound;
@@ -456,7 +468,8 @@ int MPI_Reduce(const void* sendbuf, void* recvbuf, int count,
   return MPI_SUCCESS;
 }
 
-int MPI_Allreduce(const void* sendbuf, void* recvbuf, int count,
+#pragma weak MPI_Allreduce = PMPI_Allreduce
+int PMPI_Allreduce(const void* sendbuf, void* recvbuf, int count,
                   MPI_Datatype datatype, MPI_Op op, MPI_Comm comm) {
   // sendbuf can propagate MPI_IN_PLACE and FORTRAN_MPI_IN_PLACE
   MPI_Reduce(sendbuf, recvbuf, count, datatype, op, 0 /* root */, comm);
@@ -466,7 +479,8 @@ int MPI_Allreduce(const void* sendbuf, void* recvbuf, int count,
 
 #ifdef ADD_UNDEFINED
 // MPI standard 3.1:  Section 5.10
-int MPI_Reduce_scatter_block(const void* sendbuf, void* recvbuf,
+#pragma weak MPI_Reduce_scatter_block = PMPI_Reduce_scatter_block
+int PMPI_Reduce_scatter_block(const void* sendbuf, void* recvbuf,
                              int recvcount, MPI_Datatype datatype, MPI_Op op,
                              MPI_Comm comm) {
   fprintf(stderr, "%s not implemented\n", __FUNCTION__);
@@ -475,7 +489,8 @@ int MPI_Reduce_scatter_block(const void* sendbuf, void* recvbuf,
 }
 #endif
 
-int MPI_Reduce_scatter(const void* sendbuf, void* recvbuf,
+#pragma weak MPI_Reduce_scatter = PMPI_Reduce_scatter
+int PMPI_Reduce_scatter(const void* sendbuf, void* recvbuf,
                        const int recvcounts[], MPI_Datatype datatype, MPI_Op op,
                        MPI_Comm comm) {
   fprintf(stderr, "%s not implemented\n", __FUNCTION__);
@@ -484,7 +499,8 @@ int MPI_Reduce_scatter(const void* sendbuf, void* recvbuf,
 }
 
 // MPI standard 3.1:  Section 5.11
-int MPI_Scan(const void* sendbuf, void* recvbuf, int count,
+#pragma weak MPI_Scan = PMPI_Scan
+int PMPI_Scan(const void* sendbuf, void* recvbuf, int count,
              MPI_Datatype datatype, MPI_Op op, MPI_Comm comm) {
   PROLOG_Comm_rank_size;
 
@@ -545,7 +561,8 @@ int MPI_Scan(const void* sendbuf, void* recvbuf, int count,
   return MPI_SUCCESS;
 }
 #ifdef ADD_UNDEFINED
-int MPI_Exscan(const void* sendbuf, void* recvbuf, int count,
+#pragma weak MPI_Exscan = PMPI_Exscan
+int PMPI_Exscan(const void* sendbuf, void* recvbuf, int count,
              MPI_Datatype datatype, MPI_Op op, MPI_Comm comm) {
   fprintf(stderr, "%s not implemented\n", __FUNCTION__);
   ABORT();
@@ -561,21 +578,24 @@ int MPI_Exscan(const void* sendbuf, void* recvbuf, int count,
  ********************************************************************/
 // MPI standard 3.1:  Section 5.12
 
-int MPI_Ibarrier(MPI_Comm comm, MPI_Request *request) {
+#pragma weak MPI_Ibarrier = PMPI_Ibarrier
+int PMPI_Ibarrier(MPI_Comm comm, MPI_Request *request) {
   ACTIVATE_REQUEST(request);
   return MPI_Barrier(comm);
 }
 
 // FIXME:  This works for most applications, but there is a theoretical danger
 //         of deadlock.  We could implement using MPI_{Isend,Irecv} to fix that.
-int MPI_Ibcast(void* buffer, int count, MPI_Datatype datatype,
+#pragma weak MPI_Ibcast = PMPI_Ibcast
+int PMPI_Ibcast(void* buffer, int count, MPI_Datatype datatype,
                int root, MPI_Comm comm, MPI_Request *request) {
   ACTIVATE_REQUEST(request);
   return MPI_Bcast(buffer, count, datatype, root, comm);
 }
 
 #ifdef ADD_UNDEFINED
-int MPI_Igather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+#pragma weak MPI_Igather = PMPI_Igather
+int PMPI_Igather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                 void* recvbuf, int recvcount, MPI_Datatype recvtype,
                 int root, MPI_Comm comm, MPI_Request *request) {
   ACTIVATE_REQUEST(request);
@@ -583,7 +603,8 @@ int MPI_Igather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                     recvbuf, recvcount, recvtype, root, comm);
 }
 
-int MPI_Iscatter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+#pragma weak MPI_Iscatter = PMPI_Iscatter
+int PMPI_Iscatter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                  void* recvbuf, int recvcount, MPI_Datatype recvtype,
                  int root, MPI_Comm comm, MPI_Request *request) {
   ACTIVATE_REQUEST(request);
@@ -591,7 +612,8 @@ int MPI_Iscatter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                      recvbuf, recvcount, recvtype, root, comm);
 }
 
-int MPI_Iallgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+#pragma weak MPI_Iallgather = PMPI_Iallgather
+int PMPI_Iallgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                    void* recvbuf, int recvcount, MPI_Datatype recvtype,
                    MPI_Comm comm, MPI_Request *request) {
   ACTIVATE_REQUEST(request);
@@ -599,7 +621,8 @@ int MPI_Iallgather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                        recvtype, comm);
 }
 
-int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+#pragma weak MPI_Iallgatherv = PMPI_Iallgatherv
+int PMPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                      void *recvbuf, const int recvcounts[], const int displs[],
                      MPI_Datatype recvtype, MPI_Comm comm,
                      MPI_Request *request) {
@@ -608,7 +631,8 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                         recvbuf, recvcounts, displs, recvtype, comm);
 }
 
-int MPI_Ialltoall(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
+#pragma weak MPI_Ialltoall = PMPI_Ialltoall
+int PMPI_Ialltoall(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
           void* recvbuf, int recvcount, MPI_Datatype recvtype,
           MPI_Comm comm, MPI_Request *request) {
   ACTIVATE_REQUEST(request);
@@ -616,7 +640,8 @@ int MPI_Ialltoall(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
                       recvbuf, recvcount, recvtype, comm);
 }
 
-int MPI_Ialltoallv(const void* sendbuf, const int sendcounts[],
+#pragma weak MPI_Ialltoallv = PMPI_Ialltoallv
+int PMPI_Ialltoallv(const void* sendbuf, const int sendcounts[],
                    const int sdispls[], MPI_Datatype sendtype,
                    void* recvbuf, const int recvcounts[],
                    const int rdispls[], MPI_Datatype recvtype,
@@ -626,7 +651,8 @@ int MPI_Ialltoallv(const void* sendbuf, const int sendcounts[],
                    recvbuf, recvcounts, rdispls, recvtype, comm);
 }
 
-int MPI_Ialltoallw(const void* sendbuf, const int sendcounts[],
+#pragma weak MPI_Ialltoallw = PMPI_Ialltoallw
+int PMPI_Ialltoallw(const void* sendbuf, const int sendcounts[],
                    const int sdispls[], const MPI_Datatype sendtypes[],
                    void* recvbuf, const int recvcounts[], const int rdispls[],
                    const MPI_Datatype recvtypes[], MPI_Comm comm,
@@ -640,7 +666,8 @@ int MPI_Ialltoallw(const void* sendbuf, const int sendcounts[],
 
 // FIXME:  This works for most applications, but there is a theoretical danger
 //         of deadlock.  We could implement using MPI_{Isend,Irecv} to fix that.
-int MPI_Ireduce(const void* sendbuf, void* recvbuf, int count,
+#pragma weak MPI_Ireduce = PMPI_Ireduce
+int PMPI_Ireduce(const void* sendbuf, void* recvbuf, int count,
                 MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm,
                 MPI_Request *request) {
   ACTIVATE_REQUEST(request);
@@ -648,14 +675,16 @@ int MPI_Ireduce(const void* sendbuf, void* recvbuf, int count,
 }
 
 #ifdef ADD_UNDEFINED
-int MPI_Iallreduce(const void* sendbuf, void* recvbuf, int count,
+#pragma weak MPI_Iallreduce = PMPI_Iallreduce
+int PMPI_Iallreduce(const void* sendbuf, void* recvbuf, int count,
                 MPI_Datatype datatype, MPI_Op op, MPI_Comm comm,
                 MPI_Request *request) {
   ACTIVATE_REQUEST(request);
   return MPI_Allreduce(sendbuf, recvbuf, count, datatype, op, comm);
 }
 
-int MPI_Ireduce_scatter_block(const void* sendbuf, void* recvbuf,
+#pragma weak MPI_Ireduce_scatter_block = PMPI_Ireduce_scatter_block
+int PMPI_Ireduce_scatter_block(const void* sendbuf, void* recvbuf,
                               int recvcount, MPI_Datatype datatype, MPI_Op op,
                               MPI_Comm comm, MPI_Request *request) {
   ACTIVATE_REQUEST(request);
@@ -663,7 +692,8 @@ int MPI_Ireduce_scatter_block(const void* sendbuf, void* recvbuf,
                                    op, comm);
 }
 
-int MPI_Ireduce_scatter(const void* sendbuf, void* recvbuf,
+#pragma weak MPI_Ireduce_scatter = PMPI_Ireduce_scatter
+int PMPI_Ireduce_scatter(const void* sendbuf, void* recvbuf,
                         const int recvcounts[], MPI_Datatype datatype,
                         MPI_Op op, MPI_Comm comm, MPI_Request *request) {
   ACTIVATE_REQUEST(request);
@@ -671,14 +701,16 @@ int MPI_Ireduce_scatter(const void* sendbuf, void* recvbuf,
                             op, comm);
 }
 
-int MPI_Iscan(const void* sendbuf, void* recvbuf, int count,
+#pragma weak MPI_Iscan = PMPI_Iscan
+int PMPI_Iscan(const void* sendbuf, void* recvbuf, int count,
               MPI_Datatype datatype, MPI_Op op, MPI_Comm comm,
               MPI_Request *request) {
   ACTIVATE_REQUEST(request);
   return MPI_Scan(sendbuf, recvbuf, count, datatype, op, comm);
 }
 
-int MPI_Iexscan(const void* sendbuf, void* recvbuf, int count,
+#pragma weak MPI_Iexscan = PMPI_Iexscan
+int PMPI_Iexscan(const void* sendbuf, void* recvbuf, int count,
                 MPI_Datatype datatype, MPI_Op op, MPI_Comm comm,
                 MPI_Request *request) {
   ACTIVATE_REQUEST(request);

--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -55,7 +55,8 @@ using namespace dmtcp_mpi;
 extern "C" {
 
 #ifndef MPI_COLLECTIVE_P2P
-int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype,
+#pragma weak MPI_Bcast = PMPI_Bcast
+int PMPI_Bcast(void *buffer, int count, MPI_Datatype datatype,
               int root, MPI_Comm comm)
 {
   commit_begin(comm);
@@ -71,7 +72,8 @@ int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype,
   return retval;
 }
 
-int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype,
+#pragma weak MPI_Ibcast = PMPI_Ibcast
+int PMPI_Ibcast(void *buffer, int count, MPI_Datatype datatype,
                int root, MPI_Comm comm, MPI_Request *request)
 {
   int retval;
@@ -95,7 +97,8 @@ int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype,
   return retval;
 }
 
-int MPI_Barrier(MPI_Comm comm)
+#pragma weak MPI_Barrier = PMPI_Barrier
+int PMPI_Barrier(MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -109,7 +112,8 @@ int MPI_Barrier(MPI_Comm comm)
   return retval;
 }
 
-int MPI_Ibarrier(MPI_Comm comm, MPI_Request *request)
+#pragma weak MPI_Ibarrier = PMPI_Ibarrier
+int PMPI_Ibarrier(MPI_Comm comm, MPI_Request *request)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -206,7 +210,8 @@ MPI_Allreduce_reproducible(const void *sendbuf,
   return rc;
 }
 
-int MPI_Allreduce(const void * sendbuf, void * recvbuf,
+#pragma weak MPI_Allreduce = PMPI_Allreduce
+int PMPI_Allreduce(const void * sendbuf, void * recvbuf,
               int count, MPI_Datatype datatype,
               MPI_Op op, MPI_Comm comm)
 {
@@ -238,7 +243,8 @@ int MPI_Allreduce(const void * sendbuf, void * recvbuf,
   return retval;
 }
 
-int MPI_Reduce(const void *sendbuf, void *recvbuf, int count,
+#pragma weak MPI_Reduce = PMPI_Reduce
+int PMPI_Reduce(const void *sendbuf, void *recvbuf, int count,
                MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm)
 {
   commit_begin(comm);
@@ -260,7 +266,8 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count,
   return retval;
 }
 
-int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count,
+#pragma weak MPI_Ireduce = PMPI_Ireduce
+int PMPI_Ireduce(const void *sendbuf, void *recvbuf, int count,
                 MPI_Datatype datatype, MPI_Op op,
                 int root, MPI_Comm comm, MPI_Request *request)
 {
@@ -288,7 +295,8 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count,
   return retval;
 }
 
-int MPI_Reduce_scatter(const void *sendbuf, void *recvbuf,
+#pragma weak MPI_Reduce_scatter = PMPI_Reduce_scatter
+int PMPI_Reduce_scatter(const void *sendbuf, void *recvbuf,
                        const int recvcounts[], MPI_Datatype datatype,
                        MPI_Op op, MPI_Comm comm)
 {
@@ -358,7 +366,7 @@ MPI_Alltoall_internal(const void *sendbuf, int sendcount,
                       MPI_Datatype sendtype, void *recvbuf, int recvcount,
                       MPI_Datatype recvtype, MPI_Comm comm)
 {
-  static int MPI_ALLTOALL_TAG = 0;
+  static int PMPI_ALLTOALL_TAG = 0;
   int retval, comm_size, rank;
   MPI_Comm_rank(comm, &rank);
   MPI_Comm_size(comm, &comm_size);
@@ -415,7 +423,8 @@ MPI_Alltoall_internal(const void *sendbuf, int sendcount,
 #endif
 
 #ifndef MPI_COLLECTIVE_P2P
-int MPI_Alltoall(const void *sendbuf, int sendcount,
+#pragma weak MPI_Alltoall = PMPI_Alltoall
+int PMPI_Alltoall(const void *sendbuf, int sendcount,
                  MPI_Datatype sendtype, void *recvbuf, int recvcount,
                  MPI_Datatype recvtype, MPI_Comm comm)
 {
@@ -428,7 +437,8 @@ int MPI_Alltoall(const void *sendbuf, int sendcount,
   return retval;
 }
 
-int MPI_Alltoallv(const void *sendbuf, const int *sendcounts,
+#pragma weak MPI_Alltoallv = PMPI_Alltoallv
+int PMPI_Alltoallv(const void *sendbuf, const int *sendcounts,
                   const int *sdispls, MPI_Datatype sendtype,
                   void *recvbuf, const int *recvcounts,
                   const int *rdispls, MPI_Datatype recvtype,
@@ -454,7 +464,8 @@ int MPI_Alltoallv(const void *sendbuf, const int *sendcounts,
   return retval;
 }
 
-int MPI_Gather(const void *sendbuf, int sendcount,
+#pragma weak MPI_Gather = PMPI_Gather
+int PMPI_Gather(const void *sendbuf, int sendcount,
                MPI_Datatype sendtype, void *recvbuf, int recvcount,
                MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
@@ -482,7 +493,8 @@ int MPI_Gather(const void *sendbuf, int sendcount,
   return retval;
 }
 
-int MPI_Gatherv(const void *sendbuf, int sendcount,
+#pragma weak MPI_Gatherv = PMPI_Gatherv
+int PMPI_Gatherv(const void *sendbuf, int sendcount,
                 MPI_Datatype sendtype, void *recvbuf,
                 const int *recvcounts, const int *displs,
                 MPI_Datatype recvtype, int root, MPI_Comm comm)
@@ -507,7 +519,8 @@ int MPI_Gatherv(const void *sendbuf, int sendcount,
   return retval;
 }
 
-int MPI_Scatter(const void *sendbuf, int sendcount,
+#pragma weak MPI_Scatter = PMPI_Scatter
+int PMPI_Scatter(const void *sendbuf, int sendcount,
                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
                 MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
@@ -531,7 +544,8 @@ int MPI_Scatter(const void *sendbuf, int sendcount,
   return retval;
 }
 
-int MPI_Scatterv(const void *sendbuf,
+#pragma weak MPI_Scatterv = PMPI_Scatterv
+int PMPI_Scatterv(const void *sendbuf,
                  const int *sendcounts, const int *displs,
                  MPI_Datatype sendtype, void *recvbuf, int recvcount,
                  MPI_Datatype recvtype, int root, MPI_Comm comm)
@@ -556,7 +570,8 @@ int MPI_Scatterv(const void *sendbuf,
   return retval;
 }
 
-int MPI_Allgather(const void *sendbuf, int sendcount,
+#pragma weak MPI_Allgather = PMPI_Allgather
+int PMPI_Allgather(const void *sendbuf, int sendcount,
                   MPI_Datatype sendtype, void *recvbuf, int recvcount,
                   MPI_Datatype recvtype, MPI_Comm comm)
 {
@@ -580,7 +595,8 @@ int MPI_Allgather(const void *sendbuf, int sendcount,
   return retval;
 }
 
-int MPI_Allgatherv(const void *sendbuf, int sendcount,
+#pragma weak MPI_Allgatherv = PMPI_Allgatherv
+int PMPI_Allgatherv(const void *sendbuf, int sendcount,
                    MPI_Datatype sendtype, void *recvbuf,
                    const int *recvcounts, const int *displs,
                    MPI_Datatype recvtype, MPI_Comm comm)
@@ -605,7 +621,8 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount,
   return retval;
 }
 
-int MPI_Scan(const void *sendbuf, void *recvbuf,
+#pragma weak MPI_Scan = PMPI_Scan
+int PMPI_Scan(const void *sendbuf, void *recvbuf,
              int count, MPI_Datatype datatype,
              MPI_Op op, MPI_Comm comm)
 {
@@ -630,7 +647,8 @@ int MPI_Scan(const void *sendbuf, void *recvbuf,
 #endif // #ifndef MPI_COLLECTIVE_P2P
 
 // FIXME: Also check the MPI_Cart family, if they use collective communications.
-int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm)
+#pragma weak MPI_Comm_split = PMPI_Comm_split
+int PMPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm)
 {
   commit_begin(comm);
   int retval;
@@ -651,7 +669,8 @@ int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm)
   return retval;
 }
 
-int MPI_Comm_dup(MPI_Comm comm, MPI_Comm *newcomm)
+#pragma weak MPI_Comm_dup = PMPI_Comm_dup
+int PMPI_Comm_dup(MPI_Comm comm, MPI_Comm *newcomm)
 {
   commit_begin(comm);
   int retval;

--- a/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -52,10 +52,11 @@ isUsingCollectiveToP2p() {
 
 using namespace dmtcp_mpi;
 
+extern "C" {
+
 #ifndef MPI_COLLECTIVE_P2P
-USER_DEFINED_WRAPPER(int, Bcast,
-                     (void *) buffer, (int) count, (MPI_Datatype) datatype,
-                     (int) root, (MPI_Comm) comm)
+int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype,
+              int root, MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -70,9 +71,8 @@ USER_DEFINED_WRAPPER(int, Bcast,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Ibcast,
-                     (void *) buffer, (int) count, (MPI_Datatype) datatype,
-                     (int) root, (MPI_Comm) comm, (MPI_Request *) request)
+int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype,
+               int root, MPI_Comm comm, MPI_Request *request)
 {
   int retval;
   commit_begin(comm);
@@ -95,7 +95,7 @@ USER_DEFINED_WRAPPER(int, Ibcast,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Barrier, (MPI_Comm) comm)
+int MPI_Barrier(MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -109,8 +109,7 @@ USER_DEFINED_WRAPPER(int, Barrier, (MPI_Comm) comm)
   return retval;
 }
 
-EXTERNC
-USER_DEFINED_WRAPPER(int, Ibarrier, (MPI_Comm) comm, (MPI_Request *) request)
+int MPI_Ibarrier(MPI_Comm comm, MPI_Request *request)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -207,10 +206,9 @@ MPI_Allreduce_reproducible(const void *sendbuf,
   return rc;
 }
 
-USER_DEFINED_WRAPPER(int, Allreduce,
-                     (const void *) sendbuf, (void *) recvbuf,
-                     (int) count, (MPI_Datatype) datatype,
-                     (MPI_Op) op, (MPI_Comm) comm)
+int MPI_Allreduce(const void * sendbuf, void * recvbuf,
+              int count, MPI_Datatype datatype,
+              MPI_Op op, MPI_Comm comm)
 {
   char *s = getenv("MANA_USE_ALLREDUCE_REPRODUCIBLE");
   int use_allreduce_reproducible = (s != NULL) ? atoi(s) : 0;
@@ -240,10 +238,8 @@ USER_DEFINED_WRAPPER(int, Allreduce,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Reduce,
-                     (const void *) sendbuf, (void *) recvbuf, (int) count,
-                     (MPI_Datatype) datatype, (MPI_Op) op,
-                     (int) root, (MPI_Comm) comm)
+int MPI_Reduce(const void *sendbuf, void *recvbuf, int count,
+               MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -264,10 +260,9 @@ USER_DEFINED_WRAPPER(int, Reduce,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Ireduce,
-                     (const void *) sendbuf, (void *) recvbuf, (int) count,
-                     (MPI_Datatype) datatype, (MPI_Op) op,
-                     (int) root, (MPI_Comm) comm, (MPI_Request *) request)
+int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count,
+                MPI_Datatype datatype, MPI_Op op,
+                int root, MPI_Comm comm, MPI_Request *request)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -293,10 +288,9 @@ USER_DEFINED_WRAPPER(int, Ireduce,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Reduce_scatter,
-                     (const void *) sendbuf, (void *) recvbuf,
-                     (const int) recvcounts[], (MPI_Datatype) datatype,
-                     (MPI_Op) op, (MPI_Comm) comm)
+int MPI_Reduce_scatter(const void *sendbuf, void *recvbuf,
+                       const int recvcounts[], MPI_Datatype datatype,
+                       MPI_Op op, MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -421,10 +415,9 @@ MPI_Alltoall_internal(const void *sendbuf, int sendcount,
 #endif
 
 #ifndef MPI_COLLECTIVE_P2P
-USER_DEFINED_WRAPPER(int, Alltoall,
-                     (const void *) sendbuf, (int) sendcount,
-                     (MPI_Datatype) sendtype, (void *) recvbuf, (int) recvcount,
-                     (MPI_Datatype) recvtype, (MPI_Comm) comm)
+int MPI_Alltoall(const void *sendbuf, int sendcount,
+                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                 MPI_Datatype recvtype, MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -435,12 +428,11 @@ USER_DEFINED_WRAPPER(int, Alltoall,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Alltoallv,
-                     (const void *) sendbuf, (const int *) sendcounts,
-                     (const int *) sdispls, (MPI_Datatype) sendtype,
-                     (void *) recvbuf, (const int *) recvcounts,
-                     (const int *) rdispls, (MPI_Datatype) recvtype,
-                     (MPI_Comm) comm)
+int MPI_Alltoallv(const void *sendbuf, const int *sendcounts,
+                  const int *sdispls, MPI_Datatype sendtype,
+                  void *recvbuf, const int *recvcounts,
+                  const int *rdispls, MPI_Datatype recvtype,
+                  MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -462,9 +454,9 @@ USER_DEFINED_WRAPPER(int, Alltoallv,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Gather, (const void *) sendbuf, (int) sendcount,
-                     (MPI_Datatype) sendtype, (void *) recvbuf, (int) recvcount,
-                     (MPI_Datatype) recvtype, (int) root, (MPI_Comm) comm)
+int MPI_Gather(const void *sendbuf, int sendcount,
+               MPI_Datatype sendtype, void *recvbuf, int recvcount,
+               MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -490,10 +482,10 @@ USER_DEFINED_WRAPPER(int, Gather, (const void *) sendbuf, (int) sendcount,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Gatherv, (const void *) sendbuf, (int) sendcount,
-                     (MPI_Datatype) sendtype, (void *) recvbuf,
-                     (const int*) recvcounts, (const int*) displs,
-                     (MPI_Datatype) recvtype, (int) root, (MPI_Comm) comm)
+int MPI_Gatherv(const void *sendbuf, int sendcount,
+                MPI_Datatype sendtype, void *recvbuf,
+                const int *recvcounts, const int *displs,
+                MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -515,9 +507,9 @@ USER_DEFINED_WRAPPER(int, Gatherv, (const void *) sendbuf, (int) sendcount,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Scatter, (const void *) sendbuf, (int) sendcount,
-                     (MPI_Datatype) sendtype, (void *) recvbuf, (int) recvcount,
-                     (MPI_Datatype) recvtype, (int) root, (MPI_Comm) comm)
+int MPI_Scatter(const void *sendbuf, int sendcount,
+                MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -539,10 +531,10 @@ USER_DEFINED_WRAPPER(int, Scatter, (const void *) sendbuf, (int) sendcount,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Scatterv, (const void *) sendbuf,
-                     (const int *) sendcounts, (const int *) displs,
-                     (MPI_Datatype) sendtype, (void *) recvbuf, (int) recvcount,
-                     (MPI_Datatype) recvtype, (int) root, (MPI_Comm) comm)
+int MPI_Scatterv(const void *sendbuf,
+                 const int *sendcounts, const int *displs,
+                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                 MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -564,9 +556,9 @@ USER_DEFINED_WRAPPER(int, Scatterv, (const void *) sendbuf,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Allgather, (const void *) sendbuf, (int) sendcount,
-                     (MPI_Datatype) sendtype, (void *) recvbuf, (int) recvcount,
-                     (MPI_Datatype) recvtype, (MPI_Comm) comm)
+int MPI_Allgather(const void *sendbuf, int sendcount,
+                  MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                  MPI_Datatype recvtype, MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -588,10 +580,10 @@ USER_DEFINED_WRAPPER(int, Allgather, (const void *) sendbuf, (int) sendcount,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Allgatherv, (const void *) sendbuf, (int) sendcount,
-                     (MPI_Datatype) sendtype, (void *) recvbuf,
-                     (const int*) recvcounts, (const int *) displs,
-                     (MPI_Datatype) recvtype, (MPI_Comm) comm)
+int MPI_Allgatherv(const void *sendbuf, int sendcount,
+                   MPI_Datatype sendtype, void *recvbuf,
+                   const int *recvcounts, const int *displs,
+                   MPI_Datatype recvtype, MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -613,9 +605,9 @@ USER_DEFINED_WRAPPER(int, Allgatherv, (const void *) sendbuf, (int) sendcount,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Scan, (const void *) sendbuf, (void *) recvbuf,
-                     (int) count, (MPI_Datatype) datatype,
-                     (MPI_Op) op, (MPI_Comm) comm)
+int MPI_Scan(const void *sendbuf, void *recvbuf,
+             int count, MPI_Datatype datatype,
+             MPI_Op op, MPI_Comm comm)
 {
   commit_begin(comm);
   int retval;
@@ -638,8 +630,7 @@ USER_DEFINED_WRAPPER(int, Scan, (const void *) sendbuf, (void *) recvbuf,
 #endif // #ifndef MPI_COLLECTIVE_P2P
 
 // FIXME: Also check the MPI_Cart family, if they use collective communications.
-USER_DEFINED_WRAPPER(int, Comm_split, (MPI_Comm) comm, (int) color, (int) key,
-    (MPI_Comm *) newcomm)
+int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm)
 {
   commit_begin(comm);
   int retval;
@@ -660,7 +651,7 @@ USER_DEFINED_WRAPPER(int, Comm_split, (MPI_Comm) comm, (int) color, (int) key,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Comm_dup, (MPI_Comm) comm, (MPI_Comm *) newcomm)
+int MPI_Comm_dup(MPI_Comm comm, MPI_Comm *newcomm)
 {
   commit_begin(comm);
   int retval;
@@ -681,49 +672,4 @@ USER_DEFINED_WRAPPER(int, Comm_dup, (MPI_Comm) comm, (MPI_Comm *) newcomm)
   return retval;
 }
 
-
-#ifndef MPI_COLLECTIVE_P2P
-PMPI_IMPL(int, MPI_Bcast, void *buffer, int count, MPI_Datatype datatype,
-          int root, MPI_Comm comm)
-PMPI_IMPL(int, MPI_Ibcast, void *buffer, int count, MPI_Datatype datatype,
-          int root, MPI_Comm comm, MPI_Request *request)
-PMPI_IMPL(int, MPI_Barrier, MPI_Comm comm)
-PMPI_IMPL(int, MPI_Ibarrier, MPI_Comm comm, MPI_Request * request)
-PMPI_IMPL(int, MPI_Allreduce, const void *sendbuf, void *recvbuf, int count,
-          MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
-PMPI_IMPL(int, MPI_Reduce, const void *sendbuf, void *recvbuf, int count,
-          MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm)
-PMPI_IMPL(int, MPI_Ireduce, const void *sendbuf, void *recvbuf, int count,
-          MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm,
-          MPI_Request *request)
-PMPI_IMPL(int, MPI_Alltoall, const void *sendbuf, int sendcount,
-          MPI_Datatype sendtype, void *recvbuf, int recvcount,
-          MPI_Datatype recvtype, MPI_Comm comm)
-PMPI_IMPL(int, MPI_Alltoallv, const void *sendbuf, const int sendcounts[],
-          const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-          const int recvcounts[], const int rdispls[], MPI_Datatype recvtype,
-          MPI_Comm comm)
-PMPI_IMPL(int, MPI_Allgather, const void *sendbuf, int sendcount,
-          MPI_Datatype sendtype, void *recvbuf, int recvcount,
-          MPI_Datatype recvtype, MPI_Comm comm)
-PMPI_IMPL(int, MPI_Allgatherv, const void * sendbuf, int sendcount,
-          MPI_Datatype sendtype, void *recvbuf, const int *recvcount,
-          const int *displs, MPI_Datatype recvtype, MPI_Comm comm)
-PMPI_IMPL(int, MPI_Gather, const void *sendbuf, int sendcount,
-          MPI_Datatype sendtype, void *recvbuf, int recvcount,
-          MPI_Datatype recvtype, int root, MPI_Comm comm)
-PMPI_IMPL(int, MPI_Gatherv, const void *sendbuf, int sendcount,
-          MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-          const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm)
-PMPI_IMPL(int, MPI_Scatter, const void *sendbuf, int sendcount,
-          MPI_Datatype sendtype, void *recvbuf, int recvcount,
-          MPI_Datatype recvtype, int root, MPI_Comm comm)
-PMPI_IMPL(int, MPI_Scatterv, const void *sendbuf, const int sendcounts[],
-          const int displs[], MPI_Datatype sendtype, void *recvbuf,
-          int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm)
-PMPI_IMPL(int, MPI_Scan, const void *sendbuf, void *recvbuf, int count,
-          MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
-#endif // #ifndef MPI_COLLECTIVE_P2P
-PMPI_IMPL(int, MPI_Comm_split, MPI_Comm comm, int color, int key,
-          MPI_Comm *newcomm)
-PMPI_IMPL(int, MPI_Comm_dup, MPI_Comm comm, MPI_Comm *newcomm)
+} // end of: extern "C"

--- a/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
@@ -91,7 +91,9 @@ static const int MPI_HOST_RANK = MPI_PROC_NULL;
 static const int MPI_IO_SOURCE = MPI_ANY_SOURCE;
 static const int MPI_WTIME_IS_GLOBAL_VAL = 0;
 
-USER_DEFINED_WRAPPER(int, Comm_size, (MPI_Comm) comm, (int *) size)
+extern "C" {
+
+int MPI_Comm_size(MPI_Comm comm, int *size)
 {
   int retval = MPI_SUCCESS;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -103,7 +105,7 @@ USER_DEFINED_WRAPPER(int, Comm_size, (MPI_Comm) comm, (int *) size)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Comm_rank, (MPI_Comm) comm, (int *) rank)
+int MPI_Comm_rank(MPI_Comm comm, int *rank)
 {
   int retval = MPI_SUCCESS;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -115,8 +117,7 @@ USER_DEFINED_WRAPPER(int, Comm_rank, (MPI_Comm) comm, (int *) rank)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Comm_create, (MPI_Comm) comm, (MPI_Group) group,
-                     (MPI_Comm *) newcomm)
+int MPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm *newcomm)
 {
   int retval;
   commit_begin(comm);
@@ -138,7 +139,7 @@ USER_DEFINED_WRAPPER(int, Comm_create, (MPI_Comm) comm, (MPI_Group) group,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Abort, (MPI_Comm) comm, (int) errorcode)
+int Abort(MPI_Comm comm, int errorcode)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -150,8 +151,7 @@ USER_DEFINED_WRAPPER(int, Abort, (MPI_Comm) comm, (int) errorcode)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Comm_compare,
-                     (MPI_Comm) comm1, (MPI_Comm) comm2, (int*) result)
+int MPI_Comm_compare(MPI_Comm comm1, MPI_Comm comm2, int *result)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -166,8 +166,7 @@ USER_DEFINED_WRAPPER(int, Comm_compare,
 
 // TODO: Remove this function. It's only used in P2P draining. And we
 // already have solution to avoid using this function in P2P.
-int
-MPI_Comm_free_internal(MPI_Comm *comm)
+int MPI_Comm_free_internal(MPI_Comm *comm)
 {
   int retval;
   MPI_Comm real_comm = get_real_id((mana_mpi_handle){.comm = *comm}).comm;
@@ -177,7 +176,7 @@ MPI_Comm_free_internal(MPI_Comm *comm)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Comm_free, (MPI_Comm *) comm)
+int MPI_Comm_free(MPI_Comm *comm)
 {
   // This bit of code is to execute the delete callback function when
   // MPI_Comm_free is called. Typically we call this function for each
@@ -206,8 +205,7 @@ USER_DEFINED_WRAPPER(int, Comm_free, (MPI_Comm *) comm)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Comm_get_attr, (MPI_Comm) comm,
-                     (int) comm_keyval, (void *) attribute_val, (int *) flag)
+int MPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag)
 {
   int retval = MPI_SUCCESS;
   *flag = 0;
@@ -247,8 +245,7 @@ USER_DEFINED_WRAPPER(int, Comm_get_attr, (MPI_Comm) comm,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Comm_set_attr, (MPI_Comm) comm,
-                     (int) comm_keyval, (void *) attribute_val)
+int MPI_Comm_set_attr(MPI_Comm comm, int comm_keyval, void *attribute_val)
 {
   int retval = MPI_SUCCESS;
   if (comm == MPI_COMM_NULL) {
@@ -274,7 +271,7 @@ USER_DEFINED_WRAPPER(int, Comm_set_attr, (MPI_Comm) comm,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Comm_delete_attr, (MPI_Comm) comm, (int) comm_keyval)
+int MPI_Comm_delete_attr(MPI_Comm comm, int comm_keyval)
 {
   int retval = MPI_SUCCESS;
   if (comm == MPI_COMM_NULL) {
@@ -298,8 +295,7 @@ USER_DEFINED_WRAPPER(int, Comm_delete_attr, (MPI_Comm) comm, (int) comm_keyval)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Comm_set_errhandler,
-                     (MPI_Comm) comm, (MPI_Errhandler) errhandler)
+int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -311,8 +307,7 @@ USER_DEFINED_WRAPPER(int, Comm_set_errhandler,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Topo_test,
-                     (MPI_Comm) comm, (int *) status)
+int Topo_test(MPI_Comm comm, int *status)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -324,8 +319,8 @@ USER_DEFINED_WRAPPER(int, Topo_test,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Comm_split_type, (MPI_Comm) comm, (int) split_type,
-                     (int) key, (MPI_Info) inf, (MPI_Comm*) newcomm)
+int MPI_Comm_split_type(MPI_Comm comm, int split_type,
+                        int key, MPI_Info inf, MPI_Comm *newcomm)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -344,8 +339,8 @@ USER_DEFINED_WRAPPER(int, Comm_split_type, (MPI_Comm) comm, (int) split_type,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Attr_get, (MPI_Comm) comm, (int) keyval,
-                     (void*) attribute_val, (int*) flag)
+int MPI_Attr_get(MPI_Comm comm, int keyval,
+                 void *attribute_val, int *flag)
 {
   JWARNING(false).Text(
     "Use of MPI_Attr_get is deprecated - use MPI_Comm_get_attr instead");
@@ -359,7 +354,7 @@ USER_DEFINED_WRAPPER(int, Attr_get, (MPI_Comm) comm, (int) keyval,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Attr_delete, (MPI_Comm) comm, (int) keyval)
+int MPI_Attr_delete(MPI_Comm comm, int keyval)
 {
 
   JWARNING(false).Text(
@@ -374,8 +369,7 @@ USER_DEFINED_WRAPPER(int, Attr_delete, (MPI_Comm) comm, (int) keyval)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Attr_put, (MPI_Comm) comm,
-                     (int) keyval, (void*) attribute_val)
+int MPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val)
 {
   JWARNING(false).Text(
     "Use of MPI_Attr_put is deprecated - use MPI_Comm_set_attr instead");
@@ -389,10 +383,9 @@ USER_DEFINED_WRAPPER(int, Attr_put, (MPI_Comm) comm,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Comm_create_keyval,
-                     (MPI_Comm_copy_attr_function *) comm_copy_attr_fn,
-                     (MPI_Comm_delete_attr_function *) comm_delete_attr_fn,
-                     (int *) comm_keyval, (void *) extra_state)
+int MPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn,
+                       MPI_Comm_delete_attr_function *comm_delete_attr_fn,
+                       int *comm_keyval, void *extra_state)
 {
   int retval = MPI_SUCCESS;
   int keyval = 0;
@@ -421,7 +414,7 @@ USER_DEFINED_WRAPPER(int, Comm_create_keyval,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Comm_free_keyval, (int *) comm_keyval)
+int MPI_Comm_free_keyval(int *comm_keyval)
 {
   int retval = MPI_SUCCESS;
   int keyval = *comm_keyval;
@@ -434,9 +427,8 @@ USER_DEFINED_WRAPPER(int, Comm_free_keyval, (int *) comm_keyval)
   return retval;
 }
 
-int
-MPI_Comm_create_group_internal(MPI_Comm comm, MPI_Group group, int tag,
-                               MPI_Comm *newcomm)
+int MPI_Comm_create_group_internal(MPI_Comm comm, MPI_Group group, int tag,
+                                   MPI_Comm *newcomm)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -449,8 +441,8 @@ MPI_Comm_create_group_internal(MPI_Comm comm, MPI_Group group, int tag,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Comm_create_group, (MPI_Comm) comm,
-                     (MPI_Group) group, (int) tag, (MPI_Comm *) newcomm)
+int MPI_Comm_create_group(MPI_Comm comm,
+                          MPI_Group group, int tag, MPI_Comm *newcomm)
 {
   commit_begin(comm);
   int retval = MPI_Comm_create_group_internal(comm, group, tag, newcomm);
@@ -465,30 +457,4 @@ USER_DEFINED_WRAPPER(int, Comm_create_group, (MPI_Comm) comm,
   return retval;
 }
 
-PMPI_IMPL(int, MPI_Comm_size, MPI_Comm comm, int *world_size)
-PMPI_IMPL(int, MPI_Comm_rank, MPI_Comm comm, int *world_rank)
-PMPI_IMPL(int, MPI_Abort, MPI_Comm comm, int errorcode)
-PMPI_IMPL(int, MPI_Comm_create, MPI_Comm comm, MPI_Group group,
-          MPI_Comm *newcomm)
-PMPI_IMPL(int, MPI_Comm_compare, MPI_Comm comm1, MPI_Comm comm2, int *result)
-PMPI_IMPL(int, MPI_Comm_free, MPI_Comm *comm)
-PMPI_IMPL(int, MPI_Comm_get_attr, MPI_Comm comm, int comm_keyval,
-          void *attribute_val, int *flag)
-PMPI_IMPL(int, MPI_Comm_set_attr, MPI_Comm comm, int comm_keyval,
-          void *attribute_val)
-PMPI_IMPL(int, MPI_Comm_set_errhandler, MPI_Comm comm,
-          MPI_Errhandler errhandler)
-PMPI_IMPL(int, MPI_Topo_test, MPI_Comm comm, int* status)
-PMPI_IMPL(int, MPI_Comm_split_type, MPI_Comm comm, int split_type, int key,
-          MPI_Info info, MPI_Comm *newcomm)
-PMPI_IMPL(int, MPI_Attr_get, MPI_Comm comm, int keyval,
-          void *attribute_val, int *flag)
-PMPI_IMPL(int, MPI_Attr_delete, MPI_Comm comm, int keyval)
-PMPI_IMPL(int, MPI_Attr_put, MPI_Comm comm, int keyval, void *attribute_val)
-PMPI_IMPL(int, MPI_Comm_create_keyval,
-          MPI_Comm_copy_attr_function * comm_copy_attr_fn,
-          MPI_Comm_delete_attr_function * comm_delete_attr_fn,
-          int *comm_keyval, void *extra_state)
-PMPI_IMPL(int, MPI_Comm_free_keyval, int *comm_keyval)
-PMPI_IMPL(int, MPI_Comm_create_group, MPI_Comm comm, MPI_Group group,
-          int tag, MPI_Comm *newcomm)
+} // end of: extern "C"

--- a/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
@@ -93,7 +93,8 @@ static const int MPI_WTIME_IS_GLOBAL_VAL = 0;
 
 extern "C" {
 
-int MPI_Comm_size(MPI_Comm comm, int *size)
+#pragma weak MPI_Comm_size = PMPI_Comm_size
+int PMPI_Comm_size(MPI_Comm comm, int *size)
 {
   int retval = MPI_SUCCESS;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -105,7 +106,8 @@ int MPI_Comm_size(MPI_Comm comm, int *size)
   return retval;
 }
 
-int MPI_Comm_rank(MPI_Comm comm, int *rank)
+#pragma weak MPI_Comm_rank = PMPI_Comm_rank
+int PMPI_Comm_rank(MPI_Comm comm, int *rank)
 {
   int retval = MPI_SUCCESS;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -117,7 +119,8 @@ int MPI_Comm_rank(MPI_Comm comm, int *rank)
   return retval;
 }
 
-int MPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm *newcomm)
+#pragma weak MPI_Comm_create = PMPI_Comm_create
+int PMPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm *newcomm)
 {
   int retval;
   commit_begin(comm);
@@ -139,7 +142,8 @@ int MPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm *newcomm)
   return retval;
 }
 
-int Abort(MPI_Comm comm, int errorcode)
+#pragma weak MPI_Abort = PMPI_Abort
+int PMPI_Abort(MPI_Comm comm, int errorcode)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -151,7 +155,8 @@ int Abort(MPI_Comm comm, int errorcode)
   return retval;
 }
 
-int MPI_Comm_compare(MPI_Comm comm1, MPI_Comm comm2, int *result)
+#pragma weak MPI_Comm_compare = PMPI_Comm_compare
+int PMPI_Comm_compare(MPI_Comm comm1, MPI_Comm comm2, int *result)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -176,7 +181,8 @@ int MPI_Comm_free_internal(MPI_Comm *comm)
   return retval;
 }
 
-int MPI_Comm_free(MPI_Comm *comm)
+#pragma weak MPI_Comm_free = PMPI_Comm_free
+int PMPI_Comm_free(MPI_Comm *comm)
 {
   // This bit of code is to execute the delete callback function when
   // MPI_Comm_free is called. Typically we call this function for each
@@ -205,7 +211,8 @@ int MPI_Comm_free(MPI_Comm *comm)
   return retval;
 }
 
-int MPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag)
+#pragma weak MPI_Comm_get_attr = PMPI_Comm_get_attr
+int PMPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag)
 {
   int retval = MPI_SUCCESS;
   *flag = 0;
@@ -245,7 +252,8 @@ int MPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *
   return retval;
 }
 
-int MPI_Comm_set_attr(MPI_Comm comm, int comm_keyval, void *attribute_val)
+#pragma weak MPI_Comm_set_attr = PMPI_Comm_set_attr
+int PMPI_Comm_set_attr(MPI_Comm comm, int comm_keyval, void *attribute_val)
 {
   int retval = MPI_SUCCESS;
   if (comm == MPI_COMM_NULL) {
@@ -271,7 +279,8 @@ int MPI_Comm_set_attr(MPI_Comm comm, int comm_keyval, void *attribute_val)
   return retval;
 }
 
-int MPI_Comm_delete_attr(MPI_Comm comm, int comm_keyval)
+#pragma weak MPI_Comm_delete_attr = PMPI_Comm_delete_attr
+int PMPI_Comm_delete_attr(MPI_Comm comm, int comm_keyval)
 {
   int retval = MPI_SUCCESS;
   if (comm == MPI_COMM_NULL) {
@@ -295,7 +304,8 @@ int MPI_Comm_delete_attr(MPI_Comm comm, int comm_keyval)
   return retval;
 }
 
-int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler)
+#pragma weak MPI_Comm_set_errhandler = PMPI_Comm_set_errhandler
+int PMPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -307,7 +317,8 @@ int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler)
   return retval;
 }
 
-int Topo_test(MPI_Comm comm, int *status)
+#pragma weak MPI_Topo_test = PMPI_Topo_test
+int PMPI_Topo_test(MPI_Comm comm, int *status)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -319,7 +330,8 @@ int Topo_test(MPI_Comm comm, int *status)
   return retval;
 }
 
-int MPI_Comm_split_type(MPI_Comm comm, int split_type,
+#pragma weak MPI_Comm_split_type = PMPI_Comm_split_type
+int PMPI_Comm_split_type(MPI_Comm comm, int split_type,
                         int key, MPI_Info inf, MPI_Comm *newcomm)
 {
   int retval;
@@ -339,7 +351,8 @@ int MPI_Comm_split_type(MPI_Comm comm, int split_type,
   return retval;
 }
 
-int MPI_Attr_get(MPI_Comm comm, int keyval,
+#pragma weak MPI_Attr_get = PMPI_Attr_get
+int PMPI_Attr_get(MPI_Comm comm, int keyval,
                  void *attribute_val, int *flag)
 {
   JWARNING(false).Text(
@@ -354,7 +367,8 @@ int MPI_Attr_get(MPI_Comm comm, int keyval,
   return retval;
 }
 
-int MPI_Attr_delete(MPI_Comm comm, int keyval)
+#pragma weak MPI_Attr_delete = PMPI_Attr_delete
+int PMPI_Attr_delete(MPI_Comm comm, int keyval)
 {
 
   JWARNING(false).Text(
@@ -369,7 +383,8 @@ int MPI_Attr_delete(MPI_Comm comm, int keyval)
   return retval;
 }
 
-int MPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val)
+#pragma weak MPI_Attr_put = PMPI_Attr_put
+int PMPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val)
 {
   JWARNING(false).Text(
     "Use of MPI_Attr_put is deprecated - use MPI_Comm_set_attr instead");
@@ -383,7 +398,8 @@ int MPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val)
   return retval;
 }
 
-int MPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn,
+#pragma weak MPI_Comm_create_keyval = PMPI_Comm_create_keyval
+int PMPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn,
                        MPI_Comm_delete_attr_function *comm_delete_attr_fn,
                        int *comm_keyval, void *extra_state)
 {
@@ -414,7 +430,8 @@ int MPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn,
   return retval;
 }
 
-int MPI_Comm_free_keyval(int *comm_keyval)
+#pragma weak MPI_Comm_free_keyval = PMPI_Comm_free_keyval
+int PMPI_Comm_free_keyval(int *comm_keyval)
 {
   int retval = MPI_SUCCESS;
   int keyval = *comm_keyval;
@@ -427,6 +444,7 @@ int MPI_Comm_free_keyval(int *comm_keyval)
   return retval;
 }
 
+#pragma weak MPI_Comm_create_group = PMPI_Comm_create_group
 int MPI_Comm_create_group_internal(MPI_Comm comm, MPI_Group group, int tag,
                                    MPI_Comm *newcomm)
 {
@@ -441,7 +459,7 @@ int MPI_Comm_create_group_internal(MPI_Comm comm, MPI_Group group, int tag,
   return retval;
 }
 
-int MPI_Comm_create_group(MPI_Comm comm,
+int PMPI_Comm_create_group(MPI_Comm comm,
                           MPI_Group group, int tag, MPI_Comm *newcomm)
 {
   commit_begin(comm);

--- a/mpi-proxy-split/mpi-wrappers/mpi_error_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_error_wrappers.cpp
@@ -28,13 +28,29 @@
 #include "protectedfds.h"
 
 #include "mpi_nextfunc.h"
-#include "record-replay.h"
 
-DEFINE_FNC(int, Error_class, (int) errorcode, (int *) errorclass);
-DEFINE_FNC(int, Error_string, (int) errorcode, (char *) string,
-           (int *) resultlen);
+extern "C" {
 
-PMPI_IMPL(int, MPI_Error_class, int errorcode, int *errorclass)
-PMPI_IMPL(int, MPI_Error_string, int errorcode, char *string,
-          int *resultlen)
+int MPI_Error_class(int errorcode, int *errorclass)
+{
+  int retval = 0;
+  DMTCP_PLUGIN_DISABLE_CKPT();
+  JUMP_TO_LOWER_HALF(lh_info->fsaddr);
+  retval = NEXT_FUNC(Error_class)(errorcode, errorclass);
+  RETURN_TO_UPPER_HALF();
+  DMTCP_PLUGIN_ENABLE_CKPT();
+  return retval;
+}
 
+int MPI_Error_string(int errorcode, char *string, int *resultlen)
+{
+  int retval = 0;
+  DMTCP_PLUGIN_DISABLE_CKPT();
+  JUMP_TO_LOWER_HALF(lh_info->fsaddr);
+  retval = NEXT_FUNC(Error_string)(errorcode, string, resultlen);
+  RETURN_TO_UPPER_HALF();
+  DMTCP_PLUGIN_ENABLE_CKPT();
+  return retval;
+}
+
+} // end of: extern "C"

--- a/mpi-proxy-split/mpi-wrappers/mpi_error_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_error_wrappers.cpp
@@ -31,7 +31,8 @@
 
 extern "C" {
 
-int MPI_Error_class(int errorcode, int *errorclass)
+#pragma weak MPI_Error_class = PMPI_Error_class
+int PMPI_Error_class(int errorcode, int *errorclass)
 {
   int retval = 0;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -42,7 +43,8 @@ int MPI_Error_class(int errorcode, int *errorclass)
   return retval;
 }
 
-int MPI_Error_string(int errorcode, char *string, int *resultlen)
+#pragma weak MPI_Error_string = PMPI_Error_string
+int PMPI_Error_string(int errorcode, char *string, int *resultlen)
 {
   int retval = 0;
   DMTCP_PLUGIN_DISABLE_CKPT();

--- a/mpi-proxy-split/mpi-wrappers/mpi_file_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_file_wrappers.cpp
@@ -42,7 +42,8 @@ extern "C" {
 // It's possible that there could be a Fortran to C interface bug in the
 // passing of the filename. If there are ever any bugs related to MPI
 // opening a file with the wrong name, that's likely the cause
-int MPI_File_open(MPI_Comm comm, const char *filename,
+#pragma weak MPI_File_open = PMPI_File_open
+int PMPI_File_open(MPI_Comm comm, const char *filename,
                   int amode, MPI_Info info, MPI_File *fh)
 {
   int retval;
@@ -75,7 +76,8 @@ int MPI_File_open(MPI_Comm comm, const char *filename,
   return retval;
 }
 
-int MPI_File_get_atomicity(MPI_File fh, int *flag)
+#pragma weak MPI_File_get_atomicity = PMPI_File_get_atomicity
+int PMPI_File_get_atomicity(MPI_File fh, int *flag)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -87,7 +89,8 @@ int MPI_File_get_atomicity(MPI_File fh, int *flag)
   return retval;
 }
 
-int MPI_File_set_atomicity(MPI_File fh, int flag)
+#pragma weak MPI_File_set_atomicity = PMPI_File_set_atomicity
+int PMPI_File_set_atomicity(MPI_File fh, int flag)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -99,7 +102,8 @@ int MPI_File_set_atomicity(MPI_File fh, int flag)
   return retval;
 }
 
-int MPI_File_set_size(MPI_File fh, MPI_Offset size)
+#pragma weak MPI_File_set_size = PMPI_File_set_size
+int PMPI_File_set_size(MPI_File fh, MPI_Offset size)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -111,7 +115,8 @@ int MPI_File_set_size(MPI_File fh, MPI_Offset size)
   return retval;
 }
 
-int MPI_File_get_size(MPI_File fh, MPI_Offset *size)
+#pragma weak MPI_File_get_size = PMPI_File_get_size
+int PMPI_File_get_size(MPI_File fh, MPI_Offset *size)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -123,7 +128,8 @@ int MPI_File_get_size(MPI_File fh, MPI_Offset *size)
   return retval;
 }
 
-int MPI_File_set_view(MPI_File fh, MPI_Offset disp,
+#pragma weak MPI_File_set_view = PMPI_File_set_view
+int PMPI_File_set_view(MPI_File fh, MPI_Offset disp,
                       MPI_Datatype etype, MPI_Datatype filetype,
                       const char *datarep, MPI_Info info)
 {
@@ -153,7 +159,8 @@ int MPI_File_set_view(MPI_File fh, MPI_Offset disp,
 }
 
 // TODO: Use descriptor to save etype and filetype set by File_set_view
-int MPI_File_get_view(MPI_File fh, MPI_Offset* disp,
+#pragma weak MPI_File_get_view = PMPI_File_get_view
+int PMPI_File_get_view(MPI_File fh, MPI_Offset* disp,
                       MPI_Datatype *etype, MPI_Datatype *filetype,
                       char *datarep)
 {
@@ -174,7 +181,8 @@ int MPI_File_get_view(MPI_File fh, MPI_Offset* disp,
   return retval;
 }
 
-int MPI_File_read(MPI_File fh, void *buf, int count,
+#pragma weak MPI_File_read = PMPI_File_read
+int PMPI_File_read(MPI_File fh, void *buf, int count,
                   MPI_Datatype datatype, MPI_Status *status)
 {
   int retval;
@@ -188,7 +196,8 @@ int MPI_File_read(MPI_File fh, void *buf, int count,
   return retval;
 }
 
-int MPI_File_read_at(MPI_File fh, MPI_Offset offset,
+#pragma weak MPI_File_read_at = PMPI_File_read_at
+int PMPI_File_read_at(MPI_File fh, MPI_Offset offset,
                      void *buf, int count, MPI_Datatype datatype,
                      MPI_Status *status)
 {
@@ -204,7 +213,8 @@ int MPI_File_read_at(MPI_File fh, MPI_Offset offset,
   return retval;
 }
 
-int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset,
+#pragma weak MPI_File_read_at_all = PMPI_File_read_at_all
+int PMPI_File_read_at_all(MPI_File fh, MPI_Offset offset,
                          void *buf, int count, MPI_Datatype datatype,
                          MPI_Status *status)
 {
@@ -225,7 +235,8 @@ int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset,
   return retval;
 }
 
-int MPI_File_read_all(MPI_File fh, void *buf,
+#pragma weak MPI_File_read_all = PMPI_File_read_all
+int PMPI_File_read_all(MPI_File fh, void *buf,
                       int count, MPI_Datatype datatype, MPI_Status *status)
 {
   // FIXME:
@@ -244,7 +255,8 @@ int MPI_File_read_all(MPI_File fh, void *buf,
   return retval;
 }
 
-int MPI_File_write(MPI_File fh, const void *buf,
+#pragma weak MPI_File_write = PMPI_File_write
+int PMPI_File_write(MPI_File fh, const void *buf,
                    int count, MPI_Datatype datatype, MPI_Status *status)
 {
   int retval;
@@ -258,7 +270,8 @@ int MPI_File_write(MPI_File fh, const void *buf,
   return retval;
 }
 
-int MPI_File_write_at(MPI_File fh, MPI_Offset offset,
+#pragma weak MPI_File_write_at = PMPI_File_write_at
+int PMPI_File_write_at(MPI_File fh, MPI_Offset offset,
                       const void *buf, int count, MPI_Datatype datatype,
                       MPI_Status *status)
 {
@@ -274,7 +287,8 @@ int MPI_File_write_at(MPI_File fh, MPI_Offset offset,
   return retval;
 }
 
-int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset,
+#pragma weak MPI_File_write_at_all = PMPI_File_write_at_all
+int PMPI_File_write_at_all(MPI_File fh, MPI_Offset offset,
                           const void *buf, int count, MPI_Datatype datatype,
                           MPI_Status *status)
 {
@@ -291,7 +305,8 @@ int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset,
   return retval;
 }
 
-int MPI_File_write_all(MPI_File fh, const void *buf,
+#pragma weak MPI_File_write_all = PMPI_File_write_all
+int PMPI_File_write_all(MPI_File fh, const void *buf,
                        int count, MPI_Datatype datatype, MPI_Status *status)
 {
   // FIXME: See File_read_all (the same applies here)
@@ -306,7 +321,8 @@ int MPI_File_write_all(MPI_File fh, const void *buf,
   return retval;
 }
 
-int MPI_File_sync(MPI_File fh)
+#pragma weak MPI_File_sync = PMPI_File_sync
+int PMPI_File_sync(MPI_File fh)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -318,7 +334,8 @@ int MPI_File_sync(MPI_File fh)
   return retval;
 }
 
-int MPI_File_get_position(MPI_File fh, MPI_Offset* offset)
+#pragma weak MPI_File_get_position = PMPI_File_get_position
+int PMPI_File_get_position(MPI_File fh, MPI_Offset* offset)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -330,7 +347,8 @@ int MPI_File_get_position(MPI_File fh, MPI_Offset* offset)
   return retval;
 }
 
-int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence)
+#pragma weak MPI_File_seek = PMPI_File_seek
+int PMPI_File_seek(MPI_File fh, MPI_Offset offset, int whence)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -342,7 +360,8 @@ int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence)
   return retval;
 }
 
-int MPI_File_close(MPI_File *fh)
+#pragma weak MPI_File_close = PMPI_File_close
+int PMPI_File_close(MPI_File *fh)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -362,7 +381,8 @@ int MPI_File_close(MPI_File *fh)
   return retval;
 }
 
-int MPI_File_delete(const char *filename, MPI_Info info)
+#pragma weak MPI_File_delete = PMPI_File_delete
+int PMPI_File_delete(const char *filename, MPI_Info info)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -383,7 +403,8 @@ int MPI_File_delete(const char *filename, MPI_Info info)
 }
 
 
-int MPI_File_set_errhandler(MPI_File file, MPI_Errhandler errhandler)
+#pragma weak MPI_File_set_errhandler = PMPI_File_set_errhandler
+int PMPI_File_set_errhandler(MPI_File file, MPI_Errhandler errhandler)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -395,7 +416,8 @@ int MPI_File_set_errhandler(MPI_File file, MPI_Errhandler errhandler)
   return retval;
 }
 
-int MPI_File_get_errhandler(MPI_File file, MPI_Errhandler *errhandler)
+#pragma weak MPI_File_get_errhandler = PMPI_File_get_errhandler
+int PMPI_File_get_errhandler(MPI_File file, MPI_Errhandler *errhandler)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();

--- a/mpi-proxy-split/mpi-wrappers/mpi_file_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_file_wrappers.cpp
@@ -37,11 +37,13 @@ using namespace dmtcp_mpi;
 
 std::unordered_map<MPI_File, OpenFileParameters> g_params_map;
 
+extern "C" {
+
 // It's possible that there could be a Fortran to C interface bug in the
 // passing of the filename. If there are ever any bugs related to MPI
 // opening a file with the wrong name, that's likely the cause
-USER_DEFINED_WRAPPER(int, File_open, (MPI_Comm) comm, (const char *) filename,
-                     (int) amode, (MPI_Info) info, (MPI_File *) fh)
+int MPI_File_open(MPI_Comm comm, const char *filename,
+                  int amode, MPI_Info info, MPI_File *fh)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -73,7 +75,7 @@ USER_DEFINED_WRAPPER(int, File_open, (MPI_Comm) comm, (const char *) filename,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_get_atomicity, (MPI_File) fh, (int*) flag)
+int MPI_File_get_atomicity(MPI_File fh, int *flag)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -85,7 +87,7 @@ USER_DEFINED_WRAPPER(int, File_get_atomicity, (MPI_File) fh, (int*) flag)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_set_atomicity, (MPI_File) fh, (int) flag)
+int MPI_File_set_atomicity(MPI_File fh, int flag)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -97,7 +99,7 @@ USER_DEFINED_WRAPPER(int, File_set_atomicity, (MPI_File) fh, (int) flag)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_set_size, (MPI_File) fh, (MPI_Offset) size)
+int MPI_File_set_size(MPI_File fh, MPI_Offset size)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -109,7 +111,7 @@ USER_DEFINED_WRAPPER(int, File_set_size, (MPI_File) fh, (MPI_Offset) size)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_get_size, (MPI_File) fh, (MPI_Offset *) size)
+int MPI_File_get_size(MPI_File fh, MPI_Offset *size)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -121,9 +123,9 @@ USER_DEFINED_WRAPPER(int, File_get_size, (MPI_File) fh, (MPI_Offset *) size)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_set_view, (MPI_File) fh, (MPI_Offset) disp,
-                     (MPI_Datatype) etype, (MPI_Datatype) filetype,
-                     (const char*) datarep, (MPI_Info) info)
+int MPI_File_set_view(MPI_File fh, MPI_Offset disp,
+                      MPI_Datatype etype, MPI_Datatype filetype,
+                      const char *datarep, MPI_Info info)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -151,9 +153,9 @@ USER_DEFINED_WRAPPER(int, File_set_view, (MPI_File) fh, (MPI_Offset) disp,
 }
 
 // TODO: Use descriptor to save etype and filetype set by File_set_view
-USER_DEFINED_WRAPPER(int, File_get_view, (MPI_File) fh, (MPI_Offset*) disp,
-                     (MPI_Datatype*) etype, (MPI_Datatype*) filetype,
-                     (char*) datarep)
+int MPI_File_get_view(MPI_File fh, MPI_Offset* disp,
+                      MPI_Datatype *etype, MPI_Datatype *filetype,
+                      char *datarep)
 {
   int retval = MPI_SUCCESS;
   /*
@@ -172,8 +174,8 @@ USER_DEFINED_WRAPPER(int, File_get_view, (MPI_File) fh, (MPI_Offset*) disp,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_read, (MPI_File) fh, (void*) buf, (int) count,
-                     (MPI_Datatype) datatype, (MPI_Status*) status)
+int MPI_File_read(MPI_File fh, void *buf, int count,
+                  MPI_Datatype datatype, MPI_Status *status)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -186,9 +188,9 @@ USER_DEFINED_WRAPPER(int, File_read, (MPI_File) fh, (void*) buf, (int) count,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_read_at, (MPI_File) fh, (MPI_Offset) offset,
-                     (void*) buf, (int) count, (MPI_Datatype) datatype,
-                     (MPI_Status*) status)
+int MPI_File_read_at(MPI_File fh, MPI_Offset offset,
+                     void *buf, int count, MPI_Datatype datatype,
+                     MPI_Status *status)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -202,9 +204,9 @@ USER_DEFINED_WRAPPER(int, File_read_at, (MPI_File) fh, (MPI_Offset) offset,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_read_at_all, (MPI_File) fh, (MPI_Offset) offset,
-                     (void*) buf, (int) count, (MPI_Datatype) datatype,
-                     (MPI_Status*) status)
+int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset,
+                         void *buf, int count, MPI_Datatype datatype,
+                         MPI_Status *status)
 {
   // FIXME:
   // This function is both blocking and collective. However, we believe that
@@ -223,8 +225,8 @@ USER_DEFINED_WRAPPER(int, File_read_at_all, (MPI_File) fh, (MPI_Offset) offset,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_read_all, (MPI_File) fh, (void*) buf,
-                    (int) count, (MPI_Datatype) datatype, (MPI_Status *) status)
+int MPI_File_read_all(MPI_File fh, void *buf,
+                      int count, MPI_Datatype datatype, MPI_Status *status)
 {
   // FIXME:
   // This function is both blocking and collective. However, we believe that
@@ -242,8 +244,8 @@ USER_DEFINED_WRAPPER(int, File_read_all, (MPI_File) fh, (void*) buf,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_write, (MPI_File) fh, (const void*) buf,
-                     (int) count, (MPI_Datatype) datatype, (MPI_Status*) status)
+int MPI_File_write(MPI_File fh, const void *buf,
+                   int count, MPI_Datatype datatype, MPI_Status *status)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -256,9 +258,9 @@ USER_DEFINED_WRAPPER(int, File_write, (MPI_File) fh, (const void*) buf,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_write_at, (MPI_File) fh, (MPI_Offset) offset,
-                     (const void*) buf, (int) count, (MPI_Datatype) datatype,
-                     (MPI_Status*) status)
+int MPI_File_write_at(MPI_File fh, MPI_Offset offset,
+                      const void *buf, int count, MPI_Datatype datatype,
+                      MPI_Status *status)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -272,9 +274,9 @@ USER_DEFINED_WRAPPER(int, File_write_at, (MPI_File) fh, (MPI_Offset) offset,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_write_at_all, (MPI_File) fh, (MPI_Offset) offset,
-                     (const void*) buf, (int) count, (MPI_Datatype) datatype,
-                     (MPI_Status*) status)
+int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset,
+                          const void *buf, int count, MPI_Datatype datatype,
+                          MPI_Status *status)
 {
   // FIXME: See File_read_at_all (the same applies here)
   int retval;
@@ -289,8 +291,8 @@ USER_DEFINED_WRAPPER(int, File_write_at_all, (MPI_File) fh, (MPI_Offset) offset,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_write_all, (MPI_File) fh, (const void*) buf,
-                     (int) count, (MPI_Datatype) datatype, (MPI_Status*) status)
+int MPI_File_write_all(MPI_File fh, const void *buf,
+                       int count, MPI_Datatype datatype, MPI_Status *status)
 {
   // FIXME: See File_read_all (the same applies here)
   int retval;
@@ -304,7 +306,7 @@ USER_DEFINED_WRAPPER(int, File_write_all, (MPI_File) fh, (const void*) buf,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_sync, (MPI_File) fh)
+int MPI_File_sync(MPI_File fh)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -316,8 +318,7 @@ USER_DEFINED_WRAPPER(int, File_sync, (MPI_File) fh)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_get_position, (MPI_File) fh,
-                     (MPI_Offset*) offset)
+int MPI_File_get_position(MPI_File fh, MPI_Offset* offset)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -329,8 +330,7 @@ USER_DEFINED_WRAPPER(int, File_get_position, (MPI_File) fh,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_seek, (MPI_File) fh, (MPI_Offset) offset,
-                     (int) whence)
+int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -342,7 +342,7 @@ USER_DEFINED_WRAPPER(int, File_seek, (MPI_File) fh, (MPI_Offset) offset,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_close, (MPI_File*) fh)
+int MPI_File_close(MPI_File *fh)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -362,7 +362,7 @@ USER_DEFINED_WRAPPER(int, File_close, (MPI_File*) fh)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_delete, (const char *) filename, (MPI_Info) info)
+int MPI_File_delete(const char *filename, MPI_Info info)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -383,8 +383,7 @@ USER_DEFINED_WRAPPER(int, File_delete, (const char *) filename, (MPI_Info) info)
 }
 
 
-USER_DEFINED_WRAPPER(int, File_set_errhandler, (MPI_File) file,
-                     (MPI_Errhandler) errhandler)
+int MPI_File_set_errhandler(MPI_File file, MPI_Errhandler errhandler)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -396,8 +395,7 @@ USER_DEFINED_WRAPPER(int, File_set_errhandler, (MPI_File) file,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, File_get_errhandler, (MPI_File) file,
-                     (MPI_Errhandler *) errhandler)
+int MPI_File_get_errhandler(MPI_File file, MPI_Errhandler *errhandler)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -409,40 +407,4 @@ USER_DEFINED_WRAPPER(int, File_get_errhandler, (MPI_File) file,
   return retval;
 }
 
-
-PMPI_IMPL(int, MPI_File_open, MPI_Comm comm, const char *filename, int amode,
-          MPI_Info info, MPI_File *fh)
-PMPI_IMPL(int, MPI_File_get_atomicity, MPI_File fh, int* flag)
-PMPI_IMPL(int, MPI_File_set_atomicity, MPI_File fh, int flag)
-PMPI_IMPL(int, MPI_File_set_size, MPI_File fh, MPI_Offset size)
-PMPI_IMPL(int, MPI_File_get_size, MPI_File fh, MPI_Offset* size)
-PMPI_IMPL(int, MPI_File_set_view, MPI_File fh, MPI_Offset disp,
-          MPI_Datatype etype, MPI_Datatype filetype, const char* datarep,
-          MPI_Info info)
-PMPI_IMPL(int, MPI_File_get_view, MPI_File fh, MPI_Offset* disp,
-          MPI_Datatype* etype, MPI_Datatype* filetype, char* datarep)
-PMPI_IMPL(int, MPI_File_read, MPI_File fh, void* buf, int count,
-          MPI_Datatype datatype, MPI_Status* status)
-PMPI_IMPL(int, MPI_File_read_all, MPI_File fh, void* buf, int count,
-          MPI_Datatype datatype, MPI_Status* status)
-PMPI_IMPL(int, MPI_File_read_at, MPI_File fh, MPI_Offset offset, void* buf,
-          int count, MPI_Datatype datatype, MPI_Status* status)
-PMPI_IMPL(int, MPI_File_read_at_all, MPI_File fh, MPI_Offset offset, void* buf,
-          int count, MPI_Datatype datatype, MPI_Status* status)
-PMPI_IMPL(int, MPI_File_write, MPI_File fh, const void* buf, int count,
-          MPI_Datatype datatype, MPI_Status* status)
-PMPI_IMPL(int, MPI_File_write_all, MPI_File fh, const void* buf, int count,
-          MPI_Datatype datatype, MPI_Status* status)
-PMPI_IMPL(int, MPI_File_write_at, MPI_File fh, MPI_Offset offset,
-          const void* buf, int count, MPI_Datatype datatype, MPI_Status* status)
-PMPI_IMPL(int, MPI_File_write_at_all, MPI_File fh, MPI_Offset offset,
-          const void* buf, int count, MPI_Datatype datatype, MPI_Status* status)
-PMPI_IMPL(int, MPI_File_sync, MPI_File fh)
-PMPI_IMPL(int, MPI_File_get_position, MPI_File fh, MPI_Offset* offset)
-PMPI_IMPL(int, MPI_File_seek, MPI_File fh, MPI_Offset offset, int whence)
-PMPI_IMPL(int, MPI_File_close, MPI_File* fh)
-PMPI_IMPL(int, MPI_File_set_errhandler, MPI_File file,
-          MPI_Errhandler errhandler)
-PMPI_IMPL(int, MPI_File_get_errhandler, MPI_File file,
-          MPI_Errhandler *errhandler)
-PMPI_IMPL(int, MPI_File_delete, const char *filename, MPI_Info info)
+} // end of: extern "C"

--- a/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
@@ -35,7 +35,8 @@ using namespace dmtcp_mpi;
 
 extern "C" {
 
-int MPI_Comm_group(MPI_Comm comm, MPI_Group *group)
+#pragma weak MPI_Comm_group = PMPI_Comm_group
+int PMPI_Comm_group(MPI_Comm comm, MPI_Group *group)
 {
   int retval = MPI_SUCCESS;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -52,7 +53,8 @@ int MPI_Comm_group(MPI_Comm comm, MPI_Group *group)
   return retval;
 }
 
-int MPI_Group_size(MPI_Group group, int *size)
+#pragma weak MPI_Group_size = PMPI_Group_size
+int PMPI_Group_size(MPI_Group group, int *size)
 {
   int retval = MPI_SUCCESS;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -64,7 +66,8 @@ int MPI_Group_size(MPI_Group group, int *size)
   return retval;
 }
 
-int MPI_Group_free(MPI_Group *group)
+#pragma weak MPI_Group_free = PMPI_Group_free
+int PMPI_Group_free(MPI_Group *group)
 {
   int retval = MPI_SUCCESS;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -73,7 +76,8 @@ int MPI_Group_free(MPI_Group *group)
   return retval;
 }
 
-int MPI_Group_compare(MPI_Group group1, MPI_Group group2, int *result)
+#pragma weak MPI_Group_compare = PMPI_Group_compare
+int PMPI_Group_compare(MPI_Group group1, MPI_Group group2, int *result)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -86,7 +90,8 @@ int MPI_Group_compare(MPI_Group group1, MPI_Group group2, int *result)
   return retval;
 }
 
-int MPI_Group_rank(MPI_Group group, int *rank)
+#pragma weak MPI_Group_rank = PMPI_Group_rank
+int PMPI_Group_rank(MPI_Group group, int *rank)
 {
   int retval = MPI_SUCCESS;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -98,7 +103,8 @@ int MPI_Group_rank(MPI_Group group, int *rank)
   return retval;
 }
 
-int MPI_Group_incl(MPI_Group group, int n, const int* ranks, MPI_Group * newgroup)
+#pragma weak MPI_Group_incl = PMPI_Group_incl
+int PMPI_Group_incl(MPI_Group group, int n, const int* ranks, MPI_Group * newgroup)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -117,7 +123,8 @@ int MPI_Group_incl(MPI_Group group, int n, const int* ranks, MPI_Group * newgrou
   return retval;
 }
 
-int MPI_Group_translate_ranks(MPI_Group group1, int n, const int ranks1[],
+#pragma weak MPI_Group_translate_ranks = PMPI_Group_translate_ranks
+int PMPI_Group_translate_ranks(MPI_Group group1, int n, const int ranks1[],
                           MPI_Group group2, int ranks2[])
 {
   int retval;

--- a/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
@@ -33,7 +33,9 @@
 
 using namespace dmtcp_mpi;
 
-USER_DEFINED_WRAPPER(int, Comm_group, (MPI_Comm) comm, (MPI_Group *) group)
+extern "C" {
+
+int MPI_Comm_group(MPI_Comm comm, MPI_Group *group)
 {
   int retval = MPI_SUCCESS;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -50,7 +52,7 @@ USER_DEFINED_WRAPPER(int, Comm_group, (MPI_Comm) comm, (MPI_Group *) group)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Group_size, (MPI_Group) group, (int *) size)
+int MPI_Group_size(MPI_Group group, int *size)
 {
   int retval = MPI_SUCCESS;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -62,7 +64,7 @@ USER_DEFINED_WRAPPER(int, Group_size, (MPI_Group) group, (int *) size)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Group_free, (MPI_Group *) group)
+int MPI_Group_free(MPI_Group *group)
 {
   int retval = MPI_SUCCESS;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -71,8 +73,7 @@ USER_DEFINED_WRAPPER(int, Group_free, (MPI_Group *) group)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Group_compare, (MPI_Group) group1,
-                     (MPI_Group) group2, (int *) result)
+int MPI_Group_compare(MPI_Group group1, MPI_Group group2, int *result)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -85,7 +86,7 @@ USER_DEFINED_WRAPPER(int, Group_compare, (MPI_Group) group1,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Group_rank, (MPI_Group) group, (int *) rank)
+int MPI_Group_rank(MPI_Group group, int *rank)
 {
   int retval = MPI_SUCCESS;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -97,8 +98,7 @@ USER_DEFINED_WRAPPER(int, Group_rank, (MPI_Group) group, (int *) rank)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Group_incl, (MPI_Group) group, (int) n,
-                     (const int*) ranks, (MPI_Group *) newgroup)
+int MPI_Group_incl(MPI_Group group, int n, const int* ranks, MPI_Group * newgroup)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -117,9 +117,8 @@ USER_DEFINED_WRAPPER(int, Group_incl, (MPI_Group) group, (int) n,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Group_translate_ranks, (MPI_Group) group1,
-                     (int) n, (const int) ranks1[], (MPI_Group) group2,
-                     (int) ranks2[])
+int MPI_Group_translate_ranks(MPI_Group group1, int n, const int ranks1[],
+                          MPI_Group group2, int ranks2[])
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -133,13 +132,4 @@ USER_DEFINED_WRAPPER(int, Group_translate_ranks, (MPI_Group) group1,
   return retval;
 }
 
-PMPI_IMPL(int, MPI_Comm_group, MPI_Comm comm, MPI_Group *group)
-PMPI_IMPL(int, MPI_Group_size, MPI_Group group, int *size)
-PMPI_IMPL(int, MPI_Group_free, MPI_Group *group)
-PMPI_IMPL(int, MPI_Group_compare, MPI_Group group1,
-          MPI_Group group2, int *result)
-PMPI_IMPL(int, MPI_Group_rank, MPI_Group group, int *rank)
-PMPI_IMPL(int, MPI_Group_incl, MPI_Group group, int n,
-          const int *ranks, MPI_Group *newgroup)
-PMPI_IMPL(int, MPI_Group_translate_ranks, MPI_Group group1, int n,
-          const int ranks1[], MPI_Group group2, int ranks2[]);
+} // end of: extern "C"

--- a/mpi-proxy-split/mpi-wrappers/mpi_nextfunc.h
+++ b/mpi-proxy-split/mpi-wrappers/mpi_nextfunc.h
@@ -70,39 +70,11 @@
 // addresses of the functions) might change post restart; so, we cannot simply
 // remember the old addresses. We need to update the addresses post restart.
 #ifndef NEXT_FUNC
-#if 0
-# define NEXT_FUNC(func)                                                       \
-  ({                                                                           \
-    static __typeof__(&MPI_##func)_real_MPI_## func =                          \
-                                                (__typeof__(&MPI_##func)) - 1; \
-    if (_real_MPI_ ## func == (__typeof__(&MPI_##func)) - 1) {                 \
-      _real_MPI_ ## func = (__typeof__(&MPI_##func))pdlsym(MPI_Fnc_##func);    \
-    }                                                                          \
-    _real_MPI_ ## func;                                                        \
-  })
-#else
 # define NEXT_FUNC(func)                                                       \
   ({                                                                           \
     (__typeof__(&MPI_##func))pdlsym(MPI_Fnc_##func);                           \
   })
-#endif
 #endif // ifndef NEXT_FUNC
-
-// Convenience macro to define simple wrapper functions
-#define DEFINE_FNC(rettype, name, args...)                                     \
-  EXTERNC rettype MPI_##name(APPLY(PAIR, args))                                \
-  {                                                                            \
-    rettype retval;                                                            \
-    DMTCP_PLUGIN_DISABLE_CKPT();                                               \
-    JUMP_TO_LOWER_HALF(lh_info->fsaddr);                                           \
-    retval = NEXT_FUNC(name)(APPLY(STRIP, args));                              \
-    RETURN_TO_UPPER_HALF();                                                    \
-    DMTCP_PLUGIN_ENABLE_CKPT();                                                \
-    return retval;                                                             \
-  }
-
-#define USER_DEFINED_WRAPPER(rettype, name, args...)                           \
-  EXTERNC rettype MPI_##name(APPLY(PAIR, args))
 
 // Fortran MPI named constants
 // MPI 3.1 standard:

--- a/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
@@ -34,7 +34,8 @@ using namespace dmtcp_mpi;
 
 extern "C" {
 
-int MPI_Op_create(MPI_User_function *user_fn, int commute, MPI_Op *op)
+#pragma weak MPI_Op_create = PMPI_Op_create
+int PMPI_Op_create(MPI_User_function *user_fn, int commute, MPI_Op *op)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -51,7 +52,8 @@ int MPI_Op_create(MPI_User_function *user_fn, int commute, MPI_Op *op)
   return retval;
 }
 
-int MPI_Op_free(MPI_Op *op)
+#pragma weak MPI_Op_free = PMPI_Op_free
+int PMPI_Op_free(MPI_Op *op)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -69,7 +71,8 @@ int MPI_Op_free(MPI_Op *op)
   return retval;
 }
 
-int MPI_Reduce_local(const void *inbuf, void *inoutbuf, int count,
+#pragma weak MPI_Reduce_local = PMPI_Reduce_local
+int PMPI_Reduce_local(const void *inbuf, void *inoutbuf, int count,
                      MPI_Datatype datatype, MPI_Op op)
 {
   int retval;

--- a/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
@@ -32,10 +32,9 @@
 
 using namespace dmtcp_mpi;
 
+extern "C" {
 
-USER_DEFINED_WRAPPER(int, Op_create,
-                     (MPI_User_function *) user_fn, (int) commute,
-                     (MPI_Op *) op)
+int MPI_Op_create(MPI_User_function *user_fn, int commute, MPI_Op *op)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -52,7 +51,7 @@ USER_DEFINED_WRAPPER(int, Op_create,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Op_free, (MPI_Op*) op)
+int MPI_Op_free(MPI_Op *op)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -70,9 +69,8 @@ USER_DEFINED_WRAPPER(int, Op_free, (MPI_Op*) op)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Reduce_local,
-                     (const void *) inbuf, (void *) inoutbuf, (int) count,
-                     (MPI_Datatype) datatype, (MPI_Op) op)
+int MPI_Reduce_local(const void *inbuf, void *inoutbuf, int count,
+                     MPI_Datatype datatype, MPI_Op op)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -86,9 +84,4 @@ USER_DEFINED_WRAPPER(int, Reduce_local,
   return retval;
 }
 
-
-PMPI_IMPL(int, MPI_Op_create, MPI_User_function *user_fn,
-          int commute, MPI_Op *op)
-PMPI_IMPL(int, MPI_Op_free, MPI_Op *op)
-PMPI_IMPL(int, MPI_Reduce_local, const void *inbuf, void *inoutbuf, int count,
-          MPI_Datatype datatype, MPI_Op op)
+} // end of: extern "C"

--- a/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
@@ -38,9 +38,10 @@
 
 extern int p2p_deterministic_skip_save_request;
 
-USER_DEFINED_WRAPPER(int, Send,
-                     (const void *) buf, (int) count, (MPI_Datatype) datatype,
-                     (int) dest, (int) tag, (MPI_Comm) comm)
+extern "C" {
+
+int MPI_Send(const void *buf, int count, MPI_Datatype datatype,
+             int dest, int tag, MPI_Comm comm)
 {
   int retval;
   while (mana_state == CKPT_P2P) {
@@ -66,10 +67,9 @@ USER_DEFINED_WRAPPER(int, Send,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Isend,
-                     (const void *) buf, (int) count, (MPI_Datatype) datatype,
-                     (int) dest, (int) tag,
-                     (MPI_Comm) comm, (MPI_Request *) request)
+int MPI_Isend(const void *buf, int count, MPI_Datatype datatype,
+              int dest, int tag,
+              MPI_Comm comm, MPI_Request *request)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -101,9 +101,9 @@ USER_DEFINED_WRAPPER(int, Isend,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Rsend, (const void*) ibuf, (int) count,
-                     (MPI_Datatype) datatype, (int) dest,
-                     (int) tag, (MPI_Comm) comm)
+int MPI_Rsend(const void* ibuf, int count,
+              MPI_Datatype datatype, int dest,
+              int tag, MPI_Comm comm)
 {
   int retval;
   while (mana_state == CKPT_P2P) {
@@ -130,10 +130,8 @@ USER_DEFINED_WRAPPER(int, Rsend, (const void*) ibuf, (int) count,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Recv,
-                     (void *) buf, (int) count, (MPI_Datatype) datatype,
-                     (int) source, (int) tag,
-                     (MPI_Comm) comm, (MPI_Status *) status)
+int MPI_Recv(void *buf, int count, MPI_Datatype datatype,
+             int source, int tag, MPI_Comm comm, MPI_Status *status)
 {
   int retval;
   int flag = 0;
@@ -178,10 +176,8 @@ USER_DEFINED_WRAPPER(int, Recv,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Irecv,
-                     (void *) buf, (int) count, (MPI_Datatype) datatype,
-                     (int) source, (int) tag,
-                     (MPI_Comm) comm, (MPI_Request *) request)
+int MPI_Irecv(void *buf, int count, MPI_Datatype datatype,
+              int source, int tag, MPI_Comm comm, MPI_Request *request)
 {
   int retval;
   int flag = 0;
@@ -252,11 +248,11 @@ USER_DEFINED_WRAPPER(int, Irecv,
 }
 
 // FIXME: Move this to mpi_collective_wrappers.cpp and reimplement
-USER_DEFINED_WRAPPER(int, Sendrecv, (const void *) sendbuf, (int) sendcount,
-                     (MPI_Datatype) sendtype, (int) dest,
-                     (int) sendtag, (void *) recvbuf,
-                     (int) recvcount, (MPI_Datatype) recvtype, (int) source,
-                     (int) recvtag, (MPI_Comm) comm, (MPI_Status *) status)
+int MPI_Sendrecv(const void *sendbuf, int sendcount,
+                 MPI_Datatype sendtype, int dest,
+                 int sendtag, void *recvbuf,
+                 int recvcount, MPI_Datatype recvtype, int source,
+                 int recvtag, MPI_Comm comm, MPI_Status *status)
 {
   int retval;
 #if 0
@@ -296,10 +292,10 @@ USER_DEFINED_WRAPPER(int, Sendrecv, (const void *) sendbuf, (int) sendcount,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Sendrecv_replace, (void *) buf, (int) count,
-                     (MPI_Datatype) datatype, (int) dest,
-                     (int) sendtag, (int) source,
-                     (int) recvtag, (MPI_Comm) comm, (MPI_Status *) status)
+int MPI_Sendrecv_replace(void *buf, int count,
+                         MPI_Datatype datatype, int dest,
+                         int sendtag, int source,
+                         int recvtag, MPI_Comm comm, MPI_Status *status)
 {
   MPI_Request reqs[2];
   MPI_Status sts[2];
@@ -336,21 +332,4 @@ USER_DEFINED_WRAPPER(int, Sendrecv_replace, (void *) buf, (int) count,
   return retval;
 }
 
-
-PMPI_IMPL(int, MPI_Send, const void *buf, int count, MPI_Datatype datatype,
-          int dest, int tag, MPI_Comm comm)
-PMPI_IMPL(int, MPI_Isend, const void *buf, int count, MPI_Datatype datatype,
-          int dest, int tag, MPI_Comm comm, MPI_Request* request)
-PMPI_IMPL(int, MPI_Recv, void *buf, int count, MPI_Datatype datatype,
-          int source, int tag, MPI_Comm comm, MPI_Status *status)
-PMPI_IMPL(int, MPI_Irecv, void *buf, int count, MPI_Datatype datatype,
-          int source, int tag, MPI_Comm comm, MPI_Request *request)
-PMPI_IMPL(int, MPI_Sendrecv, const void *sendbuf, int sendcount,
-          MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf,
-          int recvcount, MPI_Datatype recvtype, int source, int recvtag,
-          MPI_Comm comm, MPI_Status *status)
-PMPI_IMPL(int, MPI_Sendrecv_replace, void * buf, int count,
-          MPI_Datatype datatype, int dest, int sendtag, int source,
-          int recvtag, MPI_Comm comm, MPI_Status *status)
-PMPI_IMPL(int, MPI_Rsend, const void *ibuf, int count, MPI_Datatype datatype,
-          int dest, int tag, MPI_Comm comm)
+} // end of: extern "C"

--- a/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
@@ -40,7 +40,8 @@ extern int p2p_deterministic_skip_save_request;
 
 extern "C" {
 
-int MPI_Send(const void *buf, int count, MPI_Datatype datatype,
+#pragma weak MPI_Send = PMPI_Send
+int PMPI_Send(const void *buf, int count, MPI_Datatype datatype,
              int dest, int tag, MPI_Comm comm)
 {
   int retval;
@@ -67,7 +68,8 @@ int MPI_Send(const void *buf, int count, MPI_Datatype datatype,
   return retval;
 }
 
-int MPI_Isend(const void *buf, int count, MPI_Datatype datatype,
+#pragma weak MPI_Isend = PMPI_Isend
+int PMPI_Isend(const void *buf, int count, MPI_Datatype datatype,
               int dest, int tag,
               MPI_Comm comm, MPI_Request *request)
 {
@@ -101,7 +103,8 @@ int MPI_Isend(const void *buf, int count, MPI_Datatype datatype,
   return retval;
 }
 
-int MPI_Rsend(const void* ibuf, int count,
+#pragma weak MPI_Rsend = PMPI_Rsend
+int PMPI_Rsend(const void* ibuf, int count,
               MPI_Datatype datatype, int dest,
               int tag, MPI_Comm comm)
 {
@@ -130,7 +133,8 @@ int MPI_Rsend(const void* ibuf, int count,
   return retval;
 }
 
-int MPI_Recv(void *buf, int count, MPI_Datatype datatype,
+#pragma weak MPI_Recv = PMPI_Recv
+int PMPI_Recv(void *buf, int count, MPI_Datatype datatype,
              int source, int tag, MPI_Comm comm, MPI_Status *status)
 {
   int retval;
@@ -176,7 +180,8 @@ int MPI_Recv(void *buf, int count, MPI_Datatype datatype,
   return retval;
 }
 
-int MPI_Irecv(void *buf, int count, MPI_Datatype datatype,
+#pragma weak MPI_Irecv = PMPI_Irecv
+int PMPI_Irecv(void *buf, int count, MPI_Datatype datatype,
               int source, int tag, MPI_Comm comm, MPI_Request *request)
 {
   int retval;
@@ -247,8 +252,8 @@ int MPI_Irecv(void *buf, int count, MPI_Datatype datatype,
   return retval;
 }
 
-// FIXME: Move this to mpi_collective_wrappers.cpp and reimplement
-int MPI_Sendrecv(const void *sendbuf, int sendcount,
+#pragma weak MPI_Sendrecv = PMPI_Sendrecv
+int PMPI_Sendrecv(const void *sendbuf, int sendcount,
                  MPI_Datatype sendtype, int dest,
                  int sendtag, void *recvbuf,
                  int recvcount, MPI_Datatype recvtype, int source,
@@ -292,7 +297,8 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount,
   return retval;
 }
 
-int MPI_Sendrecv_replace(void *buf, int count,
+#pragma weak MPI_Sendrecv_replace = PMPI_Sendrecv_replace
+int PMPI_Sendrecv_replace(void *buf, int count,
                          MPI_Datatype datatype, int dest,
                          int sendtag, int source,
                          int recvtag, MPI_Comm comm, MPI_Status *status)

--- a/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -59,7 +59,8 @@ int MPI_Test_internal(MPI_Request *request, int *flag, MPI_Status *status,
   return retval;
 }
 
-int MPI_Test(MPI_Request* request, int* flag, MPI_Status* status)
+#pragma weak MPI_Test = PMPI_Test
+int PMPI_Test(MPI_Request* request, int* flag, MPI_Status* status)
 {
   int retval;
   if (*request == MPI_REQUEST_NULL) {
@@ -122,7 +123,8 @@ int MPI_Test(MPI_Request* request, int* flag, MPI_Status* status)
   return retval;
 }
 
-int MPI_Testall(int count, MPI_Request *array_of_requests, int *flag,
+#pragma weak MPI_Testall = PMPI_Testall
+int PMPI_Testall(int count, MPI_Request *array_of_requests, int *flag,
                 MPI_Status *array_of_statuses)
 {
   // NOTE: See MPI_Testany below for the rationale for these variables.
@@ -160,7 +162,8 @@ int MPI_Testall(int count, MPI_Request *array_of_requests, int *flag,
   return retval;
 }
 
-int MPI_Testany(int count, MPI_Request *array_of_requests, int *index,
+#pragma weak MPI_Testany = PMPI_Testany
+int PMPI_Testany(int count, MPI_Request *array_of_requests, int *index,
                 int *flag, MPI_Status *status)
 {
   // FIXME:  Revise this note if definition if FORTRAM_MPI_STATUS_IGNORE
@@ -197,7 +200,8 @@ int MPI_Testany(int count, MPI_Request *array_of_requests, int *index,
   return retval;
 }
 
-int MPI_Waitall(int count, MPI_Request *array_of_requests,
+#pragma weak MPI_Waitall = PMPI_Waitall
+int PMPI_Waitall(int count, MPI_Request *array_of_requests,
                 MPI_Status *array_of_statuses)
 {
   // FIXME: Revisit this wrapper - call get_real_id on array
@@ -240,7 +244,8 @@ int MPI_Waitall(int count, MPI_Request *array_of_requests,
   return retval;
 }
 
-int MPI_Waitany(int count, MPI_Request *array_of_requests,
+#pragma weak MPI_Waitany = PMPI_Waitany
+int PMPI_Waitany(int count, MPI_Request *array_of_requests,
                 int *index, MPI_Status *status)
 {
   // NOTE: See MPI_Testany above for the rationale for these variables.
@@ -318,7 +323,8 @@ int MPI_Waitany(int count, MPI_Request *array_of_requests,
   }
 }
 
-int MPI_Wait(MPI_Request *request, MPI_Status *status)
+#pragma weak MPI_Wait = PMPI_Wait
+int PMPI_Wait(MPI_Request *request, MPI_Status *status)
 {
   int retval;
   if (*request == MPI_REQUEST_NULL) {
@@ -379,7 +385,8 @@ int MPI_Wait(MPI_Request *request, MPI_Status *status)
   return retval;
 }
 
-int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status *status)
+#pragma weak MPI_Probe = PMPI_Probe
+int PMPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status *status)
 {
   int retval;
   int flag = 0;
@@ -389,7 +396,8 @@ int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status *status)
   return retval;
 }
 
-int MPI_Iprobe(int source, int tag, MPI_Comm comm, int *flag, MPI_Status *status)
+#pragma weak MPI_Iprobe = PMPI_Iprobe
+int PMPI_Iprobe(int source, int tag, MPI_Comm comm, int *flag, MPI_Status *status)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -405,7 +413,8 @@ int MPI_Iprobe(int source, int tag, MPI_Comm comm, int *flag, MPI_Status *status
   return retval;
 }
 
-int MPI_Request_get_status(MPI_Request request, int *flag, MPI_Status *status)
+#pragma weak MPI_Request_get_status = PMPI_Request_get_status
+int PMPI_Request_get_status(MPI_Request request, int *flag, MPI_Status *status)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -417,7 +426,8 @@ int MPI_Request_get_status(MPI_Request request, int *flag, MPI_Status *status)
   return retval;
 }
 
-int MPI_Get_elements(const MPI_Status *status, MPI_Datatype datatype,
+#pragma weak MPI_Get_elements = PMPI_Get_elements
+int PMPI_Get_elements(const MPI_Status *status, MPI_Datatype datatype,
                      int *count)
 {
   int retval;
@@ -429,7 +439,8 @@ int MPI_Get_elements(const MPI_Status *status, MPI_Datatype datatype,
   return retval;
 }
 
-int MPI_Get_elements_x(const MPI_Status *status, MPI_Datatype datatype,
+#pragma weak MPI_Get_elements_x = PMPI_Get_elements_x
+int PMPI_Get_elements_x(const MPI_Status *status, MPI_Datatype datatype,
                        MPI_Count *count)
 {
   int retval;

--- a/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
@@ -34,7 +34,8 @@ using namespace dmtcp_mpi;
 
 extern "C" {
 
-int MPI_Type_size(MPI_Datatype datatype, int *size)
+#pragma weak MPI_Type_size = PMPI_Type_size
+int PMPI_Type_size(MPI_Datatype datatype, int *size)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -46,7 +47,8 @@ int MPI_Type_size(MPI_Datatype datatype, int *size)
   return retval;
 }
 
-int MPI_Type_free(MPI_Datatype *type)
+#pragma weak MPI_Type_free = PMPI_Type_free
+int PMPI_Type_free(MPI_Datatype *type)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -61,7 +63,8 @@ int MPI_Type_free(MPI_Datatype *type)
   return retval;
 }
 
-int MPI_Type_commit(MPI_Datatype *type)
+#pragma weak MPI_Type_commit = PMPI_Type_commit
+int PMPI_Type_commit(MPI_Datatype *type)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -76,7 +79,8 @@ int MPI_Type_commit(MPI_Datatype *type)
   return retval;
 }
 
-int MPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype *newtype)
+#pragma weak MPI_Type_contiguous = PMPI_Type_contiguous
+int PMPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -92,13 +96,15 @@ int MPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype *newtype)
   return retval;
 }
 
-int MPI_Type_create_hvector(int count, int blocklength, MPI_Aint stride,
+#pragma weak MPI_Type_create_hvector = PMPI_Type_create_hvector
+int PMPI_Type_create_hvector(int count, int blocklength, MPI_Aint stride,
                             MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
   return MPI_Type_create_hvector(count, blocklength, stride, oldtype, newtype);
 }
 
-int MPI_Type_vector(int count, int blocklength, int stride, MPI_Datatype oldtype,
+#pragma weak MPI_Type_vector = PMPI_Type_vector
+int PMPI_Type_vector(int count, int blocklength, int stride, MPI_Datatype oldtype,
                     MPI_Datatype *newtype)
 {
   int size;
@@ -110,13 +116,14 @@ int MPI_Type_vector(int count, int blocklength, int stride, MPI_Datatype oldtype
   return MPI_Type_create_hvector(count, blocklength, stride*size, oldtype, newtype);
 }
 
-//       int MPI_Type_create_struct(int count,
+//       int PMPI_Type_create_struct(int count,
 //                                const int array_of_blocklengths[],
 //                                const MPI_Aint array_of_displacements[],
 //                                const MPI_Datatype array_of_types[],
 //                                MPI_Datat
 
-int MPI_Type_create_struct(int count, const int *array_of_blocklengths,
+#pragma weak MPI_Type_create_struct = PMPI_Type_create_struct
+int PMPI_Type_create_struct(int count, const int *array_of_blocklengths,
                            const MPI_Aint *array_of_displacements,
                            const MPI_Datatype *array_of_types, MPI_Datatype *newtype)
 {
@@ -147,20 +154,21 @@ int MPI_Type_create_struct(int count, const int *array_of_blocklengths,
 // APIs. We use MPICH_NUMVERSION (3.4a2) to differentiate the cray-mpich on Cori
 // and Perlmuttter. This ad-hoc workaround should be removed once the cray-mpich
 // on Perlmutter is fixed to use the right API.
+#pragma weak MPI_Type_struct = PMPI_Type_struct
 #ifdef MPICH_NUMVERSION
 #if MPICH_NUMVERSION < MPICH_CALC_VERSION(3,4,0,0,2) && defined(CRAY_MPICH_VERSION)
-int MPI_Type_struct(int count,
+int PMPI_Type_struct(int count,
                     const int *array_of_blocklengths,
                     const MPI_Aint *array_of_displacements,
                     const MPI_Datatype *array_of_types, MPI_Datatype *newtype)
 #else
-int MPI_Type_struct(int count,
+int PMPI_Type_struct(int count,
                     int *array_of_blocklengths,
                     MPI_Aint *array_of_displacements,
                     MPI_Datatype *array_of_types, MPI_Datatype *newtype)
 #endif
 #else
-int MPI_Type_struct(int count,
+int PMPI_Type_struct(int count,
                     int *array_of_blocklengths,
                     MPI_Aint *array_of_displacements,
                     MPI_Datatype *array_of_types, MPI_Datatype *newtype)
@@ -171,7 +179,8 @@ int MPI_Type_struct(int count,
                                 );
 }
 
-int MPI_Type_create_hindexed(int count, const int *array_of_blocklengths,
+#pragma weak MPI_Type_create_hindexed = PMPI_Type_create_hindexed
+int PMPI_Type_create_hindexed(int count, const int *array_of_blocklengths,
                              const MPI_Aint *array_of_displacements,
                              MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
@@ -203,7 +212,8 @@ int MPI_Type_create_hindexed(int count, const int *array_of_blocklengths,
 #endif
 }
 
-int MPI_Type_create_hindexed_block(int count, int blocklength,
+#pragma weak MPI_Type_create_hindexed_block = PMPI_Type_create_hindexed_block
+int PMPI_Type_create_hindexed_block(int count, int blocklength,
                                    const MPI_Aint *array_of_displacements,
                                    MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
@@ -233,7 +243,8 @@ int MPI_Type_create_hindexed_block(int count, int blocklength,
 #endif
 }
 
-int MPI_Type_hindexed_block(int count, int blocklength,
+#pragma weak MPI_Type_hindexed_block = PMPI_Type_hindexed_block
+int PMPI_Type_hindexed_block(int count, int blocklength,
                             const MPI_Aint *array_of_displacements,
                             MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
@@ -242,7 +253,8 @@ int MPI_Type_hindexed_block(int count, int blocklength,
                                         newtype);
 }
 
-int MPI_Type_indexed(int count, const int *array_of_blocklengths,
+#pragma weak MPI_Type_indexed = PMPI_Type_indexed
+int PMPI_Type_indexed(int count, const int *array_of_blocklengths,
                      const int *array_of_displacements,
                      MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
@@ -264,7 +276,8 @@ int MPI_Type_indexed(int count, const int *array_of_blocklengths,
   return retval;
 }
 
-int MPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype *newtype)
+#pragma weak MPI_Type_dup = PMPI_Type_dup
+int PMPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -280,7 +293,8 @@ int MPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype *newtype)
   return retval;
 }
 
-int MPI_Type_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent,
+#pragma weak MPI_Type_create_resized = PMPI_Type_create_resized
+int PMPI_Type_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent,
                             MPI_Datatype *newtype)
 {
   int retval;
@@ -297,7 +311,8 @@ int MPI_Type_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent,
   return retval;
 }
 
-int MPI_Type_get_extent(MPI_Datatype datatype, MPI_Aint *lb, MPI_Aint *extent)
+#pragma weak MPI_Type_get_extent = PMPI_Type_get_extent
+int PMPI_Type_get_extent(MPI_Datatype datatype, MPI_Aint *lb, MPI_Aint *extent)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -309,7 +324,8 @@ int MPI_Type_get_extent(MPI_Datatype datatype, MPI_Aint *lb, MPI_Aint *extent)
   return retval;
 }
 
-int MPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm, int *size)
+#pragma weak MPI_Pack_size = PMPI_Pack_size
+int PMPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm, int *size)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -322,7 +338,8 @@ int MPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm, int *size)
   return retval;
 }
 
-int MPI_Pack(const void *inbuf, int incount, MPI_Datatype datatype, 
+#pragma weak MPI_Pack = PMPI_Pack
+int PMPI_Pack(const void *inbuf, int incount, MPI_Datatype datatype, 
              void *outbuf, int outsize, int *position, MPI_Comm comm)
 {
   int retval;
@@ -337,7 +354,8 @@ int MPI_Pack(const void *inbuf, int incount, MPI_Datatype datatype,
   return retval;
 }
 
-int MPI_Type_get_name(MPI_Datatype datatype, char *type_name, int *resultlen)
+#pragma weak MPI_Type_get_name = PMPI_Type_get_name
+int PMPI_Type_get_name(MPI_Datatype datatype, char *type_name, int *resultlen)
 {
    int retval;
    DMTCP_PLUGIN_DISABLE_CKPT();
@@ -349,7 +367,8 @@ int MPI_Type_get_name(MPI_Datatype datatype, char *type_name, int *resultlen)
    return retval;
 }
 
-int MPI_Type_get_size_x(MPI_Datatype type, MPI_Count *size)
+#pragma weak MPI_Type_size_x = PMPI_Type_size_x
+int PMPI_Type_size_x(MPI_Datatype type, MPI_Count *size)
 {
    int retval;
    DMTCP_PLUGIN_DISABLE_CKPT();
@@ -361,5 +380,4 @@ int MPI_Type_get_size_x(MPI_Datatype type, MPI_Count *size)
    return retval;
 }
 
-DEFINE_FNC(int, Type_size_x, (MPI_Datatype) type, (MPI_Count *) size);
 } // end of: extern "C"

--- a/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
@@ -32,7 +32,9 @@
 
 using namespace dmtcp_mpi;
 
-USER_DEFINED_WRAPPER(int, Type_size, (MPI_Datatype) datatype, (int *) size)
+extern "C" {
+
+int MPI_Type_size(MPI_Datatype datatype, int *size)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -44,7 +46,7 @@ USER_DEFINED_WRAPPER(int, Type_size, (MPI_Datatype) datatype, (int *) size)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Type_free, (MPI_Datatype *) type)
+int MPI_Type_free(MPI_Datatype *type)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -59,7 +61,7 @@ USER_DEFINED_WRAPPER(int, Type_free, (MPI_Datatype *) type)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Type_commit, (MPI_Datatype *) type)
+int MPI_Type_commit(MPI_Datatype *type)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -74,8 +76,7 @@ USER_DEFINED_WRAPPER(int, Type_commit, (MPI_Datatype *) type)
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Type_contiguous, (int) count, (MPI_Datatype) oldtype,
-                     (MPI_Datatype *) newtype)
+int MPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -91,39 +92,14 @@ USER_DEFINED_WRAPPER(int, Type_contiguous, (int) count, (MPI_Datatype) oldtype,
   return retval;
 }
 
-// removed in MPI-3.0 (2012)
-#if 0
-USER_DEFINED_WRAPPER(int, Type_hvector, (int) count, (int) blocklength,
-                    (MPI_Aint) stride, (MPI_Datatype) oldtype,
-                    (MPI_Datatype*) newtype)
-{
-  int retval;
-  DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_Datatype real_datatype = get_real_id((mana_mpi_handle){.datatype = oldtype}).datatype;
-  JUMP_TO_LOWER_HALF(lh_info->fsaddr);
-  retval = NEXT_FUNC(Type_hvector)(count, blocklength,
-                                  stride, real_datatype, newtype);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
-    *newtype = new_virt_datatype(*newtype);
-    LOG_CALL(restoreTypes, Type_hvector, count, blocklength,
-             stride, oldtype, *newtype);
-  }
-  DMTCP_PLUGIN_ENABLE_CKPT();
-  return retval;
-}
-#endif
-
-USER_DEFINED_WRAPPER(int, Type_create_hvector, (int) count, (int) blocklength,
-                    (MPI_Aint) stride, (MPI_Datatype) oldtype,
-                    (MPI_Datatype*) newtype)
+int MPI_Type_create_hvector(int count, int blocklength, MPI_Aint stride,
+                            MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
   return MPI_Type_create_hvector(count, blocklength, stride, oldtype, newtype);
 }
 
-USER_DEFINED_WRAPPER(int, Type_vector, (int) count, (int) blocklength,
-                     (int) stride, (MPI_Datatype) oldtype,
-                    (MPI_Datatype*) newtype)
+int MPI_Type_vector(int count, int blocklength, int stride, MPI_Datatype oldtype,
+                    MPI_Datatype *newtype)
 {
   int size;
   int retval = MPI_Type_size(oldtype, &size);
@@ -138,12 +114,11 @@ USER_DEFINED_WRAPPER(int, Type_vector, (int) count, (int) blocklength,
 //                                const int array_of_blocklengths[],
 //                                const MPI_Aint array_of_displacements[],
 //                                const MPI_Datatype array_of_types[],
-//                                MPI_Datatype *newtype)
+//                                MPI_Datat
 
-USER_DEFINED_WRAPPER(int, Type_create_struct, (int) count,
-                     (const int*) array_of_blocklengths,
-                     (const MPI_Aint*) array_of_displacements,
-                     (const MPI_Datatype*) array_of_types, (MPI_Datatype*) newtype)
+int MPI_Type_create_struct(int count, const int *array_of_blocklengths,
+                           const MPI_Aint *array_of_displacements,
+                           const MPI_Datatype *array_of_types, MPI_Datatype *newtype)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -174,21 +149,21 @@ USER_DEFINED_WRAPPER(int, Type_create_struct, (int) count,
 // on Perlmutter is fixed to use the right API.
 #ifdef MPICH_NUMVERSION
 #if MPICH_NUMVERSION < MPICH_CALC_VERSION(3,4,0,0,2) && defined(CRAY_MPICH_VERSION)
-USER_DEFINED_WRAPPER(int, Type_struct, (int) count,
-                     (const int*) array_of_blocklengths,
-                     (const MPI_Aint*) array_of_displacements,
-                     (const MPI_Datatype*) array_of_types, (MPI_Datatype*) newtype)
+int MPI_Type_struct(int count,
+                    const int *array_of_blocklengths,
+                    const MPI_Aint *array_of_displacements,
+                    const MPI_Datatype *array_of_types, MPI_Datatype *newtype)
 #else
-USER_DEFINED_WRAPPER(int, Type_struct, (int) count,
-                     (int*) array_of_blocklengths,
-                     (MPI_Aint*) array_of_displacements,
-                     (MPI_Datatype*) array_of_types, (MPI_Datatype*) newtype)
+int MPI_Type_struct(int count,
+                    int *array_of_blocklengths,
+                    MPI_Aint *array_of_displacements,
+                    MPI_Datatype *array_of_types, MPI_Datatype *newtype)
 #endif
 #else
-USER_DEFINED_WRAPPER(int, Type_struct, (int) count,
-                     (int*) array_of_blocklengths,
-                     (MPI_Aint*) array_of_displacements,
-                     (MPI_Datatype*) array_of_types, (MPI_Datatype*) newtype)
+int MPI_Type_struct(int count,
+                    int *array_of_blocklengths,
+                    MPI_Aint *array_of_displacements,
+                    MPI_Datatype *array_of_types, MPI_Datatype *newtype)
 #endif
 {
   return MPI_Type_create_struct(count, array_of_blocklengths,
@@ -196,58 +171,16 @@ USER_DEFINED_WRAPPER(int, Type_struct, (int) count,
                                 );
 }
 
-// removed in MPI-3.0 (2012)
-#if 0
-#ifdef MPICH_NUMVERSION
-#if MPICH_NUMVERSION < MPICH_CALC_VERSION(3,4,0,0,2) && defined(CRAY_MPICH_VERSION)
-USER_DEFINED_WRAPPER(int, Type_hindexed, (int) count,
-                     (const int*) array_of_blocklengths,
-                     (const MPI_Aint*) array_of_displacements,
-                     (MPI_Datatype) oldtype, (MPI_Datatype*) newtype)
-#else
-USER_DEFINED_WRAPPER(int, Type_hindexed, (int) count,
-                     (int*) array_of_blocklengths,
-                     (MPI_Aint*) array_of_displacements,
-                     (MPI_Datatype) oldtype, (MPI_Datatype*) newtype)
-#endif
-#else
-USER_DEFINED_WRAPPER(int, Type_hindexed, (int) count,
-                     (int*) array_of_blocklengths,
-                     (MPI_Aint*) array_of_displacements,
-                     (MPI_Datatype) oldtype, (MPI_Datatype*) newtype)
-#endif
-{
-  int retval;
-  DMTCP_PLUGIN_DISABLE_CKPT();
-  MPI_Datatype real_datatype = get_real_id((mana_mpi_handle){.datatype = oldtype}).datatype;
-  JUMP_TO_LOWER_HALF(lh_info->fsaddr);
-  retval = NEXT_FUNC(Type_hindexed)(count, array_of_blocklengths,
-                                   array_of_displacements,
-                                   real_datatype, newtype);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && MPI_LOGGING()) {
-    *newtype = new_virt_datatype(*newtype);
-    FncArg bs = CREATE_LOG_BUF(array_of_blocklengths, count * sizeof(int));
-    FncArg ds = CREATE_LOG_BUF(array_of_displacements,
-                               count * sizeof(MPI_Aint));
-    LOG_CALL(restoreTypes, Type_hindexed, count, bs, ds, oldtype, *newtype);
-  }
-  DMTCP_PLUGIN_ENABLE_CKPT();
-  return retval;
-}
-#endif
-
-USER_DEFINED_WRAPPER(int, Type_create_hindexed, (int) count,
-                     (const int*) array_of_blocklengths,
-                     (const MPI_Aint*) array_of_displacements,
-                     (MPI_Datatype) oldtype, (MPI_Datatype*) newtype)
+int MPI_Type_create_hindexed(int count, const int *array_of_blocklengths,
+                             const MPI_Aint *array_of_displacements,
+                             MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
 #ifdef MPICH_NUMVERSION
 #if MPICH_NUMVERSION < MPICH_CALC_VERSION(3,4,0,0,2) && defined(CRAY_MPICH_VERSION)
   return MPI_Type_create_hindexed(count, array_of_blocklengths, array_of_displacements,
                            oldtype, newtype);
 #else
-  int* non_const_bl_arr = (int*) malloc(count * sizeof(int));
+  int *non_const_bl_arr = (int*)malloc(count * sizeof(int));
   MPI_Aint* non_const_disp_arr = (MPI_Aint*) malloc(count * sizeof(MPI_Aint));
   memcpy(non_const_bl_arr, array_of_blocklengths, count * sizeof(int));
   memcpy(non_const_disp_arr, array_of_displacements, count * sizeof(MPI_Aint));
@@ -258,7 +191,7 @@ USER_DEFINED_WRAPPER(int, Type_create_hindexed, (int) count,
   return ret;
 #endif
 #else
-  int* non_const_bl_arr = (int*) malloc(count * sizeof(int));
+  int *non_const_bl_arr = (int*)malloc(count * sizeof(int));
   MPI_Aint* non_const_disp_arr = (MPI_Aint*) malloc(count * sizeof(MPI_Aint));
   memcpy(non_const_bl_arr, array_of_blocklengths, count * sizeof(int));
   memcpy(non_const_disp_arr, array_of_displacements, count * sizeof(MPI_Aint));
@@ -270,10 +203,9 @@ USER_DEFINED_WRAPPER(int, Type_create_hindexed, (int) count,
 #endif
 }
 
-USER_DEFINED_WRAPPER(int, Type_create_hindexed_block, (int) count,
-                     (int) blocklength,
-                     (const MPI_Aint*) array_of_displacements,
-                     (MPI_Datatype) oldtype, (MPI_Datatype*) newtype)
+int MPI_Type_create_hindexed_block(int count, int blocklength,
+                                   const MPI_Aint *array_of_displacements,
+                                   MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
   int array_of_blocklengths[count];
   for (int i = 0; i < count; i++) {
@@ -301,20 +233,18 @@ USER_DEFINED_WRAPPER(int, Type_create_hindexed_block, (int) count,
 #endif
 }
 
-USER_DEFINED_WRAPPER(int, Type_hindexed_block, (int) count,
-                     (int) blocklength,
-                     (const MPI_Aint*) array_of_displacements,
-                     (MPI_Datatype) oldtype, (MPI_Datatype*) newtype)
+int MPI_Type_hindexed_block(int count, int blocklength,
+                            const MPI_Aint *array_of_displacements,
+                            MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
   return MPI_Type_create_hindexed_block(count, blocklength,
                                         array_of_displacements, oldtype,
                                         newtype);
 }
 
-USER_DEFINED_WRAPPER(int, Type_indexed, (int) count,
-                     (const int*) array_of_blocklengths,
-                     (const int*) array_of_displacements,
-                     (MPI_Datatype) oldtype, (MPI_Datatype*) newtype)
+int MPI_Type_indexed(int count, const int *array_of_blocklengths,
+                     const int *array_of_displacements,
+                     MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -334,8 +264,7 @@ USER_DEFINED_WRAPPER(int, Type_indexed, (int) count,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Type_dup, (MPI_Datatype) oldtype,
-                     (MPI_Datatype*) newtype)
+int MPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -351,8 +280,8 @@ USER_DEFINED_WRAPPER(int, Type_dup, (MPI_Datatype) oldtype,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Type_create_resized, (MPI_Datatype) oldtype,
-                     (MPI_Aint) lb, (MPI_Aint) extent, (MPI_Datatype*) newtype)
+int MPI_Type_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent,
+                            MPI_Datatype *newtype)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -368,8 +297,7 @@ USER_DEFINED_WRAPPER(int, Type_create_resized, (MPI_Datatype) oldtype,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Type_get_extent, (MPI_Datatype) datatype,
-                     (MPI_Aint*) lb, (MPI_Aint*) extent)
+int MPI_Type_get_extent(MPI_Datatype datatype, MPI_Aint *lb, MPI_Aint *extent)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -381,9 +309,7 @@ USER_DEFINED_WRAPPER(int, Type_get_extent, (MPI_Datatype) datatype,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Pack_size, (int) incount,
-                     (MPI_Datatype) datatype, (MPI_Comm) comm,
-                     (int*) size)
+int MPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm, int *size)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -396,9 +322,8 @@ USER_DEFINED_WRAPPER(int, Pack_size, (int) incount,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Pack, (const void*) inbuf, (int) incount,
-                     (MPI_Datatype) datatype, (void*) outbuf, (int) outsize,
-                     (int*) position, (MPI_Comm) comm)
+int MPI_Pack(const void *inbuf, int incount, MPI_Datatype datatype, 
+             void *outbuf, int outsize, int *position, MPI_Comm comm)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -412,8 +337,7 @@ USER_DEFINED_WRAPPER(int, Pack, (const void*) inbuf, (int) incount,
   return retval;
 }
 
-USER_DEFINED_WRAPPER(int, Type_get_name, (MPI_Datatype) datatype, 
-                      (char*) type_name, (int*) resultlen)
+int MPI_Type_get_name(MPI_Datatype datatype, char *type_name, int *resultlen)
 {
    int retval;
    DMTCP_PLUGIN_DISABLE_CKPT();
@@ -425,83 +349,17 @@ USER_DEFINED_WRAPPER(int, Type_get_name, (MPI_Datatype) datatype,
    return retval;
 }
 
+int MPI_Type_get_size_x(MPI_Datatype type, MPI_Count *size)
+{
+   int retval;
+   DMTCP_PLUGIN_DISABLE_CKPT();
+   MPI_Datatype real_datatype = get_real_id((mana_mpi_handle){.datatype = type}).datatype;
+   JUMP_TO_LOWER_HALF(lh_info->fsaddr);
+   retval = NEXT_FUNC(Type_size_x)(real_datatype, size);
+   RETURN_TO_UPPER_HALF(); 
+   DMTCP_PLUGIN_ENABLE_CKPT();
+   return retval;
+}
+
 DEFINE_FNC(int, Type_size_x, (MPI_Datatype) type, (MPI_Count *) size);
-
-PMPI_IMPL(int, MPI_Type_size, MPI_Datatype datatype, int *size)
-PMPI_IMPL(int, MPI_Type_commit, MPI_Datatype *type)
-PMPI_IMPL(int, MPI_Type_contiguous, int count, MPI_Datatype oldtype,
-          MPI_Datatype *newtype)
-PMPI_IMPL(int, MPI_Type_free, MPI_Datatype *type)
-PMPI_IMPL(int, MPI_Type_vector, int count, int blocklength,
-          int stride, MPI_Datatype oldtype, MPI_Datatype *newtype)
-// removed in MPI-3.0 (2012)
-#if 0
-PMPI_IMPL(int, MPI_Type_hvector, int count, int blocklength,
-          MPI_Aint stride, MPI_Datatype oldtype, MPI_Datatype *newtype)
-#endif
-
-PMPI_IMPL(int, MPI_Type_create_hvector, int count, int blocklength,
-          MPI_Aint stride, MPI_Datatype oldtype, MPI_Datatype *newtype)
-// removed in MPI-3.0 (2012)
-#if 0
-PMPI_IMPL(int, MPI_Type_struct, int count, const int array_of_blocklengths[],
-          const MPI_Aint array_of_displacements[], const MPI_Datatype array_of_types[],
-          MPI_Datatype *newtype)
-#endif
-
-PMPI_IMPL(int, MPI_Type_create_struct, int count, const int array_of_blocklengths[],
-          const MPI_Aint array_of_displacements[], const MPI_Datatype array_of_types[],
-          MPI_Datatype *newtype)
-PMPI_IMPL(int, MPI_Type_create_hindexed, int count, const int array_of_blocklengths[],
-          const MPI_Aint array_of_displacements[], MPI_Datatype oldtype,
-          MPI_Datatype *newtype);
-#if 0
-#ifdef MPICH_NUMVERSION
-#if MPICH_NUMVERSION < MPICH_CALC_VERSION(3,4,0,0,2) && defined(CRAY_MPICH_VERSION)
-PMPI_IMPL(int, MPI_Type_create_struct, int count, const int array_of_blocklengths[],
-          const MPI_Aint array_of_displacements[], const MPI_Datatype array_of_types[],
-          MPI_Datatype *newtype)
-PMPI_IMPL(int, MPI_Type_create_hindexed, int count, const int array_of_blocklengths[],
-          const MPI_Aint array_of_displacements[], MPI_Datatype oldtype,
-          MPI_Datatype *newtype);
-#else
-PMPI_IMPL(int, MPI_Type_create_struct, int count, const int array_of_blocklengths[],
-          const MPI_Aint array_of_displacements[], const MPI_Datatype array_of_types[],
-          MPI_Datatype *newtype)
-PMPI_IMPL(int, MPI_Type_create_hindexed, int count, const int array_of_blocklengths[],
-          const MPI_Aint array_of_displacements[], MPI_Datatype oldtype,
-          MPI_Datatype *newtype);
-#endif
-#else
-PMPI_IMPL(int, MPI_Type_create_struct, int count, const int array_of_blocklengths[],
-          const MPI_Aint array_of_displacements[], const MPI_Datatype array_of_types[],
-          MPI_Datatype *newtype)
-PMPI_IMPL(int, MPI_Type_create_hindexed, int count, const int array_of_blocklengths[],
-          const MPI_Aint array_of_displacements[], MPI_Datatype oldtype,
-          MPI_Datatype *newtype);
-#endif
-#endif
-
-PMPI_IMPL(int, MPI_Type_size_x, MPI_Datatype type, MPI_Count *size)
-PMPI_IMPL(int, MPI_Type_indexed, int count, const int array_of_blocklengths[],
-          const int array_of_displacements[], MPI_Datatype oldtype,
-          MPI_Datatype *newtype)
-PMPI_IMPL(int, MPI_Type_get_extent, MPI_Datatype datatype, MPI_Aint *lb,
-          MPI_Aint *extent)
-PMPI_IMPL(int, MPI_Pack_size, int incount, MPI_Datatype datatype,
-          MPI_Comm comm, int *size)
-PMPI_IMPL(int, MPI_Pack, const void *inbuf, int incount, MPI_Datatype datatype,
-          void *outbuf, int outsize, int *position, MPI_Comm comm)
-PMPI_IMPL(int, MPI_Type_create_resized, MPI_Datatype oldtype, MPI_Aint lb,
-          MPI_Aint extent, MPI_Datatype *newtype);
-PMPI_IMPL(int, MPI_Type_dup, MPI_Datatype type, MPI_Datatype *newtype);
-// removed in MPI-3.0 (2012)
-#if 0
-PMPI_IMPL(int, MPI_Type_hindexed, int count,
-          const int array_of_blocklengths[],
-          const MPI_Aint array_of_displacements[], MPI_Datatype oldtype,
-          MPI_Datatype *newtype);
-#endif
-PMPI_IMPL(int, MPI_Type_create_hindexed_block, int count, int blocklength,
-          const MPI_Aint array_of_displacements[], MPI_Datatype oldtype,
-          MPI_Datatype *newtype);
+} // end of: extern "C"

--- a/mpi-proxy-split/mpi-wrappers/mpi_win_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_win_wrappers.cpp
@@ -7,8 +7,9 @@
 #include "protectedfds.h"
 #include "mpi_nextfunc.h"
 
-USER_DEFINED_WRAPPER(int, Alloc_mem, (MPI_Aint) size, (MPI_Info) info,
-                     (void *) baseptr)
+extern "C" {
+
+int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void *baseptr)
 {
   // Since memory allocated by the lower half will be discarded during
   // checkpoint, we need to translate MPI_Alloc_mem and MPI_Free_mem
@@ -17,7 +18,7 @@ USER_DEFINED_WRAPPER(int, Alloc_mem, (MPI_Aint) size, (MPI_Info) info,
   return MPI_SUCCESS;
 }
 
-USER_DEFINED_WRAPPER(int, Free_mem, (void *) baseptr)
+int MPI_Free_mem(void *baseptr)
 {
   // Since memory allocated by the lower half will be discarded during
   // checkpoint, we need to translate MPI_Alloc_mem and MPI_Free_mem
@@ -26,5 +27,4 @@ USER_DEFINED_WRAPPER(int, Free_mem, (void *) baseptr)
   return MPI_SUCCESS;
 }
 
-PMPI_IMPL(int, MPI_Alloc_mem, MPI_Aint size, MPI_Info info, void *baseptr)
-PMPI_IMPL(int, MPI_Free_mem, void *baseptr)
+} // end of: extern "C"

--- a/mpi-proxy-split/mpi-wrappers/mpi_win_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_win_wrappers.cpp
@@ -9,7 +9,8 @@
 
 extern "C" {
 
-int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void *baseptr)
+#pragma weak MPI_Alloc_mem = PMPI_Alloc_mem
+int PMPI_Alloc_mem(MPI_Aint size, MPI_Info info, void *baseptr)
 {
   // Since memory allocated by the lower half will be discarded during
   // checkpoint, we need to translate MPI_Alloc_mem and MPI_Free_mem
@@ -18,7 +19,8 @@ int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void *baseptr)
   return MPI_SUCCESS;
 }
 
-int MPI_Free_mem(void *baseptr)
+#pragma weak MPI_Free_mem = PMPI_Free_mem
+int PMPI_Free_mem(void *baseptr)
 {
   // Since memory allocated by the lower half will be discarded during
   // checkpoint, we need to translate MPI_Alloc_mem and MPI_Free_mem

--- a/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
@@ -53,7 +53,8 @@ ManaHeader g_mana_header = { .init_flag = MPI_INIT_NO_THREAD };
 
 extern "C" {
 
-int MPI_Init(int *argc, char ***argv) {
+#pragma weak MPI_Init = PMPI_Init
+int PMPI_Init(int *argc, char ***argv) {
   int retval;
   if (isUsingCollectiveToP2p()) {
     fprintf(stderr, collective_p2p_string);
@@ -71,7 +72,8 @@ int MPI_Init(int *argc, char ***argv) {
   return retval;
 }
 
-int MPI_Init_thread(int *argc, char ***argv, int required, int *provided) {
+#pragma weak MPI_Init_thread = PMPI_Init_thread
+int PMPI_Init_thread(int *argc, char ***argv, int required, int *provided) {
   int retval;
   if (isUsingCollectiveToP2p()) {
     fprintf(stderr, collective_p2p_string);
@@ -88,7 +90,8 @@ int MPI_Init_thread(int *argc, char ***argv, int required, int *provided) {
   return retval;
 }
 
-int MPI_Initialized(int *flag)
+#pragma weak MPI_Initialized = PMPI_Initialized
+int PMPI_Initialized(int *flag)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -99,7 +102,8 @@ int MPI_Initialized(int *flag)
   return retval;
 }
 
-int MPI_Finalized(int *flag)
+#pragma weak MPI_Finalized = PMPI_Finalized
+int PMPI_Finalized(int *flag)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -110,7 +114,8 @@ int MPI_Finalized(int *flag)
   return retval;
 }
 
-int MPI_Get_processor_name(char *name, int *resultlen)
+#pragma weak MPI_Get_processor_name = PMPI_Get_processor_name
+int PMPI_Get_processor_name(char *name, int *resultlen)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -121,7 +126,8 @@ int MPI_Get_processor_name(char *name, int *resultlen)
   return retval;
 }
 
-double MPI_Wtime()
+#pragma weak MPI_Wtime = PMPI_Wtime
+double PMPI_Wtime()
 {
   struct timespec tp;
   clock_gettime(CLOCK_REALTIME, &tp);
@@ -130,7 +136,8 @@ double MPI_Wtime()
   return ret;
 }
 
-int MPI_Finalize(void)
+#pragma weak MPI_Finalize = PMPI_Finalize
+int PMPI_Finalize(void)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -141,7 +148,8 @@ int MPI_Finalize(void)
   return retval;
 }
 
-int MPI_Get_count(const MPI_Status *status, MPI_Datatype datatype, int *count)
+#pragma weak MPI_Get_count = PMPI_Get_count
+int PMPI_Get_count(const MPI_Status *status, MPI_Datatype datatype, int *count)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -153,7 +161,8 @@ int MPI_Get_count(const MPI_Status *status, MPI_Datatype datatype, int *count)
   return retval;
 }
 
-int MPI_Get_library_version(char *version, int *resultlen)
+#pragma weak MPI_Get_library_version = PMPI_Get_library_version
+int PMPI_Get_library_version(char *version, int *resultlen)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
@@ -164,7 +173,8 @@ int MPI_Get_library_version(char *version, int *resultlen)
   return retval;
 }
 
-int MPI_Get_address(const void *location, MPI_Aint *address)
+#pragma weak MPI_Get_address = PMPI_Get_address
+int PMPI_Get_address(const void *location, MPI_Aint *address)
 {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();

--- a/mpi-proxy-split/mpi_plugin.h
+++ b/mpi-proxy-split/mpi_plugin.h
@@ -46,9 +46,6 @@
     NOT_IMPLEMENTED(MPIProxy_Cmd_Shutdown_Proxy); \
   }
 
-#define PMPI_IMPL(ret, func, ...)                               \
-  EXTERNC ret P##func(__VA_ARGS__) __attribute__ ((weak, alias (#func)));
-
 bool isUsingCollectiveToP2p();
 void recordPreMpiInitMaps();
 void recordPostMpiInitMaps();


### PR DESCRIPTION
Simplifies the wrapper structure in MANA. Fortran wrapper files and stub library files are autogenerated, so they are not touched.