### PR TITLE
Improved P2P drainning algorithm

### DIFF
--- a/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
@@ -137,46 +137,112 @@ int PMPI_Rsend(const void* ibuf, int count,
 int PMPI_Recv(void *buf, int count, MPI_Datatype datatype,
              int source, int tag, MPI_Comm comm, MPI_Status *status)
 {
-  int retval;
+  // MANA does not support MPI_THREAD_MULTIPLE.  This wrapper relies on
+  // a single global pending-Recv slot (g_pending_recv) being claimed
+  // by at most one thread at a time.
+  //
+  // Protocol overview (replaces the older MPI_Iprobe polling loop):
+  //
+  //   1. Check the MANA-internal message buffer first.  Messages
+  //      drained from in-flight Sends during a previous checkpoint's
+  //      pre-suspend (via recvMsgIntoInternalBuffer) are served here.
+  //
+  //   2. Publish (source, tag, comm, count, datatype) to g_pending_recv
+  //      with active=true, so that unblockPendingRecvs(), running on
+  //      the DMTCP coordinator thread during a future pre-suspend, can
+  //      identify this rank as blocked and arrange for a matching dummy
+  //      MPI_Send to unblock us.
+  //
+  //   3. Call NEXT_FUNC(Recv) WITHOUT bracketing it in
+  //      DMTCP_PLUGIN_DISABLE_CKPT.  The DMTCP coordinator thread must
+  //      be able to run the pre-suspend hook (and dispatch a dummy)
+  //      while this thread is blocked in the lower-half MPI_Recv.
+  //
+  //   4. After NEXT_FUNC(Recv) returns, read p2p_dummy_phase.  If true,
+  //      the message we just received was a dummy injected by
+  //      unblockPendingRecvs; discard it, park until mana_state ==
+  //      RUNNING (resume/restart complete), and retry.  Otherwise the
+  //      message is real: increment local_recv_messages, deliver
+  //      status, and return.
+  //
+  // The reason a single post-call read of p2p_dummy_phase is sufficient
+  // is documented at the declaration of p2p_dummy_phase in
+  // p2p_drain_send_recv.h.  Briefly: unblockPendingRecvs only sets
+  // p2p_dummy_phase = true AFTER drainInFlightP2p() exits, which requires
+  // this rank's local_recv_messages to have caught up with local_send_messages
+  // which only happens after we have already incremented for any real
+  // message; hence the post-call read is correctly false for real
+  // messages and (by the dispatch-after-barrier ordering in
+  // unblockPendingRecvs) correctly true for dummies.
+
+  int retval = MPI_SUCCESS;
   int flag = 0;
-  // while (mana_state == CKPT_P2P) {
-  //   usleep(100);
-  // }
-  local_recv_messages++;
+
+retry:
+  // Step 1: serve from the MANA-internal buffer if a matching message
+  // was drained during a previous pre-suspend cycle.
   if (mana_state == RUNNING &&
       existsMatchingMsgBuffer(source, tag, comm, &flag, status)) {
     int type_size;
-    retval = MPI_Type_size(datatype, &type_size);
+    MPI_Type_size(datatype, &type_size);
     int msg_size = type_size * count;
     consumeMatchingMsgBuffer(buf, count, datatype, source, tag, comm,
                              status, msg_size);
-    retval = MPI_SUCCESS;
-    DMTCP_PLUGIN_ENABLE_CKPT();
-    return retval;
+    local_recv_messages++;
+    return MPI_SUCCESS;
   }
-  while (!flag) {
-    DMTCP_PLUGIN_DISABLE_CKPT();
-    MPI_Comm realComm = get_real_id((mana_mpi_handle){.comm = comm}).comm;
-    MPI_Datatype realType = get_real_id((mana_mpi_handle){.datatype = datatype}).datatype;
-    JUMP_TO_LOWER_HALF(lh_info->fsaddr);
-    for (int i = 0; i < 1000; i++) {
-      NEXT_FUNC(Iprobe)(source, tag, realComm, &flag, status);
-      if (flag) {
-        retval = NEXT_FUNC(Recv)(buf, count, realType, source, tag, realComm,
-                                 status);
-        break; // We're done now.  MPI_Recv is finished.
-      }
+
+  // Step 2: publish the pending-Recv slot.  Field writes precede the
+  // 'active = true' write so that unblockPendingRecvs sees a fully
+  // populated record once it observes active==true.  (volatile bool
+  // active gives single-flag visibility; the field reads in
+  // unblockPendingRecvs are gated on active and synchronized by the
+  // global barrier inside that function.)
+  g_pending_recv.source = source;
+  g_pending_recv.tag = tag;
+  g_pending_recv.comm = comm;
+  g_pending_recv.count = count;
+  g_pending_recv.datatype = datatype;
+  g_pending_recv.active = true;
+
+  // Step 3: resolve virtual handles and call into the lower half.
+  // No DMTCP_PLUGIN_DISABLE_CKPT bracket here (see protocol overview
+  // above): the pre-suspend hook must be able to fire while we are
+  // blocked in NEXT_FUNC(Recv) so it can dispatch a dummy to
+  // unblock us.
+  MPI_Status local_status;
+  MPI_Comm realComm = get_real_id((mana_mpi_handle){.comm = comm}).comm;
+  MPI_Datatype realType = get_real_id((mana_mpi_handle){.datatype = datatype}).datatype;
+  JUMP_TO_LOWER_HALF(lh_info->fsaddr);
+  retval = NEXT_FUNC(Recv)(buf, count, realType, source, tag, realComm,
+                           &local_status);
+  RETURN_TO_UPPER_HALF();
+
+  // Step 4: classify as real or dummy.
+  if (p2p_dummy_phase) {
+    // Dummy.  buf and local_status contain unusable data; discard.
+    // Do NOT increment local_recv_messages (the dummy bypassed the
+    // MPI_Send wrapper on the sender, so global counters stay balanced
+    // only if we also skip the increment here).
+    g_pending_recv.active = false;
+    // Park until the checkpoint completes and we are back in the
+    // RUNNING state.  EVENT_RESUME and EVENT_RESTART both transition
+    // mana_state back to RUNNING after resetDrainCounters() clears
+    // p2p_dummy_phase.  Checkpointing is enabled during this wait
+    // loop (we hold no DMTCP_PLUGIN_DISABLE_CKPT), so DMTCP can
+    // suspend the user thread here cleanly.
+    while (mana_state != RUNNING) {
+      usleep(100);
     }
-    if (flag) { break; } // Break if we're done.
-    // If msg not available yet, slow down and don't hog the CPU core.
-    const struct timespec microsecond = {.tv_sec = 0, .tv_nsec = 1000000 };
-    nanosleep( &microsecond, NULL );
-    RETURN_TO_UPPER_HALF();
-    DMTCP_PLUGIN_ENABLE_CKPT();
+    goto retry;
   }
-#ifdef DEBUG_P2P
-  // FIXME: Move the recv counter code from MPI_Test wrapper to here.
-#endif
+
+  // Real message.
+  local_recv_messages++;
+  g_pending_recv.active = false;
+  if (status != MPI_STATUS_IGNORE) {
+    *status = local_status;
+  }
   return retval;
 }
 

--- a/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
+++ b/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
@@ -87,6 +87,11 @@ int PMPI_Init(int *argc, char ***argv) {
 
 #pragma weak MPI_Init_thread = PMPI_Init_thread
 int PMPI_Init_thread(int *argc, char ***argv, int required, int *provided) {
+  if (*provided == MPI_THREAD_MULTIPLE) {
+    fprintf(stderr, "WARNING: MANA does not support MPI_THREAD_MULTIPLE.\n"); 
+    fprintf(stderr, "MANA initialized with MPI_THREAD_SINGLE instead.\n"); 
+    fflush(stderr);
+  }
   int retval;
   if (isUsingCollectiveToP2p()) {
     fprintf(stderr, collective_p2p_string);

--- a/mpi-proxy-split/mpi_plugin.cpp
+++ b/mpi-proxy-split/mpi_plugin.cpp
@@ -899,7 +899,7 @@ mpi_plugin_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
       drain_mpi_collective();
       dmtcp_global_barrier("MPI:Drain-Send-Recv");
       mana_state = CKPT_P2P;
-      drainSendRecv(); // p2p_drain_send_recv.cpp
+      drainP2p(); // p2p_drain_send_recv.cpp
       openCkptFileFds();
       printEventToStderr("EVENT_PRESUSPEND (done)");
       break;

--- a/mpi-proxy-split/p2p_drain_send_recv.cpp
+++ b/mpi-proxy-split/p2p_drain_send_recv.cpp
@@ -60,6 +60,10 @@ int64_t local_sent_messages = 0, local_recv_messages = 0;
 std::unordered_set<MPI_Comm> active_comms;
 dmtcp::vector<mpi_message_t*> g_message_queue;
 
+// See p2p_drain_send_recv.h for documentation of these globals.
+pending_recv_t g_pending_recv = { /*.active=*/ false };
+volatile bool p2p_dummy_phase = false;
+
 void
 initialize_drain_send_recv()
 {
@@ -105,9 +109,25 @@ recvMsgIntoInternalBuffer(MPI_Status status, MPI_Comm comm)
   MPI_Type_size(MPI_BYTE, &size);
   JASSERT(size == 1);
   void *buf = JALLOC_HELPER_MALLOC(count);
-  int retval = MPI_Recv(buf, count, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG,
-           comm, MPI_STATUS_IGNORE);
+  // Bypass the MPI_Recv wrapper deliberately.  The wrapper publishes
+  // g_pending_recv from a single-slot global, and the user thread's
+  // pending blocking Recv may already have written that slot.  Calling
+  // the wrapper here would clobber it, and unblockPendingRecvs would
+  // then fail to dispatch a dummy for the user's Recv, deadlocking it.
+  // The wrapper would also (incorrectly) check p2p_dummy_phase on the
+  // return value of this real drained message.  Both problems are
+  // avoided by going through NEXT_FUNC(Recv) directly.
+  MPI_Comm realComm = get_real_id((mana_mpi_handle){.comm = comm}).comm;
+  JUMP_TO_LOWER_HALF(lh_info->fsaddr);
+  int retval = NEXT_FUNC(Recv)(buf, count, MPI_BYTE,
+                               status.MPI_SOURCE, status.MPI_TAG,
+                               realComm, MPI_STATUS_IGNORE);
   JASSERT(retval == MPI_SUCCESS);
+  RETURN_TO_UPPER_HALF();
+  // The wrapper would have incremented local_recv_messages for this
+  // real receive; we must do it explicitly when bypassing the wrapper,
+  // so the global drain test in drainInFlightP2p() sees a balanced count.
+  local_recv_messages++;
 
   mpi_message_t *message = (mpi_message_t *)JALLOC_HELPER_MALLOC(sizeof(mpi_message_t));
   message->buf        = buf;
@@ -230,24 +250,8 @@ drainRemainingP2pMsgs()
 }
 
 void
-drainSendRecv()
+drainInFlightP2p()
 {
-#if 0
-  int numReceived = -1;
-  while (numReceived != 0) {
-    while (!allDrained()) {
-      // If pending MPI_Irecv or MPI_Isend, use MPI_Test to try to complete it.
-      completePendingP2pRequests();
-      // If MPI_Irecv not posted but msg was sent, use MPI_Iprobe to drain msg.
-      drainRemainingP2pMsgs();
-    }
-    sleep(5);
-    numReceived = 0;
-    numReceived = completePendingP2pRequests();
-    // If any messages are completed aftera  5 seconds sleep,
-    // go back to the loop.
-  }
-#endif
   registerLocalSendsAndRecvs();
   while (global_sent_messages > global_recv_messages) {
     // If pending MPI_Irecv or MPI_Isend, use MPI_Test to try to complete it.
@@ -259,7 +263,7 @@ drainSendRecv()
   }
 }
 
-// FIXME: existsMaatchingMsgBuffer and consumeMatchingMsgBuffer both search
+// FIXME: existsMatchingMsgBuffer and consumeMatchingMsgBuffer both search
 // in the g_message_queue with the same condition. Maybe we can
 // combine them into one function.
 bool
@@ -314,9 +318,213 @@ consumeMatchingMsgBuffer(void *buf, int count, MPI_Datatype datatype,
   return MPI_SUCCESS;
 }
 
+// Publish g_pending_recv to kvdb (one record per rank), then for each
+// rank that is blocked on MPI_Recv, decide whether *this* rank is the
+// designated dummy sender and, if so, issue an MPI_Send to unblock the
+// receiver.  The dummy uses the receiver's own count and datatype so
+// that the lower-half MPI library matches the Recv and returns from
+// NEXT_FUNC(Recv).
+//
+// Must be called after drainInFlightP2p() has returned (i.e., after
+// global_sent == global_recv has been proven).  At that point, no real
+// user-issued p2p messages remain in flight, so any MPI_Send issued
+// here can only be consumed by a blocked MPI_Recv, and that Recv's
+// wrapper will recognize the dummy via p2p_dummy_phase.
+//
+// Dispatch rule (every rank computes the same answer from the same
+// kvdb snapshot, so each dummy is sent by exactly one rank):
+//   - If pr.source != MPI_ANY_SOURCE, the sender is pr.source (a rank
+//     in pr.comm).
+//   - If pr.source == MPI_ANY_SOURCE, the sender is the lowest-ranked
+//     member of pr.comm that is not itself blocked on MPI_Recv.  MANA
+//     assumes deadlock-free programs, so at least one such member
+//     exists.
+//   - Tag = pr.tag, or 0 if pr.tag == MPI_ANY_TAG.
+//
+// The dummy MPI_Send is issued directly via NEXT_FUNC(Send), bypassing
+// the MPI_Send wrapper, so it does NOT increment local_sent_messages.
+// (Otherwise the next checkpoint's drain test would start from a
+// skewed baseline.)
+void
+unblockPendingRecvs()
+{
+  const char *db = "/plugin/MANA/p2p-pending-recv";
+  char key[64];
+
+  // Phase A: publish this rank's pending_recv state to kvdb.  We always
+  // publish all keys so that no stale value from a previous
+  // checkpoint cycle can be observed.
+  int64_t my_active = g_pending_recv.active ? 1 : 0;
+  int64_t my_source = g_pending_recv.active ? g_pending_recv.source : 0;
+  int64_t my_tag    = g_pending_recv.active ? g_pending_recv.tag    : 0;
+  int64_t my_comm   = g_pending_recv.active ? (int64_t)g_pending_recv.comm : 0;
+  int64_t my_count  = g_pending_recv.active ? g_pending_recv.count : 0;
+  int64_t my_dtype  = g_pending_recv.active ?
+                        (int64_t)g_pending_recv.datatype : 0;
+
+  snprintf(key, sizeof(key), "active_%d", g_world_rank);
+  kvdb::set64(db, key, my_active);
+  snprintf(key, sizeof(key), "source_%d", g_world_rank);
+  kvdb::set64(db, key, my_source);
+  snprintf(key, sizeof(key), "tag_%d", g_world_rank);
+  kvdb::set64(db, key, my_tag);
+  snprintf(key, sizeof(key), "comm_%d", g_world_rank);
+  kvdb::set64(db, key, my_comm);
+  snprintf(key, sizeof(key), "count_%d", g_world_rank);
+  kvdb::set64(db, key, my_count);
+  snprintf(key, sizeof(key), "dtype_%d", g_world_rank);
+  kvdb::set64(db, key, my_dtype);
+
+  p2p_dummy_phase = true;
+
+  dmtcp_global_barrier("MPI:P2P-Pending-Recv-Published");
+
+  // Phase B: read all ranks' pending_recv state.  After the barrier,
+  // every rank's publish is visible.
+  std::vector<int64_t> active(g_world_size);
+  std::vector<int64_t> source(g_world_size);
+  std::vector<int64_t> tag(g_world_size);
+  std::vector<int64_t> comm(g_world_size);
+  std::vector<int64_t> count(g_world_size);
+  std::vector<int64_t> dtype(g_world_size);
+  for (int r = 0; r < g_world_size; r++) {
+    snprintf(key, sizeof(key), "active_%d", r);
+    kvdb::get64(db, key, &active[r]);
+    if (!active[r]) { continue; }
+    snprintf(key, sizeof(key), "source_%d", r);
+    kvdb::get64(db, key, &source[r]);
+    snprintf(key, sizeof(key), "tag_%d", r);
+    kvdb::get64(db, key, &tag[r]);
+    snprintf(key, sizeof(key), "comm_%d", r);
+    kvdb::get64(db, key, &comm[r]);
+    snprintf(key, sizeof(key), "count_%d", r);
+    kvdb::get64(db, key, &count[r]);
+    snprintf(key, sizeof(key), "dtype_%d", r);
+    kvdb::get64(db, key, &dtype[r]);
+  }
+
+  // Phase C: dispatch dummies.
+  // For each blocked rank j, every member of j's communicator
+  // independently computes the sender; only the designated 
+  // sender issues the MPI_Send.
+  // For each communicator, there must be at least one process
+  // is not blocked in a pending receive. Otherwise, it's a
+  // deadlock in user's program.
+  for (int j = 0; j < g_world_size; j++) {
+    if (!active[j]) { continue; }
+
+    MPI_Comm virtComm = (MPI_Comm)comm[j];
+    MPI_Comm realComm =
+      get_real_id((mana_mpi_handle){.comm = virtComm}).comm;
+
+    int comm_size;
+    MPI_Group local_group;
+    JUMP_TO_LOWER_HALF(lh_info->fsaddr);
+    NEXT_FUNC(Comm_size)(realComm, &comm_size);
+    NEXT_FUNC(Comm_group)(realComm, &local_group);
+    RETURN_TO_UPPER_HALF();
+
+    int *local_ranks = (int*)malloc(sizeof(int) * comm_size);
+    int *global_ranks = (int*)malloc(sizeof(int) * comm_size);
+    for (int i = 0; i < comm_size; i++) {
+      local_ranks[i] = i;
+    }
+    JUMP_TO_LOWER_HALF(lh_info->fsaddr);
+    NEXT_FUNC(Group_translate_ranks)(local_group, comm_size, local_ranks,
+                                     g_world_group, global_ranks);
+    NEXT_FUNC(Group_free)(&local_group);
+    RETURN_TO_UPPER_HALF();
+    free(local_ranks);
+
+    // Find my local rank in this comm (or -1 if I am not a member).
+    int my_local_rank_in_comm = -1;
+    for (int i = 0; i < comm_size; i++) {
+      if (global_ranks[i] == g_world_rank) {
+        my_local_rank_in_comm = i;
+        break;
+      }
+    }
+    if (my_local_rank_in_comm < 0) { free(global_ranks); continue; }
+
+    // Find j's local rank in this comm.
+    int j_local_rank_in_comm = -1;
+    for (int i = 0; i < comm_size; i++) {
+      if (global_ranks[i] == j) {
+        j_local_rank_in_comm = i;
+        break;
+      }
+    }
+    JASSERT(j_local_rank_in_comm >= 0)(j)(virtComm)
+      .Text("Blocked rank not a member of its own pending-Recv comm.");
+
+    // Determine the sender's local rank in this comm.
+    int sender_local_rank_in_comm;
+    if ((int)source[j] != MPI_ANY_SOURCE) {
+      // If the pending recv has a specific source, use the source
+      // to send the dummy message.
+      sender_local_rank_in_comm = (int)source[j];
+    } else {
+      // If the pending recv uses MPI_ANY_SOURCE, pick the process
+      // in the same communicator that has the smallest rank number
+      // and is not blocked.
+      sender_local_rank_in_comm = -1;
+      for (int i = 0; i < comm_size; i++) {
+        int global = global_ranks[i];
+        if (!active[global]) {
+          sender_local_rank_in_comm = i;
+          break;
+        }
+      }
+      JASSERT(sender_local_rank_in_comm >= 0)(j)(virtComm)
+        .Text("MPI_ANY_SOURCE Recv with no unblocked sender in comm; "
+              "user program may have deadlocked.");
+    }
+
+    if (sender_local_rank_in_comm != my_local_rank_in_comm) {
+      free(global_ranks);
+      continue;
+    }
+
+    int dummy_tag = ((int)tag[j] == MPI_ANY_TAG) ? 0 : (int)tag[j];
+    int dummy_count = (int)count[j];
+    MPI_Datatype virtDtype = (MPI_Datatype)dtype[j];
+    MPI_Datatype realDtype =
+      get_real_id((mana_mpi_handle){.datatype = virtDtype}).datatype;
+
+    int type_size = 0;
+    MPI_Type_size(virtDtype, &type_size);
+    void *dummy_buf = malloc(dummy_count * type_size);
+    memset(dummy_buf, 0, dummy_count * type_size);
+
+    JUMP_TO_LOWER_HALF(lh_info->fsaddr);
+    int rc = NEXT_FUNC(Send)(dummy_buf, dummy_count, realDtype,
+                             j_local_rank_in_comm, dummy_tag, realComm);
+    JASSERT(rc == MPI_SUCCESS)(rc)(j)(dummy_tag);
+    RETURN_TO_UPPER_HALF();
+    free(dummy_buf);
+    free(global_ranks);
+  }
+
+  // Phase D: wait for all dummies to have been issued globally.
+  dmtcp_global_barrier("MPI:P2P-Pending-Recv-Dummies-Sent");
+}
+
+void
+drainP2p()
+{
+  drainInFlightP2p();
+  unblockPendingRecvs();
+}
+
 void
 resetDrainCounters()
 {
+  // p2p_dummy_phase is cleared on EVENT_RESUME and EVENT_RESTART
+  // (where this function is called from mpi_plugin_event_hook).  This
+  // releases any MPI_Recv wrappers that were parked in their
+  // wait-for-resume loop after consuming a dummy.
+  p2p_dummy_phase = false;
+  g_pending_recv.active = false;
 #ifdef DEBUG_P2P
   memset(g_sendBytesByRank, 0, g_world_size * sizeof(int));
   memset(g_rsendBytesByRank, 0, g_world_size * sizeof(int));

--- a/mpi-proxy-split/p2p_drain_send_recv.h
+++ b/mpi-proxy-split/p2p_drain_send_recv.h
@@ -38,9 +38,76 @@ extern int64_t local_sent_messages, local_recv_messages;
 extern std::unordered_set<MPI_Comm> active_comms;
 extern dmtcp::vector<mpi_message_t*> g_message_queue;
 
+// State of a single pending blocking MPI_Recv.
+//
+// MANA does not support MPI_THREAD_MULTIPLE.  Therefore at most one
+// MPI_Recv can be in flight per process at any time, and a single
+// global slot suffices to record its parameters.  If MPI_THREAD_MULTIPLE
+// support is ever added, this slot will need to become per-thread, and
+// the kvdb publish in unblockPendingRecvs() will need to publish a
+
+  // It is read by unblockPendingRecvs() running in the DMTCP coordinator
+// thread during pre-suspend.  Declared volatile for cross-thread
+// visibility.
+typedef struct {
+  volatile bool active;
+  // The following fields are valid only when active is true.
+  int source;     // user-provided value; may be MPI_ANY_SOURCE
+  int tag;        // user-provided value; may be MPI_ANY_TAG
+  MPI_Comm comm;  // virtual communicator
+  int count;      // user-provided count (needed for dummy buffer size)
+  MPI_Datatype datatype;  // virtual datatype handle (needed for dummy matching)
+} pending_recv_t;
+
+extern pending_recv_t g_pending_recv;
+
+// Set to true at the start of the pending-Recv dummy-injection phase
+// (after drainInFlightP2p() returns and global_sent ==
+// global_recv has been proven).  Cleared in resetDrainCounters() on
+// EVENT_RESUME and EVENT_RESTART.
+//
+// INVARIANT while true: no real user-issued p2p messages can arrive at
+// any rank.  Any MPI_Recv that returns from NEXT_FUNC(Recv) while this
+// flag is true has consumed a dummy message injected by
+// unblockPendingRecvs() and must be discarded.
+//
+// The MPI_Recv wrapper reads this flag once, immediately after
+// NEXT_FUNC(Recv) returns.  A single post-call read is sufficient:
+//
+//   - For a REAL message: unblockPendingRecvs() only sets
+//     p2p_dummy_phase = true after drainInFlightP2p() exits, which
+//     requires this rank's local_recv_messages to have caught up with
+//     sent.  The MPI_Recv wrapper increments local_recv_messages
+//     AFTER its post-call dummy check.  Therefore, for a real message,
+//     the wrapper's post-call read happens-before
+//     unblockPendingRecvs sets the flag, and reads false.
+//
+//   - For a DUMMY message: unblockPendingRecvs sets p2p_dummy_phase
+//     = true and then participates in dmtcp_global_barrier
+//     ("MPI:P2P-Pending-Recv-Published") BEFORE any rank dispatches
+//     any dummy.  Therefore by the time any dummy is in flight, every
+//     rank has already set its local p2p_dummy_phase to true, and the
+//     receiver's post-call read sees true.
+extern volatile bool p2p_dummy_phase;
+
 void initialize_drain_send_recv();
 void registerLocalSendsAndRecvs();
-void drainSendRecv();
+
+// Drain all in-flight point-to-point messages by completing nonblocking
+// receives and probing for unexpected messages until global_sent ==
+// global_recv.
+void drainInFlightP2p();
+
+// Dispatch dummy MPI_Send messages to unblock any rank that is parked
+// in blocking MPI_Recv at pre-suspend time.  Must be called after
+// drainInFlightP2p() returns (i.e., after all real in-flight messages
+// have been accounted for).  See implementation for the full protocol.
+void unblockPendingRecvs();
+
+// Single entry point for draining all P2P communications before
+// checkpoint: drains in-flight messages, then unblocks pending recvs.
+void drainP2p();
+
 int drainRemainingP2pMsgs(int source);
 int recvMsgIntoInternalBuffer(MPI_Status status);
 bool existsMatchingMsgBuffer(int source, int tag, MPI_Comm comm, int *flag,

--- a/mpi-proxy-split/unit-test/drain-send-recv-test.cpp
+++ b/mpi-proxy-split/unit-test/drain-send-recv-test.cpp
@@ -125,7 +125,7 @@ TEST_F(DrainTests, testSendDrain)
   }
   getLocalRankInfo();
   registerLocalSendsAndRecvs();
-  drainSendRecv();
+  drainInFlightP2p();
   for (int i = 0; i < TWO; i++) {
     EXPECT_EQ(consumeMatchingMsgBuffer(&rbuf, 1, MPI_INT, 0,
                                     0, _comm, &sts[i], size), MPI_SUCCESS);
@@ -153,7 +153,7 @@ TEST_F(DrainTests, testSendDrainOnDiffComm)
   }
   getLocalRankInfo();
   registerLocalSendsAndRecvs();
-  drainSendRecv();
+  drainInFlightP2p();
   for (int i = 0; i < TWO; i++) {
     int rc;
     EXPECT_TRUE(existsMatchingMsgBuffer(0, 0, newcomm, &flag, &sts[i]));
@@ -190,7 +190,7 @@ TEST_F(DrainTests, testRecvDrain)
   // Checkpoint
   getLocalRankInfo();
   registerLocalSendsAndRecvs();
-  drainSendRecv();
+  drainInFlightP2p();
   // Resume
   for (int i = 0; i < TWO; i++) {
     int rc;


### PR DESCRIPTION
This PR improved the algorithm for checkpointing pending MPI_Recv() functions. 

Previously, we used MPI_Iprobe in a tight loop in the MPI_Recv() wrapper to detect if there's an incoming message. We only calls the real MPI_Recv() function in the lower half if there's a message ready to be received. This has a negative influence on the runtime performance of P2P communications.

In this PR, we removed the loop of MPI_Iprobe() function. Instead, we saved the size, datatype and tag of the to-be-received message until the MPI_Recv() is completed. If the checkpoint request is sent in the middle of a MPI_Recv() function, a matching sender will send a "dummy" message to the pending receiver to unblock it, but still in the wrapper function. After a resume or restart, the wrapper function will call the MPI_Recv function again to receive the real message.