### PR TITLE
Update the mmap wrapper in the lower half

### DIFF
--- a/mpi-proxy-split/lower-half/lower-half.cpp
+++ b/mpi-proxy-split/lower-half/lower-half.cpp
@@ -1352,6 +1352,8 @@ char *setup_upper_half_stack(int argc, char **argv, int cmd_argc, char **cmd_arg
       exit(1);
     }
 
+    init_mem_arena((char*) ROUND_UP(lh_info->uh_stack_end + PAGE_SIZE, PAGE_SIZE));
+
     return dest_stack;
 }
 

--- a/mpi-proxy-split/lower-half/lower-half.cpp
+++ b/mpi-proxy-split/lower-half/lower-half.cpp
@@ -64,11 +64,11 @@
 #define MAX_ELF_INTERP_SZ 256
 #define LOADER_SIZE_LIMIT 0x2000000
 #define MAX_CMD_ARGV2_LENGTH 100
-#define HEAP_SIZE 0x1000000
+#define HEAP_GUARD_SIZE 0x1000000
 
 // Lower half initialization helper functions
 void set_addr_no_randomize(char *argv[]);
-char *allocate_rtld_heap();
+void create_heap_guard_page();
 void initialize_lh_info();
 void *lh_dlsym(enum MPI_Fncs fnc);
 void write_lh_info_addr(int restore_mode);
