### PR TITLE
Init flags mana and mpi

### DIFF
--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -81,6 +81,8 @@ std::vector<MmapInfo_t> uh_mmaps;
 extern ManaHeader g_mana_header;
 extern std::unordered_map<MPI_File, OpenFileParameters> g_params_map;
 
+bool g_libmana_is_initialized = false;
+
 constexpr const char *MANA_FILE_REGEX_ENV = "MANA_FILE_REGEX";
 constexpr const char *MANA_SEGV_DEBUG_LOOP = "MANA_SEGV_DEBUG_LOOP";
 static std::regex *file_regex = NULL;
@@ -849,6 +851,11 @@ mpi_plugin_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
       //             detect that there is an mmap'ed region just beyond it,
       //             thus causing glibc to allocate a second arena elsewhere.
       mmap(heapAddr, 4096, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+
+      //set global flag to indiacte MANA is initialized
+      // FIXME: Move the code from PMPI_Init and PMPI_init_thread wrappers to
+      //        This section before setting the Flag for MANA's initialization
+      g_libmana_is_initialized = true;
       break;
     }
     case DMTCP_EVENT_EXIT: {

--- a/mpi-proxy-split/mpi_plugin.h
+++ b/mpi-proxy-split/mpi_plugin.h
@@ -60,5 +60,6 @@ enum mana_state_t {
 };
 
 extern mana_state_t mana_state;
+extern bool g_libmana_is_initialized;
 
 #endif // ifndef _MPI_PLUGIN_H

--- a/mpi-proxy-split/test/MANA_MPI_Initialized_test.c
+++ b/mpi-proxy-split/test/MANA_MPI_Initialized_test.c
@@ -1,0 +1,50 @@
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/*
+ * MANA Initializes MPI in the lower half, even before 
+ * user applications calls for MPI_Init in its code.
+ * Therefore, a call to MPI_Initialized in user-applciation
+ * before calling MPI_Init will return 'TRUE'
+ * (which is incorrect behavior since we want MANA to be 
+ * an invisible layer between MPI-library and user-applciation).
+ *
+ * Therefore, we have added a patch to mitigate this and
+ * this test is created to detect future regression.
+ *
+ */
+int main(int argc, char *argv[]) {
+  int flag;
+  int rank, size;
+  
+  // check if MPI is initialized before MPI_Init 
+  MPI_Initialized(&flag);
+  if (flag) {
+    fprintf(stderr, "ERROR: MPI should not be initialized before MPI_Init!\n");
+    exit(EXIT_FAILURE);
+  }
+  
+  // Initialize MPI env
+  MPI_Init(NULL, NULL);
+  
+  // check if MPI is initialized after MPI_Init 
+  MPI_Initialized(&flag);
+  if (!flag) {
+    fprintf(stderr, "ERROR: MPI should be initialized after MPI_Init!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  // making MPI-function call to conduct operational sanity test
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  printf("[%d/%d]: Hello World!\n", rank, size);
+  fflush(stdout);
+
+  // Finalize MPI env
+  MPI_Finalize();
+
+  return 0;
+
+}
+

--- a/mpi-proxy-split/test/Makefile
+++ b/mpi-proxy-split/test/Makefile
@@ -47,7 +47,7 @@ FILES=mpi_hello_world \
       File_read_write_all_test \
       Type_dup_test Type_create_hindexed_test \
       Type_create_resized_test Type_create_hindexed_block_test \
-      unsync_Finalize MPI_Double_Int_test  \
+      unsync_Finalize MPI_Double_Int_test MANA_MPI_Initialized_test \
 
 OBJS=$(addsuffix .o, ${FILES})
 


### PR DESCRIPTION
This PR resolves the inaccurate behavior of `MPI_Initiailized` function call when used with MANA. 

**Cause of Bug**: User MPI application when called `MPI_Initiailized` before calling `MPI_Init` received TRUE flag due to MANA's `MPI_Init` call in lower half.  This inaccuracy in operation was caught when launching GROMACS with MANA.

**Commit Details**:
* `Adds MANA & MPI flags in MPI_Initialized wrapper`: This commit adds new global flags, namely `g_libmpi_is_initialized` and `g_libmana_is_initialized` to keep track of library initialization. 
-- `g_libmpi_is_initialized` is set when User-applciation calls `MPI_Init` marking initialization of MPI_libraries for user.
-- `g_libmana_is_initialized` is set when MPI-plugins are setup in Upper-half before launching User-application.  
When these two flags are set, MPI_Initiliazed call is redirected to lower-half's real MPI-library, otherwise MANA wrapper will respond with flag stating MPI is not Initialized yet. 
  **NOTE:** Choice to call lower-half MPI-library is made purposely to maintain behavioral consistency of MANA as a 'transparent layer' between the user-application and the underlying MPI implementation, ensuring that MPI operations behave as expected when MANA is active
* `New test file for MPI_Initiailized wrapper operation`: This test case is inspired from GROMACS `init` execution which tests for `MPI_Initiailized` before calling `MPI_Init` to avoid reinitialization of MPI environment. This created an issue for MANA since we initialize MPI in lower-half to maintain MPI-agnostic and Network-agnostic behavior.  This test is created to avoid future regression.  