### PR TITLE
Fix for riscv

### DIFF
--- a/mpi-proxy-split/lower-half/get-symbol-offset.c
+++ b/mpi-proxy-split/lower-half/get-symbol-offset.c
@@ -96,9 +96,18 @@ off_t get_symbol_offset(const char *pathname, const char *symbol) {
       //       Package glibc-debuginfo-*.rpm exists: provides libc-*.debug
       if (access("/lib/debug/.build-id", F_OK) == 0) { // If Debian/Ubuntu
         // Debian variants use separate debug symbol file: /lib/debug/.build-id
+        // The file below is the older hierarchy.  Now it uses .build-id.
         snprintf(debugLibName, sizeof debugLibName, "%s/%s",
                  "/usr/lib/debug/lib/x86_64-linux-gnu", debugName);
-        assert(expandDebugFile(debugLibName, "/lib/debug/.build-id", debugName));
+        if (! expandDebugFile(debugLibName,
+                              "/lib/debug/.build-id", debugName)) {
+          fprintf(stderr,
+            "\nsymtab was stripped from ld-linux.so file, and no debug file\n"
+            "was found in .build-id.  Consider installing libc6-dbg package,\n"
+            "or else build a new libc6 from source.  In the latter case,\n"
+            "set LD_LIBRARY_PATH to your locally built ld-linux.so\n\n");
+          abort();
+        }
         close(fd);
         fd = open(debugLibName, O_RDONLY);
         assert(fd != -1);

--- a/mpi-proxy-split/lower-half/patch-trampoline.c
+++ b/mpi-proxy-split/lower-half/patch-trampoline.c
@@ -39,11 +39,11 @@ void patch_trampoline(void *from_addr, void *to_addr) {
   // Remember that in AArch64, stack-pointer must be 128-bit (16-byte) aligned.
    // This is the assembly, converted to binary using 'objdump -d a.out'
    // SEE: https://stackoverflow.com/questions/44949124/absolute-jump-with-a-pc-relative-data-source-aarch64
-    // For testing in GDB, after "ldr", do: (gdb) set $x8 = &bar
-    /* asm("ldr x8, .+8"); // Add 8 to pc, store in x8
-     * asm("br x8"); // jump to the 8-byte word
-     * asm("target: .dword 0x1234567812345678");
-     */
+   // For testing in GDB, after "ldr", do: (gdb) set $x8 = &bar
+   /* asm("ldr x8, .+8"); // Add 8 to pc, store in x8
+    * asm("br x8"); // jump to the 8-byte word
+    * asm("target: .dword 0x1234567812345678");
+    */
 #elif defined(__riscv)
   unsigned char asm_jump[] = {
     0x97, 0x02, 0x00, 0x00, 0xb1, 0x02, 0x83, 0xb2, 0x02, 0x00, 0x82, 0x82,


### PR DESCRIPTION
Two commits:
 1.  MANA requires the symtab of ld-linux.so, usually found in the debug version of the file.  We now tell the user if we couldn't find the debug version of the file.
 2. For RISC-V, only, lower-half/lower-half.cpp was fixed to support addresses beyond 2 GB.  The upstream kernel-loader initially assumed static linking within the 2 GB address.  That restriction is now removed int he upstream kernel-loader.