@@ -135,12 +135,6 @@ int main(int argc, char *argv[], char *envp[]) {
   lh_info->fsaddr = (void*)fsaddr;
   lh_info->fsgsbase_enabled = CheckAndEnableFsGsBase();
 
-  char *heap_addr = allocate_rtld_heap();
-
-  // Add a guard page before the start of heap; this protects
-  // the heap from getting merged with a "previous" region.
-  mprotect(heap_addr, HEAP_SIZE, PROT_NONE);
-
   // Initialize MPI in advance
   int rank;
   MPI_Init(&argc, &argv);
@@ -192,6 +186,7 @@ int main(int argc, char *argv[], char *envp[]) {
     release_reserved_memory(t, ckpt_file_pos);
     restore_session_leadership(t);
     restore_memory_data(t, ckpt_hdr);
+    create_heap_guard_page();
     /* Everything restored, close file and finish up */
     close(t->fd());
 
@@ -201,6 +196,7 @@ int main(int argc, char *argv[], char *envp[]) {
     assert(0);
   } else {
     // LAUNCH MODE:
+    create_heap_guard_page();
     parse_launch_arguments(argc, argv, &cmd_argc, &cmd_argv);
     // set default loader address
     if (ld_so_addr == NULL) {
@@ -301,29 +297,22 @@ void set_addr_no_randomize(char *argv[]) {
 }
 
 /**
- * @brief Creates a new heap region for use by the runtime linker (RTLD).
- *
- * This function allocates a new memory region to be used as the heap by 
- *  mapping a memory area starting from the current program break (`sbrk(0)`).
- *  The allocated region is initially set to `PROT_NONE` to prevent accidental access.
- *
- * @return  A pointer to the allocated heap region, or exits the program on failure.
+ * Create a guard page above the heap so that the upper half will use an arena
+ * outside of the heap.
  */
-char *allocate_rtld_heap()
+void create_heap_guard_page()
 {
   // Create new heap region to be used by RTLD
   void *lh_brk = sbrk(0);
   //const uint64_t heapSize = HEAP_SIZE;
-  char *heap_addr = (char *)mmap(lh_brk, HEAP_SIZE, PROT_NONE,
-      MAP_PRIVATE | MAP_ANONYMOUS |
-      MAP_NORESERVE ,
+  char *heap_addr = (char *)mmap(lh_brk, HEAP_GUARD_SIZE, PROT_NONE,
+      MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED,
       -1, 0);
   if (heap_addr == MAP_FAILED) {
     DLOG(ERROR, "Failed to mmap region. Error: %s\n",
         strerror(errno));
     exit(1);
   }
-  return heap_addr; 
 }
 
 /**

--- a/mpi-proxy-split/lower-half/mem-wrapper.cpp
+++ b/mpi-proxy-split/lower-half/mem-wrapper.cpp
@@ -47,18 +47,10 @@ using namespace std;
 #define _real_mmap mmap
 #define _real_munmap munmap
 
-// FIXME:  This is a hard-wired constant address.  Do we have code
-//         elsewhere that checks if this address conflicts with another
-//         memory segment?
-#define DEFAULT_UH_BASE_ADDR reinterpret_cast<char*>(0xc0000000) // 3 GB
-
 std::vector<MmapInfo_t> allocated_blocks;
-// The arena for memory allocation is from the DEFAULT_UH_BASE_ADDR (3GB)
-// with size SIZE_MAX/2 (an arbitrary large address). SIZE_MAX is the largest
-// size_t supported by the machine.
-// FIXME: Make this starting and end address dynamic and configurable
-std::vector<MmapInfo_t> free_blocks = {{DEFAULT_UH_BASE_ADDR, SIZE_MAX/2}};
+std::vector<MmapInfo_t> free_blocks;
 char *max_allocated_addr = NULL;
+static char *arena_base = NULL;
 
 static void* __mmap_wrapper(void * , size_t , int , int , int , off_t);
 static void patchLibc(int , char * , char *);
@@ -201,15 +193,27 @@ void remove_overlap_blocks(MmapInfo_t new_block, vector<MmapInfo_t> &blocks) {
 }
 
 void *next_free_addr(char *addr, size_t length) {
-  // Find the a entry in the free_mem_list that has enough size.
-  for (auto it = free_blocks.begin(); it != free_blocks.end(); it++) {
-    if (it->len > length) {
-      addr = it->addr;
-      return addr;
+  uintptr_t align_mask = PAGE_SIZE - 1;
+  if (addr != NULL) {
+    uintptr_t hint_align = (uintptr_t)addr & -(uintptr_t)addr;
+    if (hint_align > (uintptr_t)PAGE_SIZE && hint_align <= (1UL << 21)) {
+      align_mask |= (hint_align - 1);
     }
   }
-  // If no available block found, return error.
+  for (auto it = free_blocks.begin(); it != free_blocks.end(); it++) {
+    char *aligned = (char*) ROUND_UP((unsigned long)it->addr, align_mask + 1);
+    if ((size_t)(aligned - it->addr) + length <= it->len) {
+      return aligned;
+    }
+  }
   return NULL;
+}
+
+void init_mem_arena(char *base)
+{
+  arena_base = base;
+  free_blocks.clear();
+  free_blocks.push_back({arena_base, SIZE_MAX / 2});
 }
 
 // Returns a pointer to the array of mmap-ed regions
@@ -282,31 +286,29 @@ static void* __mmap_wrapper(void *addr, size_t length, int prot,
   static char *libc_base_addr = NULL;
   void *ret = MAP_FAILED;
   length = ROUND_UP(length, PAGE_SIZE);
-  if (addr == NULL ||
-      flags & MAP_FIXED == 0 ||
-      (max_allocated_addr != NULL && (char*)addr > max_allocated_addr)) {
-    addr = next_free_addr((char*)addr, length);
-    if ((char*)addr + length > max_allocated_addr) {
-      max_allocated_addr = (char*)addr + length;
+  if (arena_base != NULL) {
+    if (addr == NULL ||
+        (flags & MAP_FIXED) == 0 ||
+        (max_allocated_addr != NULL && (char*)addr > max_allocated_addr)) {
+      addr = next_free_addr((char*)addr, length);
+      if ((char*)addr + length > max_allocated_addr) {
+        max_allocated_addr = (char*)addr + length;
+      }
     }
-  }
 #ifdef MAP_FIXED_NOREPLACE
-  flags &= ~MAP_FIXED_NOREPLACE;
+    flags &= ~MAP_FIXED_NOREPLACE;
 #endif
-  flags |= MAP_FIXED;
+    flags |= MAP_FIXED;
+  }
   ret = _real_mmap(addr, length, prot, flags, fd, offset);
   if (ret != MAP_FAILED) {
     DLOG(NOISE, "LH: mmap (%lu): addr %p (%p) @ 0x%zx\n",
          allocated_blocks.size(), ret, addr, length);
-    // Add the new block to the allocated_blocks and
-    // remove it from the free_blocks.
-    char *new_block_end_addr = (char*)addr + length;
-    MmapInfo_t new_block = {(char*)addr,
-                            (size_t)(new_block_end_addr - (char*)addr)};
+    char *new_block_end_addr = (char*)ret + length;
+    MmapInfo_t new_block = {(char*)ret,
+                            (size_t)(new_block_end_addr - (char*)ret)};
     merge_overlap_blocks(new_block, allocated_blocks);
     remove_overlap_blocks(new_block, free_blocks);
-    // if the fd is not NULL, check if it's the libc. If it's the libc, patch
-    // the mmap and munmap functions to use MANA's wrappers.
     if (fd > 0) {
       char glibcFullPath[PATH_MAX] = {0};
       int found = checkLibrary(fd, "libc.so", glibcFullPath, PATH_MAX) ||

--- a/mpi-proxy-split/lower-half/mem-wrapper.cpp
+++ b/mpi-proxy-split/lower-half/mem-wrapper.cpp
@@ -213,6 +213,10 @@ void init_mem_arena(char *base)
 {
   arena_base = base;
   free_blocks.clear();
+  // This [arena_base, SIZE_MAX] pair is just for bookkeeping, suggesting
+  // this area is available for the mmap wrapper to allocate memories.
+  // The wrapper allocates memories starting from the arena_base address.
+  // We are not really mapping this region in the memory now at this moment.
   free_blocks.push_back({arena_base, SIZE_MAX / 2});
 }
 

--- a/mpi-proxy-split/lower-half/mem-wrapper.h
+++ b/mpi-proxy-split/lower-half/mem-wrapper.h
@@ -23,6 +23,7 @@
 #define MMAP_WRAPPER_H
 #include <vector>
 #include "lower-half-api.h"
+void init_mem_arena(char *arena_base);
 void* mmap_wrapper(void *, size_t , int , int , int , off_t );
 void* restore_mmap(void *, size_t , int , int , int , off_t );
 int munmap_wrapper(void *, size_t);


### PR DESCRIPTION
This PR improved the mmap wrappers. 

1. mmap() wrapper will always return aligned addresses.
2. Fixed a bug in checking if the mmap flags contains MAP_FIXED.
3. Calculating the mmap arena's base address dynamically. Previous version may have memory conflict if the rlimit (stack size) is too large.