### PR TITLE
Makefile.in: Using current $CC in dmtcp/config.log?

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -42,7 +42,9 @@ DMTCP_ROOT ?= $(top_builddir)/dmtcp
 # Macros TEST and XTERM_E used on command line by check1, check2, ...:
 #   make TEST=readline XTERM_E="xterm -e" check-readline
 
+# MANA configure does configure DMTCP.  But no re-make in DMTCP.  Check ${CC}.
 default: display-build-env add-git-hooks mana_prereqs
+	$(MAKE) maybe_clean_dmtcp
 	$(MAKE) mana
 
 all: default
@@ -82,13 +84,35 @@ distclean: clean
 	rm -rf $(top_builddir)/lib
 	- cd $(top_builddir)/bin && find . \! -name '*mana*' -delete
 
+clean: tidy
+	$(MAKE) maybe_clean_dmtcp
+	cd mpi-proxy-split && $(MAKE) clean
+
 tidy:
 	rm -rf ckpt_rank*
 	rm -f ckpt_*.dmtcp dmtcp_restart_script*
 	rm -f dmtcp_coordinator_db-*.json
 
-clean: tidy
-	cd mpi-proxy-split && $(MAKE) clean
+# MANA configure does configure DMTCP and 'make'; but doesn't do a 'clean'.
+# This saves having to re-compile DMTCP when clean'ing MANA.
+# But if a previous 'make' used a different ${CC} version, then do 'clean'.
+# NOTE on $${mycc...}:  This extracts first word (e.g., in case CC='gcc -O3').
+maybe_clean_dmtcp:
+	@ mycc='${CC}' ; \
+	@ if ! test -e $${mycc%% *} ; then \
+	  echo "C compiler ($${mycc%% *}) not found."; \
+	  echo "Please do:  ./configure && make clean && make -j8"; \
+	  exit 1; \
+	fi
+	@ cc_version="${CC} --version | head -1 | tr -d '\n')" ; \
+	  if test ! -e dmtcp/bin/dmtcp_coordinator || \
+	     test ! -e dmtcp/config.log || \
+	     ! grep --quiet "$${cc_version}" dmtcp/config.log; then \
+	    echo "** DMTCP: not present, or else compiler version"; \
+	    echo "     is not current: $${cc_version}"; \
+	    echo "** Doing 'clean' in dmtcp subdirectory."; \
+	    cd ${DMTCP_ROOT} && ${MAKE} clean; \
+	  fi
 
 mana_prereqs:
 	@ if test -n "$$HUGETLB_DEFAULT_PAGE_SIZE"; then \


### PR DESCRIPTION
@rajatpratapbisht , Please test this PR.
  @karya0 , This is the issue that we described to you earlier.  I think this is the least invasive fix.

The following problem can occur when using Slurm at HPC sites.
```
module load gcc-11.1.0
cd mana
./configure
make
# Then we logout, and then start a new session
module load gcc-8.1.0
cd mana
# User tries to run.
# Previously compiled dmtcp_coordinator has symbol with too high a version, in libstdc++.so
# This is because `ldd dmtcp/src/dmtcp_coordinator` uses LD_LIBRARY_PATH, which has now changed.
# So, the user re-configures and re-makes
./configure && make -j clean && make
# But `dmtcp/src/dmtcp_coordinator` and others still have wrong symbl versions.  They were not re-compiled
```
The solution here is to check the ${CC} version in the default make target and the clean target.

When we install a new MANA and 'make', how does MANA do 'make' on DMTCP?  If that's clear, then we can simplify the code in the 'default' target.  I'm too lazy right now to check that out.

@rajatpratapbisht ,
    Could you test out this PR, and see if it works on Discovery?
    Please test with changing modules, and also please test with a new clone of MANA.
    Finally, could you look into when MANA automatically does 'make' on DMTCP?  I'm still not entirely sure if the 'default' target is needed and correct.
    Thanks.