### PR TITLE
Fixed wrong next free addr in mmap_wrapper

### DIFF
--- a/bin/mana_launch
+++ b/bin/mana_launch
@@ -145,8 +145,8 @@ if gdb:
   cmd_line = shutil.which("gdb") + " --args "
 else:
   cmd_line = ""
-cmd_line += mana_root_path + "bin/dmtcp_launch --mpi" + host_flag + port_flag + \
-            "--no-gzip --join-coordinator --disable-dl-plugin" + \
+cmd_line += mana_root_path + "bin/dmtcp_launch --mpi " + host_flag + port_flag + \
+            " --no-gzip --join-coordinator --disable-dl-plugin" + \
             " --with-plugin " + mana_root_path + "lib/dmtcp/libmana.so " + \
             " ".join(dmtcp_flags) + " " + mana_root_path + "bin/lower-half " + \
             " " .join(target_app)

--- a/mpi-proxy-split/lower-half/lower-half-api.h
+++ b/mpi-proxy-split/lower-half/lower-half-api.h
@@ -56,6 +56,7 @@ typedef struct _LowerHalfInfo
   void *lh_dlsym;
   char *uh_stack_start;
   char *uh_stack_end;
+  char *uh_next_free_addr;
 
   // MPI Constants
   MPI_Group MANA_GROUP_NULL;

--- a/mpi-proxy-split/lower-half/lower-half.cpp
+++ b/mpi-proxy-split/lower-half/lower-half.cpp
@@ -815,7 +815,7 @@ static int restoreMemoryArea(int fd, DmtcpCkptHeader *ckptHdr)
       * mtcp_safemmap here to check for address conflicts.
       */
       mmappedat = restore_mmap(area.addr, area.size, area.prot | PROT_WRITE,
-                               area.flags | MAP_FIXED_NOREPLACE, imagefd, area.offset);
+                               area.flags, imagefd, area.offset);
 
       if (mmappedat != area.addr) {
         fprintf(stderr, "restore failed area.addr: %p, area.endAddr%p\n", area.addr, area.endAddr);
@@ -1331,7 +1331,6 @@ char *setup_upper_half_stack(int argc, char **argv, int cmd_argc, char **cmd_arg
                                     cmd_argc+1, cmd_argv2,
                                     interp_base_address + rlim.rlim_cur + LOADER_SIZE_LIMIT,
                                     auxv_ptr, stack_bottom);
-                                   // &auxv_ptr, &stack_bottom);
     lh_info->uh_stack_start = (char*) ROUND_DOWN(interp_base_address + LOADER_SIZE_LIMIT, PAGE_SIZE);
     lh_info->uh_stack_end = (char*) ROUND_UP(*stack_bottom, PAGE_SIZE);
     

--- a/mpi-proxy-split/lower-half/lower-half.cpp
+++ b/mpi-proxy-split/lower-half/lower-half.cpp
@@ -814,9 +814,8 @@ static int restoreMemoryArea(int fd, DmtcpCkptHeader *ckptHdr)
       * are valid.  Can we unmap vdso and vsyscall in Linux?  Used to use
       * mtcp_safemmap here to check for address conflicts.
       */
-      mmappedat =
-        mmap_wrapper(area.addr, area.size, area.prot | PROT_WRITE,
-                            area.flags, imagefd, area.offset);
+      mmappedat = restore_mmap(area.addr, area.size, area.prot | PROT_WRITE,
+                               area.flags | MAP_FIXED_NOREPLACE, imagefd, area.offset);
 
       if (mmappedat != area.addr) {
         fprintf(stderr, "restore failed area.addr: %p, area.endAddr%p\n", area.addr, area.endAddr);

--- a/mpi-proxy-split/lower-half/mem-wrapper.h
+++ b/mpi-proxy-split/lower-half/mem-wrapper.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include "lower-half-api.h"
 void* mmap_wrapper(void *, size_t , int , int , int , off_t );
+void* restore_mmap(void *, size_t , int , int , int , off_t );
 int munmap_wrapper(void *, size_t);
 std::vector<MmapInfo_t> &get_mmapped_list(int *num);
 #endif // MMAP_WRAPPER_H


### PR DESCRIPTION
In the earlier version, the `curr_next_free_addr` in the mmap_wrapper was not updated correctly during restart. As a result, the mmap wrapper mapped new memories at conflicting addresses after restart.