### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,30 @@ MANA is an implementation of transparent checkpointing for MPI.  It is
 built as a plugin on top of [DMTCP](https://github.com/dmtcp/dmtcp).
 
 For details of installing and using MANA, please see:
-- [MANA README file](mpi-proxy-split/README.md)
+- [MANA documentation (https://mana-doc.readthedocs.io/en/latest/) ](https://mana-doc.readthedocs.io/en/latest/)
 - [the MANA 'man' page](manpages/mana.1.md) (or `man ./mana.1` on a local copy)
-- [MANA documentation](https://mana-doc.readthedocs.io/en/latest/)
 
-For technical details, see:
+As seen in the MANA documentation, for install and a quick start, do:
+
+    git clone https://github.com/mpickpt/mana
+    cd mana
+    git submodule init
+    git submodule update
+    ./configure
+    make -j8
+    # Testing on a single host (but see MANA docs for running on a cluster):
+    PATH_TO_MANA/bin/mana_coordinator
+    PATH_TO_MANA/bin/mana_launch [mana options] [user_program and args]
+
+---
+
+To cite this project in a publicatoin, please cite:
+
+* "MANA for MPI: MPI-Agnostic Network-Agnostic Transparent Checkpointing",
+  Rohan Garg, Gregory Price, and Gene Cooperman, HPDC'19.
+  (original academic prototype)
+
+For other MANA publications with updates to this project, see:
 * "Enabling Practical Transparent Checkpointing for MPI: A Topological
      Sort Approach",
    Yao Xu and Gene Cooperman,
@@ -19,6 +38,3 @@ For technical details, see:
     Derek Schafer, Anthony Skjellum, Gene Cooperman, SuperCheck-SC23 Workshop
 	at SC'23.
   (near production version of MANA)
-* "MANA for MPI: MPI-Agnostic Network-Agnostic Transparent Checkpointing",
-  Rohan Garg, Gregory Price, and Gene Cooperman, HPDC'19.
-  (original academic prototype)


### PR DESCRIPTION
* Update it with a clearer reference to readthdocs.org, and to remove a stale link to mpi-proxy-split/README.md
* Also, add an INSTALL and QUICK-START on this page, for the user's convenience.  It's the same as at readthedocs.orig
* And re-order the citations