### PR TITLE
Linux 'test' cmd uses '=', not '=='

### DIFF
--- a/bin/mana_coordinator
+++ b/bin/mana_coordinator
@@ -14,9 +14,9 @@ options=""
 verbose=0
 help=0
 while [ -n "$1" ]; do
-  if [ "$1" == --verbose ]; then
+  if [ "$1" = --verbose ]; then
     verbose=1
-  elif [ "$1" == --help ]; then
+  elif [ "$1" = --help ]; then
     help=1
   else
     options="$options $1"
@@ -44,11 +44,11 @@ if [ "$SITE" = "nersc" ]; then
   fi
 fi
 
-if [ "$verbose" == 0 ]; then
+if [ "$verbose" = 0 ]; then
   options="$options -q -q"
 fi
 
-if [ "$verbose" == 1 ]; then
+if [ "$verbose" = 1 ]; then
   set -x
 fi
 

--- a/bin/mana_status
+++ b/bin/mana_status
@@ -27,9 +27,9 @@ options=""
 verbose=0
 help=0
 while [ -n "$1" ]; do
-  if [ "$1" == --verbose ]; then
+  if [ "$1" = --verbose ]; then
     verbose=1
-  elif [ "$1" == --help ]; then
+  elif [ "$1" = --help ]; then
     help=1
   else
     options="$options $1"
@@ -45,7 +45,7 @@ fi
 coordinator_found=0
 $dir/dmtcp_command -s -h $submissionHost -p $submissionPort 1>/dev/null \
                    && coordinator_found=1
-if [ "$coordinator_found" == 0 ]; then
+if [ "$coordinator_found" = 0 ]; then
   echo "*** Checking for coordinator:"
   set -x
     $dir/dmtcp_command --status \
@@ -59,6 +59,6 @@ if [ "$coordinator_found" == 0 ]; then
   exit 2
 fi
 
-if [ "$verbose" == 1 ]; then set -x; fi
+if [ "$verbose" = 1 ]; then set -x; fi
 $dir/dmtcp_command -h $submissionHost -p $submissionPort --list $options
 set +x


### PR DESCRIPTION
In Ubuntu 24.04, the 'test' command ('[') used in /bin/sh scripts is now stricter about supported operators.  We were sloppy and wrote things like:
> `if [ "$1" == --verbose ]; then`
This PR changes it to:
> `if [ "$1" = --verbose ]; then`