### PR TITLE
Minor fixes for shadow library support

### DIFF
--- a/bin/mana_launch.py
+++ b/bin/mana_launch.py
@@ -84,7 +84,13 @@ if "--quiet" in dmtcp_flags or "-q" in dmtcp_flags:
 check_path_exists = os.path.exists(tmp_lib_path + "/tmp")
 if check_path_exists and not shadow:
   print(f"Remove all files from dir.. {tmp_lib_path}/tmp")
-  shutil.rmtree(tmp_lib_path + "/tmp")
+  try:
+    shutil.rmtree(tmp_lib_path + "/tmp")
+  except FileNotFoundError:
+    pass  # Ignore the error if file is already deleted by another process
+  except Exception as e:  # Catch all other errors
+    print(f"Error removing {dir_path}: {e}")
+
 elif not check_path_exists and shadow:
   print(f"Run the Python script create_shadow.py with the given argument")
   subprocess.run(

--- a/mpi-proxy-split/lower-half/lower-half.cpp
+++ b/mpi-proxy-split/lower-half/lower-half.cpp
@@ -294,9 +294,6 @@ int main(int argc, char *argv[], char *envp[]) {
   lh_info->MANA_ERRORS_ARE_FATAL = MPI_ERRORS_ARE_FATAL;
   lh_info->MANA_ERRORS_RETURN = MPI_ERRORS_RETURN;
 
-  // Update LD_LIBRARY_PATH to contain
-  update_library_path(argv[0]);
-
   // Check arguments and setup arguments for the loader program (cmd)
   // if has "--restore", pass all arguments to mtcp_restart
   for (i = 1; i < argc; i++) {
@@ -418,6 +415,12 @@ int main(int argc, char *argv[], char *envp[]) {
     postRestart(0, 0);
     // The following line should not be reached.
     assert(0);
+  } else {
+    // In LAUNCH mode:
+    //  Prepend LD_LIBRARY_PATH env variable to
+    //    * '/PATH_TO_MANA/lib/dmtcp' for libmpistub.so (always)
+    //    * '/PATH_TO_MANA/lib/tmp'   for shadow libraries (only when launched with --use-shadowlibs flag)
+    update_library_path(argv[0]);
   }
 
   for (i = 1; i < argc; i++) {


### PR DESCRIPTION
This PR improves upon previous version of implementing usage of shadow-libs with the following 2 commits:
* `Fix: shadow-lib deletion error (race-condition)`: While deleting shadow libraries with mana_launch.py, due to multiple processes trying to remove same files, we were seeing run time errors and process exits prematurely. This race condition error is now resolved by adding a `try: ... catch e: ` to gracefully deal with them.
* `FIXUP: update LD_LIBRARY_PATH only at launch`: We now update the LD_LIBRARY_PATH only when we are in LAUNCH state.