### PR TITLE
Updating DMTCP to include the fix for compatibility issue with Hydra

### DIFF
--- a/mpi-proxy-split/lower-half/lower-half-api.h
+++ b/mpi-proxy-split/lower-half/lower-half-api.h
@@ -58,10 +58,6 @@ typedef struct _LowerHalfInfo
   char *uh_stack_end;
   char *uh_next_free_addr;
 
-  int pm_fd_count;
-  int pm_fds[4];
-  int pm_saved_fds[4];
-
   // MPI Constants
   MPI_Group MANA_GROUP_NULL;
   MPI_Comm MANA_COMM_NULL;

--- a/mpi-proxy-split/lower-half/lower-half.cpp
+++ b/mpi-proxy-split/lower-half/lower-half.cpp
@@ -146,26 +146,6 @@ int main(int argc, char *argv[], char *envp[]) {
   // Check arguments and setup arguments for the loader program (cmd)
   // if has "--restore", pass all arguments to mtcp_restart
   int restore_mode = parse_restore_flag(&argc, argv);
-
-  // Save Hydra PM fds to high fd numbers before DMTCP's restart fd restoration
-  // clobbers them. The upper half will restore them in DMTCP_EVENT_THREAD_RESUME.
-  if (restore_mode) {
-    lh_info->pm_fd_count = 0;
-    const char *pmi_fd_str = getenv("PMI_FD");
-    const char *hydi_fd_str = getenv("HYDI_CONTROL_FD");
-    if (hydi_fd_str && pmi_fd_str) {
-      int fds[] = {atoi(pmi_fd_str), atoi(hydi_fd_str)};
-      for (int i = 0; i < 2; i++) {
-        int saved = fcntl(fds[i], F_DUPFD, 256);
-        if (saved >= 0) {
-          lh_info->pm_fds[lh_info->pm_fd_count] = fds[i];
-          lh_info->pm_saved_fds[lh_info->pm_fd_count] = saved;
-          lh_info->pm_fd_count++;
-        }
-      }
-    }
-  }
-
   write_lh_info_addr(restore_mode);
   
   if (restore_mode) {
@@ -208,11 +188,6 @@ int main(int argc, char *argv[], char *envp[]) {
     create_heap_guard_page();
     /* Everything restored, close file and finish up */
     close(t->fd());
-
-    // Close Hydra's original PM fds so DMTCP won't clobber them during fd restoration.
-    for (int i = 0; i < lh_info->pm_fd_count; i++) {
-      close(lh_info->pm_fds[i]);
-    }
 
     PostRestartFnPtr_t postRestart = (PostRestartFnPtr_t) ckpt_hdr.postRestartAddr;
     postRestart(0, 0);

--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -998,18 +998,6 @@ mpi_plugin_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
       DmtcpMutexLock(&g_upper_half_fsbase_lock);
       g_upper_half_fsbase->insert(std::make_pair(dmtcp_get_real_tid(), getFS()));
       DmtcpMutexUnlock(&g_upper_half_fsbase_lock);
-
-      // Restore Hydra PM fds saved in the lower half before postRestart.
-      // DMTCP's fd restoration has already run by now, so we overwrite
-      // the dead restored fds with Hydra's live PM fds.
-      if (lh_info && lh_info->pm_fd_count > 0) {
-        int count = lh_info->pm_fd_count;
-        lh_info->pm_fd_count = 0;
-        for (int i = 0; i < count; i++) {
-          dup2(lh_info->pm_saved_fds[i], lh_info->pm_fds[i]);
-          close(lh_info->pm_saved_fds[i]);
-        }
-      }
       break;
     }
 


### PR DESCRIPTION
The previous PR regarding the Hydra compatibility issue was not a complete solution. Now we updated DMTCP to skip scanning pre-existing sockets if Hydra is used (just like how DMTCP handles SLURM).