### PR TITLE
Fixed: mmap wrapper may overwrite memory segment

### DIFF
--- a/mpi-proxy-split/lower-half/mem-wrapper.cpp
+++ b/mpi-proxy-split/lower-half/mem-wrapper.cpp
@@ -290,10 +290,6 @@ static void* __mmap_wrapper(void *addr, size_t length, int prot,
       max_allocated_addr = (char*)addr + length;
     }
   }
-#ifdef MAP_FIXED_NOREPLACE
-  flags &= ~MAP_FIXED_NOREPLACE;
-#endif
-  flags |= MAP_FIXED;
   ret = _real_mmap(addr, length, prot, flags, fd, offset);
   if (ret != MAP_FAILED) {
     DLOG(NOISE, "LH: mmap (%lu): addr %p (%p) @ 0x%zx\n",


### PR DESCRIPTION
I decided to use regular mmap (without MAP_FIXED or MAP_FIXED_NOREPLACE) when allocating memory in the mmap wrapper. This allows the kernel to avoid existing memory segments.

We still need some improvement regarding the memory management and mmap wrapper design for the upper-half. Maybe we can read the proc map file to dynamically decide what memory segments are available for the upper-half.